### PR TITLE
Improve Apple Silicon native and Rosetta diagnostics

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -72,6 +72,11 @@ pub(crate) fn init(enabled: bool) {
         std::env::consts::OS,
         std::env::consts::ARCH
     );
+    #[cfg(target_os = "macos")]
+    log::info!(
+        "macOS runtime architecture: {}",
+        crate::hid::macos_runtime_architecture_status()
+    );
     if enabled {
         log::info!("Diagnostics log: {}", display_path(&active_log_path()));
         log::info!("Config dir: {}", display_path(&entropy_config_dir()));

--- a/src/hid.rs
+++ b/src/hid.rs
@@ -30,6 +30,24 @@ pub(crate) fn macos_hid_scan_disabled_for_rosetta() -> bool {
     macos_running_under_rosetta()
 }
 
+#[cfg(target_os = "macos")]
+pub(crate) fn macos_runtime_architecture_status() -> &'static str {
+    if macos_running_under_rosetta() {
+        "x86_64 translated by Rosetta on Apple Silicon"
+    } else if cfg!(target_arch = "aarch64") {
+        "native arm64 Apple Silicon"
+    } else if cfg!(target_arch = "x86_64") {
+        "native x86_64 Intel"
+    } else {
+        "native macOS architecture"
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn macos_rosetta_hid_status_message() -> &'static str {
+    "Entropy is running under Rosetta. Install the macOS arm64 build to enable HID access on Apple Silicon."
+}
+
 #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
 fn macos_running_under_rosetta() -> bool {
     use std::os::raw::{c_char, c_int, c_void};

--- a/src/smart_input.rs
+++ b/src/smart_input.rs
@@ -141,8 +141,10 @@ pub fn universal_output_status() -> String {
 
 #[cfg(target_os = "macos")]
 pub fn universal_output_status() -> String {
-    "Universal output backend: macOS native — requires Accessibility/Input Monitoring permission"
-        .to_owned()
+    format!(
+        "Universal output backend: macOS native ({}) — requires Accessibility/Input Monitoring permission",
+        crate::hid::macos_runtime_architecture_status(),
+    )
 }
 
 #[cfg(target_os = "linux")]

--- a/src/ui/device_scan.rs
+++ b/src/ui/device_scan.rs
@@ -9,9 +9,7 @@ impl EntropyApp {
         #[cfg(target_os = "macos")]
         if crate::hid::macos_hid_scan_disabled_for_rosetta() {
             if self.status_msg.is_empty() {
-                self.status_msg =
-                    "Apple Silicon detected under Rosetta - install the macOS arm64 build for HID access"
-                        .into();
+                self.status_msg = crate::hid::macos_rosetta_hid_status_message().into();
             }
             return;
         }


### PR DESCRIPTION
## EN
### Summary
Improve Apple Silicon startup diagnostics so native arm64 execution and Rosetta translation are easier to distinguish.

This keeps Rosetta-aware HID scan behavior explicit and makes the Apple Silicon runtime mode easier to validate while debugging user reports.

### Verification
- Local: `git diff --check`
- Local: `cargo build --release`
- Local: `cargo test`
- Remote: GitHub Actions `Build` run: https://github.com/ergohaven/entropy/actions/runs/27808717516.

Fixes #7

## RU
### Кратко
Улучшает startup diagnostics для Apple Silicon, чтобы native arm64 execution и Rosetta translation было проще различать.

Изменение сохраняет явное Rosetta-совместимое HID scan поведение и упрощает проверку режима запуска при разборе пользовательских отчетов.

### Проверка
- Локально: `git diff --check`
- Локально: `cargo build --release`
- Локально: `cargo test`
- Remote: GitHub Actions `Build` run: https://github.com/ergohaven/entropy/actions/runs/27808717516.

Закрывает #7
