### PR TITLE
Pin explicit macOS Rust targets in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,11 @@ jobs:
           - os: macos-26
             kind: macos
             arch: arm64
+            target: aarch64-apple-darwin
           - os: macos-26-intel
             kind: macos
             arch: x86_64
+            target: x86_64-apple-darwin
 
     steps:
       - uses: actions/checkout@v4
@@ -38,6 +40,10 @@ jobs:
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
+
+      - name: Install macOS Rust target
+        if: matrix.kind == 'macos'
+        run: rustup target add ${{ matrix.target }}
 
       - name: Install Linux dependencies
         if: matrix.os == 'ubuntu-latest'
@@ -76,7 +82,7 @@ jobs:
         if: matrix.kind == 'macos'
         shell: bash
         run: |
-          scripts/build_macos_app.sh
+          TARGET="${{ matrix.target }}" scripts/build_macos_app.sh
           mkdir -p dist/release
           asset="entropy-${GITHUB_REF_NAME}-macos-${{ matrix.arch }}.dmg"
           cp dist/macos/*.dmg "dist/release/$asset"


### PR DESCRIPTION
## EN
### Summary
Pin explicit macOS Rust targets in the tag-only release workflow.

Release jobs now distinguish Apple Silicon and Intel macOS targets instead of relying on runner defaults, while keeping release validation tag-free for PR review.

### Verification
- Local: `git diff --check`
- Local: `cargo build --release`
- Local: `cargo test`
- Local package validation: `TARGET=aarch64-apple-darwin scripts/build_macos_app.sh`, `file`, `lipo -archs`, `plutil -lint`, `hdiutil verify`
- Local package validation: `TARGET=x86_64-apple-darwin scripts/build_macos_app.sh`, `file`, `lipo -archs`, `plutil -lint`, `hdiutil verify`
- Remote: GitHub Actions `Build` run: https://github.com/ergohaven/entropy/actions/runs/27808723639.

Fixes #11

## RU
### Кратко
Закрепляет явные macOS Rust targets в tag-only release workflow.

Release jobs теперь различают Apple Silicon и Intel macOS targets, а не полагаются на runner defaults. Для PR review временный release tag не создавался.

### Проверка
- Локально: `git diff --check`
- Локально: `cargo build --release`
- Локально: `cargo test`
- Локально package validation: `TARGET=aarch64-apple-darwin scripts/build_macos_app.sh`, `file`, `lipo -archs`, `plutil -lint`, `hdiutil verify`
- Локально package validation: `TARGET=x86_64-apple-darwin scripts/build_macos_app.sh`, `file`, `lipo -archs`, `plutil -lint`, `hdiutil verify`
- Remote: GitHub Actions `Build` run: https://github.com/ergohaven/entropy/actions/runs/27808723639.

Закрывает #11
