### PR TITLE
Add single-instance lock override and repeated-launch guard

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ use app::EntropyApp;
 
 const APP_TITLE: &str = concat!("Entropy (v", env!("CARGO_PKG_VERSION"), ")");
 const APP_ID: &str = "entropy";
+const SINGLE_INSTANCE_ENV: &str = "ENTROPY_SINGLE_INSTANCE";
 
 #[cfg(target_os = "windows")]
 struct SingleInstanceGuard(*mut core::ffi::c_void);
@@ -92,6 +93,18 @@ fn notify_existing_instance() {
         .map(|d| d.as_millis().to_string())
         .unwrap_or_else(|_| "0".to_string());
     let _ = std::fs::write(signal_path, now_ms);
+}
+
+fn single_instance_enabled_from_env(value: Option<&str>) -> bool {
+    !matches!(
+        value.map(str::trim).map(str::to_ascii_lowercase).as_deref(),
+        Some("0" | "false" | "off" | "no")
+    )
+}
+
+fn single_instance_enabled() -> bool {
+    let value = std::env::var(SINGLE_INSTANCE_ENV).ok();
+    single_instance_enabled_from_env(value.as_deref())
 }
 
 #[cfg(target_os = "windows")]
@@ -256,11 +269,17 @@ fn main() -> eframe::Result<()> {
     diagnostics::init(diagnostics::settings_file_enabled());
 
     #[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
-    if !try_acquire_single_instance() {
-        notify_existing_instance();
-        #[cfg(target_os = "windows")]
-        restore_existing_instance_window();
-        return Ok(());
+    {
+        if single_instance_enabled() {
+            if !try_acquire_single_instance() {
+                notify_existing_instance();
+                #[cfg(target_os = "windows")]
+                restore_existing_instance_window();
+                return Ok(());
+            }
+        } else {
+            log::info!("Single-instance guard disabled by {SINGLE_INSTANCE_ENV}");
+        }
     }
 
     #[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
@@ -323,4 +342,28 @@ fn main() -> eframe::Result<()> {
             Ok(Box::new(EntropyApp::new(cc)))
         }),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_instance_is_enabled_by_default() {
+        assert!(single_instance_enabled_from_env(None));
+    }
+
+    #[test]
+    fn single_instance_can_be_disabled_for_debugging() {
+        for value in ["0", "false", "off", "no", " FALSE "] {
+            assert!(!single_instance_enabled_from_env(Some(value)));
+        }
+    }
+
+    #[test]
+    fn single_instance_stays_enabled_for_other_values() {
+        for value in ["1", "true", "yes", "anything"] {
+            assert!(single_instance_enabled_from_env(Some(value)));
+        }
+    }
 }

--- a/src/ui/window_lifecycle.rs
+++ b/src/ui/window_lifecycle.rs
@@ -35,7 +35,10 @@ impl EntropyApp {
         self.last_single_instance_signal = signal;
         self.status_msg = "Entropy refreshed from a repeated launch".into();
         self.restore_from_tray(ctx);
-        self.start_device_scan();
+        if self.hid_device.is_none() && !matches!(self.connect_state, ConnectState::Loading { .. })
+        {
+            self.start_device_scan();
+        }
         ctx.request_repaint();
     }
 


### PR DESCRIPTION
## EN
### Summary
Add a single-instance lock override for diagnostics and guard repeated-launch device scans.

Repeated launches now restore/focus the existing app without starting a new scan when a device is already connected or a scan is already loading.

### Verification
- Local: `git diff --check`
- Local: `cargo build --release`
- Local: `cargo test`
- Remote: GitHub Actions `Build` run: https://github.com/ergohaven/entropy/actions/runs/27808729675.

Fixes #15

## RU
### Кратко
Добавляет single-instance lock override для диагностики и защищает повторные обнаружения устройств при запуске.

Повторные запуски теперь восстанавливают (переводят фокус на) существующее приложение без нового сканирования, если устройство уже подключено или сканирование уже в процессе.

### Проверка
- Локально: `git diff --check`
- Локально: `cargo build --release`
- Локально: `cargo test`
- Remote: GitHub Actions `Build` run: https://github.com/ergohaven/entropy/actions/runs/27808729675.

Закрывает #15
