### PR TITLE
Stabilize macOS HID initialization on the main thread

### DIFF
--- a/src/hid.rs
+++ b/src/hid.rs
@@ -26,6 +26,19 @@ pub(crate) fn macos_hid_operation_lock() -> std::sync::MutexGuard<'static, ()> {
 }
 
 #[cfg(target_os = "macos")]
+pub(crate) fn initialize_macos_hid_on_main_thread() {
+    if macos_hid_scan_disabled_for_rosetta() {
+        return;
+    }
+
+    // hidapi's Darwin backend binds its global IOHIDManager to the first hid_init run loop.
+    let _hid_lock = macos_hid_operation_lock();
+    if let Err(error) = hidapi::HidApi::new() {
+        log::warn!("macOS HID initialization failed: {error}");
+    }
+}
+
+#[cfg(target_os = "macos")]
 pub(crate) fn macos_hid_scan_disabled_for_rosetta() -> bool {
     macos_running_under_rosetta()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -266,6 +266,9 @@ fn main() -> eframe::Result<()> {
     #[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
     let _single_instance_available = try_acquire_single_instance();
 
+    #[cfg(target_os = "macos")]
+    hid::initialize_macos_hid_on_main_thread();
+
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
             .with_title(APP_TITLE)


### PR DESCRIPTION
## EN
### Summary
Stabilize macOS HID initialization by initializing hidapi on the main thread before UI startup.

This targets the Apple Silicon crash observed after moving Entropy.app to Applications, where hidapi's Darwin IOHIDManager can bind to an unsafe first run loop. It also preserves the Rosetta HID scan block.

### Verification
- Local: `git diff --check`
- Local: `cargo build --release`
- Local: `cargo test`
- Local: `scripts/build_macos_app.sh`
- Remote: GitHub Actions `Build` run: https://github.com/ergohaven/entropy/actions/runs/27808718588.

Fixes #8

## RU
### Кратко
Стабилизирует macOS HID инициализацию: hidapi инициализируется на main thread до запуска UI.

Изменение закрывает ошибку на Apple Silicon, которая воспроизводился после переноса Entropy.app в папку Applications, когда Darwin IOHIDManager в hidapi мог привязаться к небезопасному first run loop. Rosetta HID scan block сохранен.

### Проверка
- Локально: `git diff --check`
- Локально: `cargo build --release`
- Локально: `cargo test`
- Локально: `scripts/build_macos_app.sh`
- Remote: GitHub Actions `Build` run: https://github.com/ergohaven/entropy/actions/runs/27808718588.

Закрывает #8
