### PR TITLE
Apply cargo fmt baseline

### DIFF
--- a/src/entsettings.rs
+++ b/src/entsettings.rs
@@ -89,14 +89,13 @@ impl EntropyApp {
                 &[("path", &path.display().to_string())],
             )
         })?;
-        let bundle: EntSettingsFile = serde_json::from_str(&data)
-            .with_context(|| {
-                crate::i18n::tr_catalog_format(
-                    lang,
-                    "entsettings.failed_to_parse",
-                    &[("path", &path.display().to_string())],
-                )
-            })?;
+        let bundle: EntSettingsFile = serde_json::from_str(&data).with_context(|| {
+            crate::i18n::tr_catalog_format(
+                lang,
+                "entsettings.failed_to_parse",
+                &[("path", &path.display().to_string())],
+            )
+        })?;
         validate_entsettings_file(&bundle, lang)?;
         let backup_path = write_entsettings_auto_backup(&self.entsettings_snapshot(), lang)?;
         self.apply_entsettings(ctx, bundle)?;
@@ -152,8 +151,8 @@ impl EntropyApp {
         for file in &bundle.text_expander_extra_files {
             if let Some(file_name) = normalize_text_expander_rules_file_name(&file.file_name) {
                 let path = text_expander_extra_rules_path(&file_name);
-                let json = serde_json::to_string_pretty(&file.rules)
-                    .context(crate::i18n::tr_catalog(
+                let json =
+                    serde_json::to_string_pretty(&file.rules).context(crate::i18n::tr_catalog(
                         self.app_settings.language,
                         "entsettings.failed_to_serialize_rules",
                     ))?;

--- a/src/keycode.rs
+++ b/src/keycode.rs
@@ -5,24 +5,48 @@
 /// Side-specific info belongs in tooltips, not the keycap label.
 pub fn gui_label(_right: bool) -> &'static str {
     #[cfg(target_os = "macos")]
-    { "⌘" }
+    {
+        "⌘"
+    }
     #[cfg(target_os = "windows")]
-    { "Win" }
+    {
+        "Win"
+    }
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    { "Super" }
+    {
+        "Super"
+    }
 }
 
 /// Short GUI symbol for use in compound labels (e.g. MT, mod combos).
 pub fn gui_sym() -> &'static str {
-    #[cfg(target_os = "macos")] { "⌘" }
-    #[cfg(target_os = "windows")] { "Win" }
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))] { "Super" }
+    #[cfg(target_os = "macos")]
+    {
+        "⌘"
+    }
+    #[cfg(target_os = "windows")]
+    {
+        "Win"
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        "Super"
+    }
 }
 
 pub fn gui_mod_name() -> &'static str {
-    #[cfg(target_os = "macos")] { "Cmd" }
-    #[cfg(target_os = "windows")] { "Win" }
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))] { "Super" }
+    #[cfg(target_os = "macos")]
+    {
+        "Cmd"
+    }
+    #[cfg(target_os = "windows")]
+    {
+        "Win"
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        "Super"
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -65,7 +89,6 @@ impl KeyLegendLayout {
         }
     }
 }
-
 
 fn osm_mod_bits(value: u16) -> Option<u16> {
     (0x52A0..=0x52BF).contains(&value).then_some(value & 0x1F)
@@ -129,7 +152,9 @@ pub fn key_label_font_sizes(label: &str) -> (Option<f32>, f32) {
         let trimmed = line.trim();
         !trimmed.is_empty()
             && trimmed.chars().count() <= 3
-            && trimmed.chars().all(|c| !c.is_alphanumeric() && !c.is_whitespace())
+            && trimmed
+                .chars()
+                .all(|c| !c.is_alphanumeric() && !c.is_whitespace())
     };
 
     match lines.as_slice() {
@@ -210,320 +235,1677 @@ pub enum KeycodeCategory {
 
 pub const KEYCODES: &[Keycode] = &[
     // ── Special ──────────────────────────────────────────────────────────────
-    Keycode { value: 0x0000, name: "KC_NO",     label: "✕",   category: KeycodeCategory::Special },
-    Keycode { value: 0x0001, name: "KC_TRNS",   label: "▽",   category: KeycodeCategory::Special },
-    Keycode { value: 0x7000, name: "QK_MAGIC_SWAP_CONTROL_CAPS_LOCK",      label: "Caps/Ctrl\nSwap",    category: KeycodeCategory::Special },
-    Keycode { value: 0x7001, name: "QK_MAGIC_UNSWAP_CONTROL_CAPS_LOCK",    label: "Caps/Ctrl\nRestore", category: KeycodeCategory::Special },
-    Keycode { value: 0x7002, name: "QK_MAGIC_TOGGLE_CONTROL_CAPS_LOCK",    label: "Caps/Ctrl\nToggle",  category: KeycodeCategory::Special },
-    Keycode { value: 0x7003, name: "QK_MAGIC_CAPS_LOCK_AS_CONTROL_OFF",    label: "Caps Lock\nas Caps", category: KeycodeCategory::Special },
-    Keycode { value: 0x7004, name: "QK_MAGIC_CAPS_LOCK_AS_CONTROL_ON",     label: "Caps Lock\nas Ctrl", category: KeycodeCategory::Special },
-    Keycode { value: 0x7005, name: "QK_MAGIC_SWAP_LALT_LGUI",              label: "LAlt/LGui\nSwap",    category: KeycodeCategory::Special },
-    Keycode { value: 0x7006, name: "QK_MAGIC_UNSWAP_LALT_LGUI",            label: "LAlt/LGui\nRestore", category: KeycodeCategory::Special },
-    Keycode { value: 0x7007, name: "QK_MAGIC_SWAP_RALT_RGUI",              label: "RAlt/RGui\nSwap",    category: KeycodeCategory::Special },
-    Keycode { value: 0x7008, name: "QK_MAGIC_UNSWAP_RALT_RGUI",            label: "RAlt/RGui\nRestore", category: KeycodeCategory::Special },
-    Keycode { value: 0x7009, name: "QK_MAGIC_GUI_ON",                      label: "GUI Keys\nOn",       category: KeycodeCategory::Special },
-    Keycode { value: 0x700A, name: "QK_MAGIC_GUI_OFF",                     label: "GUI Keys\nOff",      category: KeycodeCategory::Special },
-    Keycode { value: 0x700B, name: "QK_MAGIC_TOGGLE_GUI",                  label: "GUI Keys\nToggle",   category: KeycodeCategory::Special },
-    Keycode { value: 0x700C, name: "QK_MAGIC_SWAP_GRAVE_ESC",              label: "` / Esc\nSwap",      category: KeycodeCategory::Special },
-    Keycode { value: 0x700D, name: "QK_MAGIC_UNSWAP_GRAVE_ESC",            label: "` / Esc\nRestore",   category: KeycodeCategory::Special },
-    Keycode { value: 0x700E, name: "QK_MAGIC_SWAP_BACKSLASH_BACKSPACE",    label: "\\ / Bksp\nSwap",    category: KeycodeCategory::Special },
-    Keycode { value: 0x700F, name: "QK_MAGIC_UNSWAP_BACKSLASH_BACKSPACE",  label: "\\ / Bksp\nRestore", category: KeycodeCategory::Special },
-    Keycode { value: 0x7010, name: "QK_MAGIC_TOGGLE_BACKSLASH_BACKSPACE",  label: "\\ / Bksp\nToggle",  category: KeycodeCategory::Special },
-    Keycode { value: 0x7011, name: "QK_MAGIC_NKRO_ON",                     label: "NKRO\nOn",           category: KeycodeCategory::Special },
-    Keycode { value: 0x7012, name: "QK_MAGIC_NKRO_OFF",                    label: "NKRO\nOff",          category: KeycodeCategory::Special },
-    Keycode { value: 0x7013, name: "QK_MAGIC_TOGGLE_NKRO",                 label: "NKRO\nToggle",       category: KeycodeCategory::Special },
-    Keycode { value: 0x7014, name: "QK_MAGIC_SWAP_ALT_GUI",                label: "Alt/Gui\nSwap",      category: KeycodeCategory::Special },
-    Keycode { value: 0x7015, name: "QK_MAGIC_UNSWAP_ALT_GUI",              label: "Alt/Gui\nRestore",   category: KeycodeCategory::Special },
-    Keycode { value: 0x7016, name: "QK_MAGIC_TOGGLE_ALT_GUI",              label: "Alt/Gui\nToggle",    category: KeycodeCategory::Special },
-    Keycode { value: 0x7017, name: "QK_MAGIC_SWAP_LCTL_LGUI",              label: "LCtrl/LGui\nSwap",   category: KeycodeCategory::Special },
-    Keycode { value: 0x7018, name: "QK_MAGIC_UNSWAP_LCTL_LGUI",            label: "LCtrl/LGui\nRestore",category: KeycodeCategory::Special },
-    Keycode { value: 0x7019, name: "QK_MAGIC_SWAP_RCTL_RGUI",              label: "RCtrl/RGui\nSwap",   category: KeycodeCategory::Special },
-    Keycode { value: 0x701A, name: "QK_MAGIC_UNSWAP_RCTL_RGUI",            label: "RCtrl/RGui\nRestore",category: KeycodeCategory::Special },
-    Keycode { value: 0x701B, name: "QK_MAGIC_SWAP_CTL_GUI",                label: "Ctrl/Gui\nSwap",     category: KeycodeCategory::Special },
-    Keycode { value: 0x701C, name: "QK_MAGIC_UNSWAP_CTL_GUI",              label: "Ctrl/Gui\nRestore",  category: KeycodeCategory::Special },
-    Keycode { value: 0x701D, name: "QK_MAGIC_TOGGLE_CTL_GUI",              label: "Ctrl/Gui\nToggle",   category: KeycodeCategory::Special },
-    Keycode { value: 0x701E, name: "QK_MAGIC_EE_HANDS_LEFT",               label: "EE Hands\nLeft",     category: KeycodeCategory::Special },
-    Keycode { value: 0x701F, name: "QK_MAGIC_EE_HANDS_RIGHT",              label: "EE Hands\nRight",    category: KeycodeCategory::Special },
-    Keycode { value: 0x7020, name: "QK_MAGIC_SWAP_ESCAPE_CAPS_LOCK",       label: "Caps/Esc\nSwap",     category: KeycodeCategory::Special },
-    Keycode { value: 0x7021, name: "QK_MAGIC_UNSWAP_ESCAPE_CAPS_LOCK",     label: "Caps/Esc\nRestore",  category: KeycodeCategory::Special },
-    Keycode { value: 0x7022, name: "QK_MAGIC_TOGGLE_ESCAPE_CAPS_LOCK",     label: "Caps/Esc\nToggle",   category: KeycodeCategory::Special },
-
+    Keycode {
+        value: 0x0000,
+        name: "KC_NO",
+        label: "✕",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x0001,
+        name: "KC_TRNS",
+        label: "▽",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7000,
+        name: "QK_MAGIC_SWAP_CONTROL_CAPS_LOCK",
+        label: "Caps/Ctrl\nSwap",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7001,
+        name: "QK_MAGIC_UNSWAP_CONTROL_CAPS_LOCK",
+        label: "Caps/Ctrl\nRestore",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7002,
+        name: "QK_MAGIC_TOGGLE_CONTROL_CAPS_LOCK",
+        label: "Caps/Ctrl\nToggle",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7003,
+        name: "QK_MAGIC_CAPS_LOCK_AS_CONTROL_OFF",
+        label: "Caps Lock\nas Caps",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7004,
+        name: "QK_MAGIC_CAPS_LOCK_AS_CONTROL_ON",
+        label: "Caps Lock\nas Ctrl",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7005,
+        name: "QK_MAGIC_SWAP_LALT_LGUI",
+        label: "LAlt/LGui\nSwap",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7006,
+        name: "QK_MAGIC_UNSWAP_LALT_LGUI",
+        label: "LAlt/LGui\nRestore",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7007,
+        name: "QK_MAGIC_SWAP_RALT_RGUI",
+        label: "RAlt/RGui\nSwap",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7008,
+        name: "QK_MAGIC_UNSWAP_RALT_RGUI",
+        label: "RAlt/RGui\nRestore",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7009,
+        name: "QK_MAGIC_GUI_ON",
+        label: "GUI Keys\nOn",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x700A,
+        name: "QK_MAGIC_GUI_OFF",
+        label: "GUI Keys\nOff",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x700B,
+        name: "QK_MAGIC_TOGGLE_GUI",
+        label: "GUI Keys\nToggle",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x700C,
+        name: "QK_MAGIC_SWAP_GRAVE_ESC",
+        label: "` / Esc\nSwap",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x700D,
+        name: "QK_MAGIC_UNSWAP_GRAVE_ESC",
+        label: "` / Esc\nRestore",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x700E,
+        name: "QK_MAGIC_SWAP_BACKSLASH_BACKSPACE",
+        label: "\\ / Bksp\nSwap",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x700F,
+        name: "QK_MAGIC_UNSWAP_BACKSLASH_BACKSPACE",
+        label: "\\ / Bksp\nRestore",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7010,
+        name: "QK_MAGIC_TOGGLE_BACKSLASH_BACKSPACE",
+        label: "\\ / Bksp\nToggle",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7011,
+        name: "QK_MAGIC_NKRO_ON",
+        label: "NKRO\nOn",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7012,
+        name: "QK_MAGIC_NKRO_OFF",
+        label: "NKRO\nOff",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7013,
+        name: "QK_MAGIC_TOGGLE_NKRO",
+        label: "NKRO\nToggle",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7014,
+        name: "QK_MAGIC_SWAP_ALT_GUI",
+        label: "Alt/Gui\nSwap",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7015,
+        name: "QK_MAGIC_UNSWAP_ALT_GUI",
+        label: "Alt/Gui\nRestore",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7016,
+        name: "QK_MAGIC_TOGGLE_ALT_GUI",
+        label: "Alt/Gui\nToggle",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7017,
+        name: "QK_MAGIC_SWAP_LCTL_LGUI",
+        label: "LCtrl/LGui\nSwap",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7018,
+        name: "QK_MAGIC_UNSWAP_LCTL_LGUI",
+        label: "LCtrl/LGui\nRestore",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7019,
+        name: "QK_MAGIC_SWAP_RCTL_RGUI",
+        label: "RCtrl/RGui\nSwap",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x701A,
+        name: "QK_MAGIC_UNSWAP_RCTL_RGUI",
+        label: "RCtrl/RGui\nRestore",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x701B,
+        name: "QK_MAGIC_SWAP_CTL_GUI",
+        label: "Ctrl/Gui\nSwap",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x701C,
+        name: "QK_MAGIC_UNSWAP_CTL_GUI",
+        label: "Ctrl/Gui\nRestore",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x701D,
+        name: "QK_MAGIC_TOGGLE_CTL_GUI",
+        label: "Ctrl/Gui\nToggle",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x701E,
+        name: "QK_MAGIC_EE_HANDS_LEFT",
+        label: "EE Hands\nLeft",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x701F,
+        name: "QK_MAGIC_EE_HANDS_RIGHT",
+        label: "EE Hands\nRight",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7020,
+        name: "QK_MAGIC_SWAP_ESCAPE_CAPS_LOCK",
+        label: "Caps/Esc\nSwap",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7021,
+        name: "QK_MAGIC_UNSWAP_ESCAPE_CAPS_LOCK",
+        label: "Caps/Esc\nRestore",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7022,
+        name: "QK_MAGIC_TOGGLE_ESCAPE_CAPS_LOCK",
+        label: "Caps/Esc\nToggle",
+        category: KeycodeCategory::Special,
+    },
     // ── Letters ──────────────────────────────────────────────────────────────
-    Keycode { value: 0x0004, name: "KC_A", label: "A", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0005, name: "KC_B", label: "B", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0006, name: "KC_C", label: "C", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0007, name: "KC_D", label: "D", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0008, name: "KC_E", label: "E", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0009, name: "KC_F", label: "F", category: KeycodeCategory::Basic },
-    Keycode { value: 0x000A, name: "KC_G", label: "G", category: KeycodeCategory::Basic },
-    Keycode { value: 0x000B, name: "KC_H", label: "H", category: KeycodeCategory::Basic },
-    Keycode { value: 0x000C, name: "KC_I", label: "I", category: KeycodeCategory::Basic },
-    Keycode { value: 0x000D, name: "KC_J", label: "J", category: KeycodeCategory::Basic },
-    Keycode { value: 0x000E, name: "KC_K", label: "K", category: KeycodeCategory::Basic },
-    Keycode { value: 0x000F, name: "KC_L", label: "L", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0010, name: "KC_M", label: "M", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0011, name: "KC_N", label: "N", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0012, name: "KC_O", label: "O", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0013, name: "KC_P", label: "P", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0014, name: "KC_Q", label: "Q", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0015, name: "KC_R", label: "R", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0016, name: "KC_S", label: "S", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0017, name: "KC_T", label: "T", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0018, name: "KC_U", label: "U", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0019, name: "KC_V", label: "V", category: KeycodeCategory::Basic },
-    Keycode { value: 0x001A, name: "KC_W", label: "W", category: KeycodeCategory::Basic },
-    Keycode { value: 0x001B, name: "KC_X", label: "X", category: KeycodeCategory::Basic },
-    Keycode { value: 0x001C, name: "KC_Y", label: "Y", category: KeycodeCategory::Basic },
-    Keycode { value: 0x001D, name: "KC_Z", label: "Z", category: KeycodeCategory::Basic },
-
+    Keycode {
+        value: 0x0004,
+        name: "KC_A",
+        label: "A",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0005,
+        name: "KC_B",
+        label: "B",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0006,
+        name: "KC_C",
+        label: "C",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0007,
+        name: "KC_D",
+        label: "D",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0008,
+        name: "KC_E",
+        label: "E",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0009,
+        name: "KC_F",
+        label: "F",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x000A,
+        name: "KC_G",
+        label: "G",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x000B,
+        name: "KC_H",
+        label: "H",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x000C,
+        name: "KC_I",
+        label: "I",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x000D,
+        name: "KC_J",
+        label: "J",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x000E,
+        name: "KC_K",
+        label: "K",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x000F,
+        name: "KC_L",
+        label: "L",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0010,
+        name: "KC_M",
+        label: "M",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0011,
+        name: "KC_N",
+        label: "N",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0012,
+        name: "KC_O",
+        label: "O",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0013,
+        name: "KC_P",
+        label: "P",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0014,
+        name: "KC_Q",
+        label: "Q",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0015,
+        name: "KC_R",
+        label: "R",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0016,
+        name: "KC_S",
+        label: "S",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0017,
+        name: "KC_T",
+        label: "T",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0018,
+        name: "KC_U",
+        label: "U",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0019,
+        name: "KC_V",
+        label: "V",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x001A,
+        name: "KC_W",
+        label: "W",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x001B,
+        name: "KC_X",
+        label: "X",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x001C,
+        name: "KC_Y",
+        label: "Y",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x001D,
+        name: "KC_Z",
+        label: "Z",
+        category: KeycodeCategory::Basic,
+    },
     // ── Numbers ───────────────────────────────────────────────────────────────
-    Keycode { value: 0x001E, name: "KC_1", label: "1", category: KeycodeCategory::Basic },
-    Keycode { value: 0x001F, name: "KC_2", label: "2", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0020, name: "KC_3", label: "3", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0021, name: "KC_4", label: "4", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0022, name: "KC_5", label: "5", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0023, name: "KC_6", label: "6", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0024, name: "KC_7", label: "7", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0025, name: "KC_8", label: "8", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0026, name: "KC_9", label: "9", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0027, name: "KC_0", label: "0", category: KeycodeCategory::Basic },
-
+    Keycode {
+        value: 0x001E,
+        name: "KC_1",
+        label: "1",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x001F,
+        name: "KC_2",
+        label: "2",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0020,
+        name: "KC_3",
+        label: "3",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0021,
+        name: "KC_4",
+        label: "4",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0022,
+        name: "KC_5",
+        label: "5",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0023,
+        name: "KC_6",
+        label: "6",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0024,
+        name: "KC_7",
+        label: "7",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0025,
+        name: "KC_8",
+        label: "8",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0026,
+        name: "KC_9",
+        label: "9",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0027,
+        name: "KC_0",
+        label: "0",
+        category: KeycodeCategory::Basic,
+    },
     // ── Control ───────────────────────────────────────────────────────────────
-    Keycode { value: 0x0028, name: "KC_ENTER",  label: "↵",    category: KeycodeCategory::Basic },
-    Keycode { value: 0x0029, name: "KC_ESCAPE", label: "Esc",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x002A, name: "KC_BSPACE", label: "⟵",    category: KeycodeCategory::Basic },
-    Keycode { value: 0x002B, name: "KC_TAB",    label: "Tab",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x002C, name: "KC_SPACE",  label: "Space",category: KeycodeCategory::Basic },
-    Keycode { value: 0x0039, name: "KC_CAPSLOCK",label: "Caps\nLock", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0065, name: "KC_APPLICATION", label: "Menu", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0074, name: "KC_EXEC",        label: "Exec",   category: KeycodeCategory::Basic },
-    Keycode { value: 0x0075, name: "KC_HELP",        label: "Help",   category: KeycodeCategory::Basic },
-    Keycode { value: 0x0077, name: "KC_SELECT",      label: "Select", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0078, name: "KC_STOP",        label: "Stop",   category: KeycodeCategory::Basic },
-    Keycode { value: 0x0079, name: "KC_AGAIN",       label: "Again",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x007A, name: "KC_UNDO",        label: "Undo",   category: KeycodeCategory::Basic },
-    Keycode { value: 0x007B, name: "KC_CUT",         label: "Cut",    category: KeycodeCategory::Basic },
-    Keycode { value: 0x007C, name: "KC_COPY",        label: "Copy",   category: KeycodeCategory::Basic },
-    Keycode { value: 0x007D, name: "KC_PSTE",        label: "Paste",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x007E, name: "KC_FIND",        label: "Find",   category: KeycodeCategory::Basic },
-
+    Keycode {
+        value: 0x0028,
+        name: "KC_ENTER",
+        label: "↵",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0029,
+        name: "KC_ESCAPE",
+        label: "Esc",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x002A,
+        name: "KC_BSPACE",
+        label: "⟵",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x002B,
+        name: "KC_TAB",
+        label: "Tab",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x002C,
+        name: "KC_SPACE",
+        label: "Space",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0039,
+        name: "KC_CAPSLOCK",
+        label: "Caps\nLock",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0065,
+        name: "KC_APPLICATION",
+        label: "Menu",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0074,
+        name: "KC_EXEC",
+        label: "Exec",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0075,
+        name: "KC_HELP",
+        label: "Help",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0077,
+        name: "KC_SELECT",
+        label: "Select",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0078,
+        name: "KC_STOP",
+        label: "Stop",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0079,
+        name: "KC_AGAIN",
+        label: "Again",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x007A,
+        name: "KC_UNDO",
+        label: "Undo",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x007B,
+        name: "KC_CUT",
+        label: "Cut",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x007C,
+        name: "KC_COPY",
+        label: "Copy",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x007D,
+        name: "KC_PSTE",
+        label: "Paste",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x007E,
+        name: "KC_FIND",
+        label: "Find",
+        category: KeycodeCategory::Basic,
+    },
     // ── Punctuation ───────────────────────────────────────────────────────────
-    Keycode { value: 0x002D, name: "KC_MINUS",   label: "_
--",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x002E, name: "KC_EQUAL",   label: "+
-=",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x002F, name: "KC_LBRACKET",label: "{
-[",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x0030, name: "KC_RBRACKET",label: "}
-]",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x0031, name: "KC_BSLASH",  label: "|
-\\", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0032, name: "KC_NONUS_HASH", label: "~
-#", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0033, name: "KC_SCOLON",  label: ":
-;",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x0034, name: "KC_QUOTE",   label: "\"
-'", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0035, name: "KC_GRAVE",   label: "~
-`",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x0036, name: "KC_COMMA",   label: "<
-,",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x0037, name: "KC_DOT",     label: ">
-.",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x0038, name: "KC_SLASH",   label: "?
-/",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x0064, name: "KC_NONUS_BSLASH", label: "|
-\\", category: KeycodeCategory::Basic },
-
+    Keycode {
+        value: 0x002D,
+        name: "KC_MINUS",
+        label: "_
+-",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x002E,
+        name: "KC_EQUAL",
+        label: "+
+=",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x002F,
+        name: "KC_LBRACKET",
+        label: "{
+[",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0030,
+        name: "KC_RBRACKET",
+        label: "}
+]",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0031,
+        name: "KC_BSLASH",
+        label: "|
+\\",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0032,
+        name: "KC_NONUS_HASH",
+        label: "~
+#",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0033,
+        name: "KC_SCOLON",
+        label: ":
+;",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0034,
+        name: "KC_QUOTE",
+        label: "\"
+'",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0035,
+        name: "KC_GRAVE",
+        label: "~
+`",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0036,
+        name: "KC_COMMA",
+        label: "<
+,",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0037,
+        name: "KC_DOT",
+        label: ">
+.",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0038,
+        name: "KC_SLASH",
+        label: "?
+/",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0064,
+        name: "KC_NONUS_BSLASH",
+        label: "|
+\\",
+        category: KeycodeCategory::Basic,
+    },
     // ── Shifted symbols (LSFT(kc) shortcuts) ─────────────────────────────────
     // These are 0x0200 | basic_kc
-    Keycode { value: 0x021E, name: "KC_EXLM",  label: "!",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x021F, name: "KC_AT",    label: "@",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x0220, name: "KC_HASH",  label: "#",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x0221, name: "KC_DLR",   label: "$",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x0222, name: "KC_PERC",  label: "%",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x0223, name: "KC_CIRC",  label: "^",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x0224, name: "KC_AMPR",  label: "&",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x0225, name: "KC_ASTR",  label: "*",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x0226, name: "KC_LPRN",  label: "(",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x0227, name: "KC_RPRN",  label: ")",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x022D, name: "KC_UNDS",  label: "_",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x022E, name: "KC_PLUS",  label: "+",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x022F, name: "KC_LCBR",  label: "{",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x0230, name: "KC_RCBR",  label: "}",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x0231, name: "KC_PIPE",  label: "|",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x0233, name: "KC_COLN",  label: ":",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x0234, name: "KC_DQUO",  label: "\"", category: KeycodeCategory::Basic },
-    Keycode { value: 0x0235, name: "KC_TILD",  label: "~",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x0236, name: "KC_LT",    label: "<",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x0237, name: "KC_GT",    label: ">",  category: KeycodeCategory::Basic },
-    Keycode { value: 0x0238, name: "KC_QUES",  label: "?",  category: KeycodeCategory::Basic },
-
+    Keycode {
+        value: 0x021E,
+        name: "KC_EXLM",
+        label: "!",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x021F,
+        name: "KC_AT",
+        label: "@",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0220,
+        name: "KC_HASH",
+        label: "#",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0221,
+        name: "KC_DLR",
+        label: "$",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0222,
+        name: "KC_PERC",
+        label: "%",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0223,
+        name: "KC_CIRC",
+        label: "^",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0224,
+        name: "KC_AMPR",
+        label: "&",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0225,
+        name: "KC_ASTR",
+        label: "*",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0226,
+        name: "KC_LPRN",
+        label: "(",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0227,
+        name: "KC_RPRN",
+        label: ")",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x022D,
+        name: "KC_UNDS",
+        label: "_",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x022E,
+        name: "KC_PLUS",
+        label: "+",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x022F,
+        name: "KC_LCBR",
+        label: "{",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0230,
+        name: "KC_RCBR",
+        label: "}",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0231,
+        name: "KC_PIPE",
+        label: "|",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0233,
+        name: "KC_COLN",
+        label: ":",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0234,
+        name: "KC_DQUO",
+        label: "\"",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0235,
+        name: "KC_TILD",
+        label: "~",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0236,
+        name: "KC_LT",
+        label: "<",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0237,
+        name: "KC_GT",
+        label: ">",
+        category: KeycodeCategory::Basic,
+    },
+    Keycode {
+        value: 0x0238,
+        name: "KC_QUES",
+        label: "?",
+        category: KeycodeCategory::Basic,
+    },
     // ── Function keys ─────────────────────────────────────────────────────────
-    Keycode { value: 0x003A, name: "KC_F1",  label: "F1",  category: KeycodeCategory::Function },
-    Keycode { value: 0x003B, name: "KC_F2",  label: "F2",  category: KeycodeCategory::Function },
-    Keycode { value: 0x003C, name: "KC_F3",  label: "F3",  category: KeycodeCategory::Function },
-    Keycode { value: 0x003D, name: "KC_F4",  label: "F4",  category: KeycodeCategory::Function },
-    Keycode { value: 0x003E, name: "KC_F5",  label: "F5",  category: KeycodeCategory::Function },
-    Keycode { value: 0x003F, name: "KC_F6",  label: "F6",  category: KeycodeCategory::Function },
-    Keycode { value: 0x0040, name: "KC_F7",  label: "F7",  category: KeycodeCategory::Function },
-    Keycode { value: 0x0041, name: "KC_F8",  label: "F8",  category: KeycodeCategory::Function },
-    Keycode { value: 0x0042, name: "KC_F9",  label: "F9",  category: KeycodeCategory::Function },
-    Keycode { value: 0x0043, name: "KC_F10", label: "F10", category: KeycodeCategory::Function },
-    Keycode { value: 0x0044, name: "KC_F11", label: "F11", category: KeycodeCategory::Function },
-    Keycode { value: 0x0045, name: "KC_F12", label: "F12", category: KeycodeCategory::Function },
-    Keycode { value: 0x0068, name: "KC_F13", label: "F13", category: KeycodeCategory::Function },
-    Keycode { value: 0x0069, name: "KC_F14", label: "F14", category: KeycodeCategory::Function },
-    Keycode { value: 0x006A, name: "KC_F15", label: "F15", category: KeycodeCategory::Function },
-    Keycode { value: 0x006B, name: "KC_F16", label: "F16", category: KeycodeCategory::Function },
-    Keycode { value: 0x006C, name: "KC_F17", label: "F17", category: KeycodeCategory::Function },
-    Keycode { value: 0x006D, name: "KC_F18", label: "F18", category: KeycodeCategory::Function },
-    Keycode { value: 0x006E, name: "KC_F19", label: "F19", category: KeycodeCategory::Function },
-    Keycode { value: 0x006F, name: "KC_F20", label: "F20", category: KeycodeCategory::Function },
-    Keycode { value: 0x0070, name: "KC_F21", label: "F21", category: KeycodeCategory::Function },
-    Keycode { value: 0x0071, name: "KC_F22", label: "F22", category: KeycodeCategory::Function },
-    Keycode { value: 0x0072, name: "KC_F23", label: "F23", category: KeycodeCategory::Function },
-    Keycode { value: 0x0073, name: "KC_F24", label: "F24", category: KeycodeCategory::Function },
-
+    Keycode {
+        value: 0x003A,
+        name: "KC_F1",
+        label: "F1",
+        category: KeycodeCategory::Function,
+    },
+    Keycode {
+        value: 0x003B,
+        name: "KC_F2",
+        label: "F2",
+        category: KeycodeCategory::Function,
+    },
+    Keycode {
+        value: 0x003C,
+        name: "KC_F3",
+        label: "F3",
+        category: KeycodeCategory::Function,
+    },
+    Keycode {
+        value: 0x003D,
+        name: "KC_F4",
+        label: "F4",
+        category: KeycodeCategory::Function,
+    },
+    Keycode {
+        value: 0x003E,
+        name: "KC_F5",
+        label: "F5",
+        category: KeycodeCategory::Function,
+    },
+    Keycode {
+        value: 0x003F,
+        name: "KC_F6",
+        label: "F6",
+        category: KeycodeCategory::Function,
+    },
+    Keycode {
+        value: 0x0040,
+        name: "KC_F7",
+        label: "F7",
+        category: KeycodeCategory::Function,
+    },
+    Keycode {
+        value: 0x0041,
+        name: "KC_F8",
+        label: "F8",
+        category: KeycodeCategory::Function,
+    },
+    Keycode {
+        value: 0x0042,
+        name: "KC_F9",
+        label: "F9",
+        category: KeycodeCategory::Function,
+    },
+    Keycode {
+        value: 0x0043,
+        name: "KC_F10",
+        label: "F10",
+        category: KeycodeCategory::Function,
+    },
+    Keycode {
+        value: 0x0044,
+        name: "KC_F11",
+        label: "F11",
+        category: KeycodeCategory::Function,
+    },
+    Keycode {
+        value: 0x0045,
+        name: "KC_F12",
+        label: "F12",
+        category: KeycodeCategory::Function,
+    },
+    Keycode {
+        value: 0x0068,
+        name: "KC_F13",
+        label: "F13",
+        category: KeycodeCategory::Function,
+    },
+    Keycode {
+        value: 0x0069,
+        name: "KC_F14",
+        label: "F14",
+        category: KeycodeCategory::Function,
+    },
+    Keycode {
+        value: 0x006A,
+        name: "KC_F15",
+        label: "F15",
+        category: KeycodeCategory::Function,
+    },
+    Keycode {
+        value: 0x006B,
+        name: "KC_F16",
+        label: "F16",
+        category: KeycodeCategory::Function,
+    },
+    Keycode {
+        value: 0x006C,
+        name: "KC_F17",
+        label: "F17",
+        category: KeycodeCategory::Function,
+    },
+    Keycode {
+        value: 0x006D,
+        name: "KC_F18",
+        label: "F18",
+        category: KeycodeCategory::Function,
+    },
+    Keycode {
+        value: 0x006E,
+        name: "KC_F19",
+        label: "F19",
+        category: KeycodeCategory::Function,
+    },
+    Keycode {
+        value: 0x006F,
+        name: "KC_F20",
+        label: "F20",
+        category: KeycodeCategory::Function,
+    },
+    Keycode {
+        value: 0x0070,
+        name: "KC_F21",
+        label: "F21",
+        category: KeycodeCategory::Function,
+    },
+    Keycode {
+        value: 0x0071,
+        name: "KC_F22",
+        label: "F22",
+        category: KeycodeCategory::Function,
+    },
+    Keycode {
+        value: 0x0072,
+        name: "KC_F23",
+        label: "F23",
+        category: KeycodeCategory::Function,
+    },
+    Keycode {
+        value: 0x0073,
+        name: "KC_F24",
+        label: "F24",
+        category: KeycodeCategory::Function,
+    },
     // ── Navigation ────────────────────────────────────────────────────────────
-    Keycode { value: 0x0046, name: "KC_PSCREEN",   label: "Print\nScreen", category: KeycodeCategory::Navigation },
-    Keycode { value: 0x0047, name: "KC_SCROLLLOCK", label: "Scroll\nLock",  category: KeycodeCategory::Navigation },
-    Keycode { value: 0x0048, name: "KC_PAUSE",     label: "Pause",        category: KeycodeCategory::Navigation },
-    Keycode { value: 0x0049, name: "KC_INSERT",    label: "Insert",       category: KeycodeCategory::Navigation },
-    Keycode { value: 0x004A, name: "KC_HOME",      label: "Home",         category: KeycodeCategory::Navigation },
-    Keycode { value: 0x004B, name: "KC_PGUP",      label: "Page\nUp",      category: KeycodeCategory::Navigation },
-    Keycode { value: 0x004C, name: "KC_DELETE",    label: "Delete",       category: KeycodeCategory::Navigation },
-    Keycode { value: 0x004D, name: "KC_END",       label: "End",          category: KeycodeCategory::Navigation },
-    Keycode { value: 0x004E, name: "KC_PGDOWN",    label: "Page\nDown",    category: KeycodeCategory::Navigation },
-    Keycode { value: 0x004F, name: "KC_RIGHT",     label: "➡",   category: KeycodeCategory::Navigation },
-    Keycode { value: 0x0050, name: "KC_LEFT",      label: "⬅",   category: KeycodeCategory::Navigation },
-    Keycode { value: 0x0051, name: "KC_DOWN",      label: "⬇",   category: KeycodeCategory::Navigation },
-    Keycode { value: 0x0052, name: "KC_UP",        label: "⬆",   category: KeycodeCategory::Navigation },
-
+    Keycode {
+        value: 0x0046,
+        name: "KC_PSCREEN",
+        label: "Print\nScreen",
+        category: KeycodeCategory::Navigation,
+    },
+    Keycode {
+        value: 0x0047,
+        name: "KC_SCROLLLOCK",
+        label: "Scroll\nLock",
+        category: KeycodeCategory::Navigation,
+    },
+    Keycode {
+        value: 0x0048,
+        name: "KC_PAUSE",
+        label: "Pause",
+        category: KeycodeCategory::Navigation,
+    },
+    Keycode {
+        value: 0x0049,
+        name: "KC_INSERT",
+        label: "Insert",
+        category: KeycodeCategory::Navigation,
+    },
+    Keycode {
+        value: 0x004A,
+        name: "KC_HOME",
+        label: "Home",
+        category: KeycodeCategory::Navigation,
+    },
+    Keycode {
+        value: 0x004B,
+        name: "KC_PGUP",
+        label: "Page\nUp",
+        category: KeycodeCategory::Navigation,
+    },
+    Keycode {
+        value: 0x004C,
+        name: "KC_DELETE",
+        label: "Delete",
+        category: KeycodeCategory::Navigation,
+    },
+    Keycode {
+        value: 0x004D,
+        name: "KC_END",
+        label: "End",
+        category: KeycodeCategory::Navigation,
+    },
+    Keycode {
+        value: 0x004E,
+        name: "KC_PGDOWN",
+        label: "Page\nDown",
+        category: KeycodeCategory::Navigation,
+    },
+    Keycode {
+        value: 0x004F,
+        name: "KC_RIGHT",
+        label: "➡",
+        category: KeycodeCategory::Navigation,
+    },
+    Keycode {
+        value: 0x0050,
+        name: "KC_LEFT",
+        label: "⬅",
+        category: KeycodeCategory::Navigation,
+    },
+    Keycode {
+        value: 0x0051,
+        name: "KC_DOWN",
+        label: "⬇",
+        category: KeycodeCategory::Navigation,
+    },
+    Keycode {
+        value: 0x0052,
+        name: "KC_UP",
+        label: "⬆",
+        category: KeycodeCategory::Navigation,
+    },
     // ── Numpad ────────────────────────────────────────────────────────────────
-    Keycode { value: 0x0053, name: "KC_NUMLOCK",     label: "NmLk",  category: KeycodeCategory::Numpad },
-    Keycode { value: 0x0054, name: "KC_KP_SLASH",    label: "Num/",    category: KeycodeCategory::Numpad },
-    Keycode { value: 0x0055, name: "KC_KP_ASTERISK", label: "Num*",    category: KeycodeCategory::Numpad },
-    Keycode { value: 0x0056, name: "KC_KP_MINUS",    label: "Num-",    category: KeycodeCategory::Numpad },
-    Keycode { value: 0x0057, name: "KC_KP_PLUS",     label: "Num+",    category: KeycodeCategory::Numpad },
-    Keycode { value: 0x0058, name: "KC_KP_ENTER",    label: "Num⏎", category: KeycodeCategory::Numpad },
-    Keycode { value: 0x0059, name: "KC_KP_1",  label: "Num1", category: KeycodeCategory::Numpad },
-    Keycode { value: 0x005A, name: "KC_KP_2",  label: "Num2", category: KeycodeCategory::Numpad },
-    Keycode { value: 0x005B, name: "KC_KP_3",  label: "Num3", category: KeycodeCategory::Numpad },
-    Keycode { value: 0x005C, name: "KC_KP_4",  label: "Num4", category: KeycodeCategory::Numpad },
-    Keycode { value: 0x005D, name: "KC_KP_5",  label: "Num5", category: KeycodeCategory::Numpad },
-    Keycode { value: 0x005E, name: "KC_KP_6",  label: "Num6", category: KeycodeCategory::Numpad },
-    Keycode { value: 0x005F, name: "KC_KP_7",  label: "Num7", category: KeycodeCategory::Numpad },
-    Keycode { value: 0x0060, name: "KC_KP_8",  label: "Num8", category: KeycodeCategory::Numpad },
-    Keycode { value: 0x0061, name: "KC_KP_9",  label: "Num9", category: KeycodeCategory::Numpad },
-    Keycode { value: 0x0062, name: "KC_KP_0",  label: "Num0", category: KeycodeCategory::Numpad },
-    Keycode { value: 0x0063, name: "KC_KP_DOT",   label: "Num.",  category: KeycodeCategory::Numpad },
-    Keycode { value: 0x0067, name: "KC_KP_EQUAL", label: "Num=",  category: KeycodeCategory::Numpad },
-    Keycode { value: 0x0085, name: "KC_KP_COMMA", label: "Num,",  category: KeycodeCategory::Numpad },
-
+    Keycode {
+        value: 0x0053,
+        name: "KC_NUMLOCK",
+        label: "NmLk",
+        category: KeycodeCategory::Numpad,
+    },
+    Keycode {
+        value: 0x0054,
+        name: "KC_KP_SLASH",
+        label: "Num/",
+        category: KeycodeCategory::Numpad,
+    },
+    Keycode {
+        value: 0x0055,
+        name: "KC_KP_ASTERISK",
+        label: "Num*",
+        category: KeycodeCategory::Numpad,
+    },
+    Keycode {
+        value: 0x0056,
+        name: "KC_KP_MINUS",
+        label: "Num-",
+        category: KeycodeCategory::Numpad,
+    },
+    Keycode {
+        value: 0x0057,
+        name: "KC_KP_PLUS",
+        label: "Num+",
+        category: KeycodeCategory::Numpad,
+    },
+    Keycode {
+        value: 0x0058,
+        name: "KC_KP_ENTER",
+        label: "Num⏎",
+        category: KeycodeCategory::Numpad,
+    },
+    Keycode {
+        value: 0x0059,
+        name: "KC_KP_1",
+        label: "Num1",
+        category: KeycodeCategory::Numpad,
+    },
+    Keycode {
+        value: 0x005A,
+        name: "KC_KP_2",
+        label: "Num2",
+        category: KeycodeCategory::Numpad,
+    },
+    Keycode {
+        value: 0x005B,
+        name: "KC_KP_3",
+        label: "Num3",
+        category: KeycodeCategory::Numpad,
+    },
+    Keycode {
+        value: 0x005C,
+        name: "KC_KP_4",
+        label: "Num4",
+        category: KeycodeCategory::Numpad,
+    },
+    Keycode {
+        value: 0x005D,
+        name: "KC_KP_5",
+        label: "Num5",
+        category: KeycodeCategory::Numpad,
+    },
+    Keycode {
+        value: 0x005E,
+        name: "KC_KP_6",
+        label: "Num6",
+        category: KeycodeCategory::Numpad,
+    },
+    Keycode {
+        value: 0x005F,
+        name: "KC_KP_7",
+        label: "Num7",
+        category: KeycodeCategory::Numpad,
+    },
+    Keycode {
+        value: 0x0060,
+        name: "KC_KP_8",
+        label: "Num8",
+        category: KeycodeCategory::Numpad,
+    },
+    Keycode {
+        value: 0x0061,
+        name: "KC_KP_9",
+        label: "Num9",
+        category: KeycodeCategory::Numpad,
+    },
+    Keycode {
+        value: 0x0062,
+        name: "KC_KP_0",
+        label: "Num0",
+        category: KeycodeCategory::Numpad,
+    },
+    Keycode {
+        value: 0x0063,
+        name: "KC_KP_DOT",
+        label: "Num.",
+        category: KeycodeCategory::Numpad,
+    },
+    Keycode {
+        value: 0x0067,
+        name: "KC_KP_EQUAL",
+        label: "Num=",
+        category: KeycodeCategory::Numpad,
+    },
+    Keycode {
+        value: 0x0085,
+        name: "KC_KP_COMMA",
+        label: "Num,",
+        category: KeycodeCategory::Numpad,
+    },
     // ── Modifiers ─────────────────────────────────────────────────────────────
-    Keycode { value: 0x00E0, name: "KC_LCTRL",  label: "Ctrl",  category: KeycodeCategory::Modifier },
-    Keycode { value: 0x00E1, name: "KC_LSHIFT", label: "Shift", category: KeycodeCategory::Modifier },
-    Keycode { value: 0x00E2, name: "KC_LALT",   label: "Alt",   category: KeycodeCategory::Modifier },
-    Keycode { value: 0x00E3, name: "KC_LGUI",   label: "GUI",   category: KeycodeCategory::Modifier },
-    Keycode { value: 0x00E4, name: "KC_RCTRL",  label: "Ctrl",  category: KeycodeCategory::Modifier },
-    Keycode { value: 0x00E5, name: "KC_RSHIFT", label: "Shift", category: KeycodeCategory::Modifier },
-    Keycode { value: 0x00E6, name: "KC_RALT",   label: "Alt",   category: KeycodeCategory::Modifier },
-    Keycode { value: 0x00E7, name: "KC_RGUI",   label: "GUI",   category: KeycodeCategory::Modifier },
-
+    Keycode {
+        value: 0x00E0,
+        name: "KC_LCTRL",
+        label: "Ctrl",
+        category: KeycodeCategory::Modifier,
+    },
+    Keycode {
+        value: 0x00E1,
+        name: "KC_LSHIFT",
+        label: "Shift",
+        category: KeycodeCategory::Modifier,
+    },
+    Keycode {
+        value: 0x00E2,
+        name: "KC_LALT",
+        label: "Alt",
+        category: KeycodeCategory::Modifier,
+    },
+    Keycode {
+        value: 0x00E3,
+        name: "KC_LGUI",
+        label: "GUI",
+        category: KeycodeCategory::Modifier,
+    },
+    Keycode {
+        value: 0x00E4,
+        name: "KC_RCTRL",
+        label: "Ctrl",
+        category: KeycodeCategory::Modifier,
+    },
+    Keycode {
+        value: 0x00E5,
+        name: "KC_RSHIFT",
+        label: "Shift",
+        category: KeycodeCategory::Modifier,
+    },
+    Keycode {
+        value: 0x00E6,
+        name: "KC_RALT",
+        label: "Alt",
+        category: KeycodeCategory::Modifier,
+    },
+    Keycode {
+        value: 0x00E7,
+        name: "KC_RGUI",
+        label: "GUI",
+        category: KeycodeCategory::Modifier,
+    },
     // ── Media / App / System ──────────────────────────────────────────────────
-    Keycode { value: 0x00A5, name: "KC_PWR",   label: "⏻\nPower",   category: KeycodeCategory::Media },
-    Keycode { value: 0x00A6, name: "KC_SLEP",  label: "🌙\nSleep",   category: KeycodeCategory::Media },
-    Keycode { value: 0x00A7, name: "KC_WAKE",  label: "☀\nWake",    category: KeycodeCategory::Media },
-    Keycode { value: 0x00A8, name: "KC_MUTE",  label: "🔇\nMute",    category: KeycodeCategory::Media },
-    Keycode { value: 0x00A9, name: "KC_VOLU",  label: "🔊\nVol+",    category: KeycodeCategory::Media },
-    Keycode { value: 0x00AA, name: "KC_VOLD",  label: "🔉\nVol-",    category: KeycodeCategory::Media },
-    Keycode { value: 0x00AB, name: "KC_MNXT",  label: "⏭\nNext",    category: KeycodeCategory::Media },
-    Keycode { value: 0x00AC, name: "KC_MPRV",  label: "⏮\nPrev",    category: KeycodeCategory::Media },
-    Keycode { value: 0x00AD, name: "KC_MSTP",  label: "⏹\nStop",    category: KeycodeCategory::Media },
-    Keycode { value: 0x00AE, name: "KC_MPLY",  label: "⏯\nPlay",    category: KeycodeCategory::Media },
-    Keycode { value: 0x00AF, name: "KC_MSEL",  label: "🎵\nMedia",   category: KeycodeCategory::Media },
-    Keycode { value: 0x00B0, name: "KC_EJCT",  label: "⏏\nEject",   category: KeycodeCategory::Media },
-    Keycode { value: 0x00B1, name: "KC_MAIL",  label: "✉\nMail",    category: KeycodeCategory::Media },
-    Keycode { value: 0x00B2, name: "KC_CALC",  label: "🖩\nCalc",    category: KeycodeCategory::Media },
-    Keycode { value: 0x00B3, name: "KC_MYCM",  label: "💻\nFiles",   category: KeycodeCategory::Media },
-    Keycode { value: 0x00B4, name: "KC_WSCH",  label: "🔍\nSearch",  category: KeycodeCategory::Media },
-    Keycode { value: 0x00B5, name: "KC_WHOM",  label: "🏠\nHome",    category: KeycodeCategory::Media },
-    Keycode { value: 0x00B6, name: "KC_WBAK",  label: "⬅\nBack",    category: KeycodeCategory::Media },
-    Keycode { value: 0x00B7, name: "KC_WFWD",  label: "➡\nForward", category: KeycodeCategory::Media },
-    Keycode { value: 0x00B8, name: "KC_WSTP",  label: "⏹\nStop",    category: KeycodeCategory::Media },
-    Keycode { value: 0x00B9, name: "KC_WREF",  label: "↻\nRefresh", category: KeycodeCategory::Media },
-    Keycode { value: 0x00BA, name: "KC_WFAV",  label: "★\nFavs",    category: KeycodeCategory::Media },
-    Keycode { value: 0x00BB, name: "KC_MFFD",  label: "⏩\nFwd",     category: KeycodeCategory::Media },
-    Keycode { value: 0x00BC, name: "KC_MRWD",  label: "⏪\nRew",     category: KeycodeCategory::Media },
-    Keycode { value: 0x00BD, name: "KC_BRIU",  label: "☀+\nBright", category: KeycodeCategory::Media },
-    Keycode { value: 0x00BE, name: "KC_BRID",  label: "☀-\nBright", category: KeycodeCategory::Media },
-    Keycode { value: 0x00BF, name: "KC_MCTL",  label: "Ctrl\nView", category: KeycodeCategory::Media },
-    Keycode { value: 0x00C0, name: "KC_LPAD",  label: "Launch\nPad", category: KeycodeCategory::Media },
-
+    Keycode {
+        value: 0x00A5,
+        name: "KC_PWR",
+        label: "⏻\nPower",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00A6,
+        name: "KC_SLEP",
+        label: "🌙\nSleep",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00A7,
+        name: "KC_WAKE",
+        label: "☀\nWake",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00A8,
+        name: "KC_MUTE",
+        label: "🔇\nMute",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00A9,
+        name: "KC_VOLU",
+        label: "🔊\nVol+",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00AA,
+        name: "KC_VOLD",
+        label: "🔉\nVol-",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00AB,
+        name: "KC_MNXT",
+        label: "⏭\nNext",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00AC,
+        name: "KC_MPRV",
+        label: "⏮\nPrev",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00AD,
+        name: "KC_MSTP",
+        label: "⏹\nStop",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00AE,
+        name: "KC_MPLY",
+        label: "⏯\nPlay",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00AF,
+        name: "KC_MSEL",
+        label: "🎵\nMedia",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00B0,
+        name: "KC_EJCT",
+        label: "⏏\nEject",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00B1,
+        name: "KC_MAIL",
+        label: "✉\nMail",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00B2,
+        name: "KC_CALC",
+        label: "🖩\nCalc",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00B3,
+        name: "KC_MYCM",
+        label: "💻\nFiles",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00B4,
+        name: "KC_WSCH",
+        label: "🔍\nSearch",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00B5,
+        name: "KC_WHOM",
+        label: "🏠\nHome",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00B6,
+        name: "KC_WBAK",
+        label: "⬅\nBack",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00B7,
+        name: "KC_WFWD",
+        label: "➡\nForward",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00B8,
+        name: "KC_WSTP",
+        label: "⏹\nStop",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00B9,
+        name: "KC_WREF",
+        label: "↻\nRefresh",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00BA,
+        name: "KC_WFAV",
+        label: "★\nFavs",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00BB,
+        name: "KC_MFFD",
+        label: "⏩\nFwd",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00BC,
+        name: "KC_MRWD",
+        label: "⏪\nRew",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00BD,
+        name: "KC_BRIU",
+        label: "☀+\nBright",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00BE,
+        name: "KC_BRID",
+        label: "☀-\nBright",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00BF,
+        name: "KC_MCTL",
+        label: "Ctrl\nView",
+        category: KeycodeCategory::Media,
+    },
+    Keycode {
+        value: 0x00C0,
+        name: "KC_LPAD",
+        label: "Launch\nPad",
+        category: KeycodeCategory::Media,
+    },
     // ── Mouse ─────────────────────────────────────────────────────────────────
-    Keycode { value: 0x00CD, name: "KC_MS_U",     label: "Mouse\nUp",    category: KeycodeCategory::Mouse },
-    Keycode { value: 0x00CE, name: "KC_MS_D",     label: "Mouse\nDown",  category: KeycodeCategory::Mouse },
-    Keycode { value: 0x00CF, name: "KC_MS_L",     label: "Mouse\nLeft",  category: KeycodeCategory::Mouse },
-    Keycode { value: 0x00D0, name: "KC_MS_R",     label: "Mouse\nRight", category: KeycodeCategory::Mouse },
-    Keycode { value: 0x00D1, name: "KC_BTN1",     label: "Mouse\n1",     category: KeycodeCategory::Mouse },
-    Keycode { value: 0x00D2, name: "KC_BTN2",     label: "Mouse\n2",     category: KeycodeCategory::Mouse },
-    Keycode { value: 0x00D3, name: "KC_BTN3",     label: "Mouse\n3",     category: KeycodeCategory::Mouse },
-    Keycode { value: 0x00D4, name: "KC_BTN4",     label: "Mouse\n4",     category: KeycodeCategory::Mouse },
-    Keycode { value: 0x00D5, name: "KC_BTN5",     label: "Mouse\n5",     category: KeycodeCategory::Mouse },
-    Keycode { value: 0x00D6, name: "KC_BTN6",     label: "Mouse\n6",     category: KeycodeCategory::Mouse },
-    Keycode { value: 0x00D7, name: "KC_BTN7",     label: "Mouse\n7",     category: KeycodeCategory::Mouse },
-    Keycode { value: 0x00D8, name: "KC_BTN8",     label: "Mouse\n8",     category: KeycodeCategory::Mouse },
-    Keycode { value: 0x00D9, name: "KC_WH_U",     label: "Scroll\nUp",   category: KeycodeCategory::Mouse },
-    Keycode { value: 0x00DA, name: "KC_WH_D",     label: "Scroll\nDown", category: KeycodeCategory::Mouse },
-    Keycode { value: 0x00DB, name: "KC_WH_L",     label: "Scroll\nLeft", category: KeycodeCategory::Mouse },
-    Keycode { value: 0x00DC, name: "KC_WH_R",     label: "Scroll\nRight",category: KeycodeCategory::Mouse },
-    Keycode { value: 0x00DD, name: "KC_MS_ACCEL0", label: "Accel\n0",    category: KeycodeCategory::Mouse },
-    Keycode { value: 0x00DE, name: "KC_MS_ACCEL1", label: "Accel\n1",    category: KeycodeCategory::Mouse },
-    Keycode { value: 0x00DF, name: "KC_MS_ACCEL2", label: "Accel\n2",    category: KeycodeCategory::Mouse },
-
-
+    Keycode {
+        value: 0x00CD,
+        name: "KC_MS_U",
+        label: "Mouse\nUp",
+        category: KeycodeCategory::Mouse,
+    },
+    Keycode {
+        value: 0x00CE,
+        name: "KC_MS_D",
+        label: "Mouse\nDown",
+        category: KeycodeCategory::Mouse,
+    },
+    Keycode {
+        value: 0x00CF,
+        name: "KC_MS_L",
+        label: "Mouse\nLeft",
+        category: KeycodeCategory::Mouse,
+    },
+    Keycode {
+        value: 0x00D0,
+        name: "KC_MS_R",
+        label: "Mouse\nRight",
+        category: KeycodeCategory::Mouse,
+    },
+    Keycode {
+        value: 0x00D1,
+        name: "KC_BTN1",
+        label: "Mouse\n1",
+        category: KeycodeCategory::Mouse,
+    },
+    Keycode {
+        value: 0x00D2,
+        name: "KC_BTN2",
+        label: "Mouse\n2",
+        category: KeycodeCategory::Mouse,
+    },
+    Keycode {
+        value: 0x00D3,
+        name: "KC_BTN3",
+        label: "Mouse\n3",
+        category: KeycodeCategory::Mouse,
+    },
+    Keycode {
+        value: 0x00D4,
+        name: "KC_BTN4",
+        label: "Mouse\n4",
+        category: KeycodeCategory::Mouse,
+    },
+    Keycode {
+        value: 0x00D5,
+        name: "KC_BTN5",
+        label: "Mouse\n5",
+        category: KeycodeCategory::Mouse,
+    },
+    Keycode {
+        value: 0x00D6,
+        name: "KC_BTN6",
+        label: "Mouse\n6",
+        category: KeycodeCategory::Mouse,
+    },
+    Keycode {
+        value: 0x00D7,
+        name: "KC_BTN7",
+        label: "Mouse\n7",
+        category: KeycodeCategory::Mouse,
+    },
+    Keycode {
+        value: 0x00D8,
+        name: "KC_BTN8",
+        label: "Mouse\n8",
+        category: KeycodeCategory::Mouse,
+    },
+    Keycode {
+        value: 0x00D9,
+        name: "KC_WH_U",
+        label: "Scroll\nUp",
+        category: KeycodeCategory::Mouse,
+    },
+    Keycode {
+        value: 0x00DA,
+        name: "KC_WH_D",
+        label: "Scroll\nDown",
+        category: KeycodeCategory::Mouse,
+    },
+    Keycode {
+        value: 0x00DB,
+        name: "KC_WH_L",
+        label: "Scroll\nLeft",
+        category: KeycodeCategory::Mouse,
+    },
+    Keycode {
+        value: 0x00DC,
+        name: "KC_WH_R",
+        label: "Scroll\nRight",
+        category: KeycodeCategory::Mouse,
+    },
+    Keycode {
+        value: 0x00DD,
+        name: "KC_MS_ACCEL0",
+        label: "Accel\n0",
+        category: KeycodeCategory::Mouse,
+    },
+    Keycode {
+        value: 0x00DE,
+        name: "KC_MS_ACCEL1",
+        label: "Accel\n1",
+        category: KeycodeCategory::Mouse,
+    },
+    Keycode {
+        value: 0x00DF,
+        name: "KC_MS_ACCEL2",
+        label: "Accel\n2",
+        category: KeycodeCategory::Mouse,
+    },
     // ── QMK special ───────────────────────────────────────────────────────────
-    Keycode { value: 0x7C16, name: "KC_GESC",  label: "Esc\n~", category: KeycodeCategory::Special },
-    Keycode { value: 0x7C00, name: "QK_BOOT",  label: "⚡\nBoot", category: KeycodeCategory::Special },
-    Keycode { value: 0x7C02, name: "DB_TOGG",  label: "🐛\nDebug", category: KeycodeCategory::Special },
-    Keycode { value: 0x7800, name: "QK_LOCK",  label: "🔒\nLock",category: KeycodeCategory::Special },
-    Keycode { value: 0x7C1A, name: "KC_LSPO",  label: "Shift\n(",   category: KeycodeCategory::Special },
-    Keycode { value: 0x7C1B, name: "KC_RSPC",  label: "Shift\n)",   category: KeycodeCategory::Special },
-    Keycode { value: 0x7C18, name: "KC_LCPO",  label: "Ctrl\n(",    category: KeycodeCategory::Special },
-    Keycode { value: 0x7C19, name: "KC_RCPC",  label: "Ctrl\n)",    category: KeycodeCategory::Special },
-    Keycode { value: 0x7C1C, name: "KC_LAPO",  label: "Alt\n(",      category: KeycodeCategory::Special },
-    Keycode { value: 0x7C1D, name: "KC_RAPC",  label: "Alt\n)",      category: KeycodeCategory::Special },
-    Keycode { value: 0x7C1E, name: "KC_SFTENT",label: "Shift\nEnter", category: KeycodeCategory::Special },
-    Keycode { value: 0x0087, name: "KC_RO",    label: "JIS\n\\ _",   category: KeycodeCategory::Special },
-    Keycode { value: 0x0088, name: "KC_KANA",  label: "JIS\nKana",   category: KeycodeCategory::Special },
-    Keycode { value: 0x0089, name: "KC_JYEN",  label: "JIS\n¥ |",    category: KeycodeCategory::Special },
-    Keycode { value: 0x008A, name: "KC_HENK",  label: "JIS\nHenkan", category: KeycodeCategory::Special },
-    Keycode { value: 0x008B, name: "KC_MHEN",  label: "JIS\nMuhenk", category: KeycodeCategory::Special },
-    Keycode { value: 0x008C, name: "KC_INT6",  label: "JIS\nNum ,",  category: KeycodeCategory::Special },
-    Keycode { value: 0x0090, name: "KC_LANG1", label: "Hangul\nEng", category: KeycodeCategory::Special },
-    Keycode { value: 0x0091, name: "KC_LANG2", label: "Hangul\nHanja", category: KeycodeCategory::Special },
-    Keycode { value: 0x0092, name: "KC_LANG3", label: "JIS\nKatak",  category: KeycodeCategory::Special },
-    Keycode { value: 0x0093, name: "KC_LANG4", label: "JIS\nHirag",  category: KeycodeCategory::Special },
-    Keycode { value: 0x0094, name: "KC_LANG5", label: "JIS\nZenHan", category: KeycodeCategory::Special },
-    Keycode { value: 0x7C14, name: "QK_MAKE",             label: "Make",         category: KeycodeCategory::Special },
-    Keycode { value: 0x7C15, name: "KC_ASTG",             label: "Auto\nShift",  category: KeycodeCategory::Special },
-    Keycode { value: 0x7C52, name: "CMB_TOG",             label: "Combo\nToggle",category: KeycodeCategory::Special },
-    Keycode { value: 0x7C73, name: "QK_CAPS_WORD_TOGGLE", label: "Caps\nWord",   category: KeycodeCategory::Special },
-    Keycode { value: 0x7C79, name: "QK_REPEAT_KEY",       label: "Repeat",       category: KeycodeCategory::Special },
-    Keycode { value: 0x7C7A, name: "QK_ALT_REPEAT_KEY",   label: "Alt\nRepeat",  category: KeycodeCategory::Special },
+    Keycode {
+        value: 0x7C16,
+        name: "KC_GESC",
+        label: "Esc\n~",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7C00,
+        name: "QK_BOOT",
+        label: "⚡\nBoot",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7C02,
+        name: "DB_TOGG",
+        label: "🐛\nDebug",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7800,
+        name: "QK_LOCK",
+        label: "🔒\nLock",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7C1A,
+        name: "KC_LSPO",
+        label: "Shift\n(",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7C1B,
+        name: "KC_RSPC",
+        label: "Shift\n)",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7C18,
+        name: "KC_LCPO",
+        label: "Ctrl\n(",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7C19,
+        name: "KC_RCPC",
+        label: "Ctrl\n)",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7C1C,
+        name: "KC_LAPO",
+        label: "Alt\n(",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7C1D,
+        name: "KC_RAPC",
+        label: "Alt\n)",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7C1E,
+        name: "KC_SFTENT",
+        label: "Shift\nEnter",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x0087,
+        name: "KC_RO",
+        label: "JIS\n\\ _",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x0088,
+        name: "KC_KANA",
+        label: "JIS\nKana",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x0089,
+        name: "KC_JYEN",
+        label: "JIS\n¥ |",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x008A,
+        name: "KC_HENK",
+        label: "JIS\nHenkan",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x008B,
+        name: "KC_MHEN",
+        label: "JIS\nMuhenk",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x008C,
+        name: "KC_INT6",
+        label: "JIS\nNum ,",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x0090,
+        name: "KC_LANG1",
+        label: "Hangul\nEng",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x0091,
+        name: "KC_LANG2",
+        label: "Hangul\nHanja",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x0092,
+        name: "KC_LANG3",
+        label: "JIS\nKatak",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x0093,
+        name: "KC_LANG4",
+        label: "JIS\nHirag",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x0094,
+        name: "KC_LANG5",
+        label: "JIS\nZenHan",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7C14,
+        name: "QK_MAKE",
+        label: "Make",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7C15,
+        name: "KC_ASTG",
+        label: "Auto\nShift",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7C52,
+        name: "CMB_TOG",
+        label: "Combo\nToggle",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7C73,
+        name: "QK_CAPS_WORD_TOGGLE",
+        label: "Caps\nWord",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7C79,
+        name: "QK_REPEAT_KEY",
+        label: "Repeat",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7C7A,
+        name: "QK_ALT_REPEAT_KEY",
+        label: "Alt\nRepeat",
+        category: KeycodeCategory::Special,
+    },
     // RGB Light
-    Keycode { value: 0x7820, name: "RGB_TOG",  label: "RGB\nTog",  category: KeycodeCategory::Special },
-    Keycode { value: 0x7821, name: "RGB_MOD",  label: "RGB\nMod",  category: KeycodeCategory::Special },
-    Keycode { value: 0x7822, name: "RGB_RMOD", label: "RGB\nRMod", category: KeycodeCategory::Special },
-    Keycode { value: 0x7825, name: "RGB_HUI",  label: "RGB\nH+",   category: KeycodeCategory::Special },
-    Keycode { value: 0x7826, name: "RGB_HUD",  label: "RGB\nH-",   category: KeycodeCategory::Special },
-    Keycode { value: 0x7827, name: "RGB_SAI",  label: "RGB\nS+",   category: KeycodeCategory::Special },
-    Keycode { value: 0x7828, name: "RGB_SAD",  label: "RGB\nS-",   category: KeycodeCategory::Special },
-    Keycode { value: 0x7829, name: "RGB_VAI",  label: "RGB\nV+",   category: KeycodeCategory::Special },
-    Keycode { value: 0x782A, name: "RGB_VAD",  label: "RGB\nV-",   category: KeycodeCategory::Special },
-    Keycode { value: 0x7823, name: "RGB_SPI",  label: "RGB\nSpd+", category: KeycodeCategory::Special },
-    Keycode { value: 0x7824, name: "RGB_SPD",  label: "RGB\nSpd-", category: KeycodeCategory::Special },
+    Keycode {
+        value: 0x7820,
+        name: "RGB_TOG",
+        label: "RGB\nTog",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7821,
+        name: "RGB_MOD",
+        label: "RGB\nMod",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7822,
+        name: "RGB_RMOD",
+        label: "RGB\nRMod",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7825,
+        name: "RGB_HUI",
+        label: "RGB\nH+",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7826,
+        name: "RGB_HUD",
+        label: "RGB\nH-",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7827,
+        name: "RGB_SAI",
+        label: "RGB\nS+",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7828,
+        name: "RGB_SAD",
+        label: "RGB\nS-",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7829,
+        name: "RGB_VAI",
+        label: "RGB\nV+",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x782A,
+        name: "RGB_VAD",
+        label: "RGB\nV-",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7823,
+        name: "RGB_SPI",
+        label: "RGB\nSpd+",
+        category: KeycodeCategory::Special,
+    },
+    Keycode {
+        value: 0x7824,
+        name: "RGB_SPD",
+        label: "RGB\nSpd-",
+        category: KeycodeCategory::Special,
+    },
 ];
 
 /// Normalizes symbol-looking physical keys to the printable shifted keycodes
@@ -611,8 +1993,12 @@ fn magic_keycode_tooltip(value: u16) -> Option<String> {
         0x701B => Some(format!("Swap Control and {} on both sides", gui)),
         0x701C => Some(format!("Unswap Control and {} on both sides", gui)),
         0x701D => Some(format!("Toggle Control and {} swap on both sides", gui)),
-        0x701E => Some("Set the master half of a split keyboard as the left hand (for EE_HANDS)".to_string()),
-        0x701F => Some("Set the master half of a split keyboard as the right hand (for EE_HANDS)".to_string()),
+        0x701E => Some(
+            "Set the master half of a split keyboard as the left hand (for EE_HANDS)".to_string(),
+        ),
+        0x701F => Some(
+            "Set the master half of a split keyboard as the right hand (for EE_HANDS)".to_string(),
+        ),
         0x7020 => Some("Swap Caps Lock and Escape".to_string()),
         0x7021 => Some("Unswap Caps Lock and Escape".to_string()),
         0x7022 => Some("Toggle Caps Lock and Escape swap".to_string()),
@@ -666,7 +2052,11 @@ fn compound_keycode_label(prefix: &str, kc: u16) -> String {
     format!("{}\n{}", prefix, kc_str)
 }
 
-pub fn keycode_label_with_names(value: u16, custom: &[CustomKeycode], layer_names: &[String]) -> String {
+pub fn keycode_label_with_names(
+    value: u16,
+    custom: &[CustomKeycode],
+    layer_names: &[String],
+) -> String {
     // Returns "OpName(n)\nLayerName" or "OpName(n)" if layer has no custom name
     let layer_label = |op: &str, n: u16| -> String {
         match layer_names.get(n as usize) {
@@ -732,13 +2122,13 @@ pub fn keycode_label_with_names(value: u16, custom: &[CustomKeycode], layer_name
     if (0x5200..0x5300).contains(&value) {
         let sub = value & 0xFF;
         return match (value >> 5) & 0x7 {
-            0 => layer_label("TO",  sub & 0x1F),
-            1 => layer_label("MO",  sub & 0x1F),
-            2 => layer_label("DF",  sub & 0x1F),
-            3 => layer_label("TG",  sub & 0x1F),
+            0 => layer_label("TO", sub & 0x1F),
+            1 => layer_label("MO", sub & 0x1F),
+            2 => layer_label("DF", sub & 0x1F),
+            3 => layer_label("TG", sub & 0x1F),
             4 => layer_label("OSL", sub & 0x1F),
             5 => format!("OSM\n{}", osm_mod_short_name(sub & 0x1F)),
-            6 => layer_label("TT",  sub & 0x1F),
+            6 => layer_label("TT", sub & 0x1F),
             7 => layer_label("PDF", sub & 0x1F),
             _ => format!("{:04X}", value),
         };
@@ -796,8 +2186,12 @@ pub fn keycode_label_with_names(value: u16, custom: &[CustomKeycode], layer_name
         return compound_keycode_label(&mod_str, kc);
     }
 
-    if value == 0x0001 { return "▽".to_string(); }
-    if value == 0x0000 { return "✕".to_string(); }
+    if value == 0x0001 {
+        return "▽".to_string();
+    }
+    if value == 0x0000 {
+        return "✕".to_string();
+    }
 
     // Macro keycodes: 0x7700..0x77FF
     if (0x7700..=0x77FF).contains(&value) {
@@ -835,7 +2229,11 @@ pub fn keycode_label(value: u16) -> String {
     keycode_label_with_custom(value, &[])
 }
 
-fn apply_key_legend_layout(value: u16, label: String, key_legend_layout: KeyLegendLayout) -> String {
+fn apply_key_legend_layout(
+    value: u16,
+    label: String,
+    key_legend_layout: KeyLegendLayout,
+) -> String {
     match key_legend_layout {
         KeyLegendLayout::English => label,
         KeyLegendLayout::Russian => russian_key_legend(value, false).unwrap_or(label),
@@ -881,9 +2279,8 @@ fn russian_key_legend(value: u16, russian_primary: bool) -> Option<String> {
     let symbol = |base: &str, english: &str, russian: &str| {
         symbol_legend(base, english, russian, russian_primary)
     };
-    let shifted_symbol = |english: &str, russian: &str| {
-        shifted_symbol_legend(english, russian, russian_primary)
-    };
+    let shifted_symbol =
+        |english: &str, russian: &str| shifted_symbol_legend(english, russian, russian_primary);
 
     match value {
         0x0004 => Some(pair("A", "Ф")),
@@ -1006,17 +2403,48 @@ pub fn keycode_tooltip(value: u16, custom: &[CustomKeycode], layer_names: &[Stri
     if (0x5200..0x5300).contains(&value) {
         let sub = value & 0xFF;
         return match (value >> 5) & 0x7 {
-            0 => format!("TO({}) — switch to {} and stay there", sub & 0x1F, layer_display(sub & 0x1F)),
-            1 => format!("MO({}) — activate {} while held, return when released", sub & 0x1F, layer_display(sub & 0x1F)),
-            2 => format!("DF({}) — set {} as the default base layer", sub & 0x1F, layer_display(sub & 0x1F)),
-            3 => format!("TG({}) — toggle {} on/off", sub & 0x1F, layer_display(sub & 0x1F)),
-            4 => format!("OSL({}) — activate {} for next keypress only", sub & 0x1F, layer_display(sub & 0x1F)),
+            0 => format!(
+                "TO({}) — switch to {} and stay there",
+                sub & 0x1F,
+                layer_display(sub & 0x1F)
+            ),
+            1 => format!(
+                "MO({}) — activate {} while held, return when released",
+                sub & 0x1F,
+                layer_display(sub & 0x1F)
+            ),
+            2 => format!(
+                "DF({}) — set {} as the default base layer",
+                sub & 0x1F,
+                layer_display(sub & 0x1F)
+            ),
+            3 => format!(
+                "TG({}) — toggle {} on/off",
+                sub & 0x1F,
+                layer_display(sub & 0x1F)
+            ),
+            4 => format!(
+                "OSL({}) — activate {} for next keypress only",
+                sub & 0x1F,
+                layer_display(sub & 0x1F)
+            ),
             5 => {
                 let m = mod_name(sub & 0x1F, sub >= 0x10);
-                format!("One-Shot {} — activates {} for the very next keypress only", m, m)
+                format!(
+                    "One-Shot {} — activates {} for the very next keypress only",
+                    m, m
+                )
             }
-            6 => format!("TT({}) — tap to toggle {}, hold to activate while held", sub & 0x1F, layer_display(sub & 0x1F)),
-            7 => format!("PDF({}) — permanently set {} as the default layer", sub & 0x1F, layer_display(sub & 0x1F)),
+            6 => format!(
+                "TT({}) — tap to toggle {}, hold to activate while held",
+                sub & 0x1F,
+                layer_display(sub & 0x1F)
+            ),
+            7 => format!(
+                "PDF({}) — permanently set {} as the default layer",
+                sub & 0x1F,
+                layer_display(sub & 0x1F)
+            ),
             _ => format!("Unknown layer op (0x{:04X})", value),
         };
     }
@@ -1026,7 +2454,13 @@ pub fn keycode_tooltip(value: u16, custom: &[CustomKeycode], layer_names: &[Stri
         let layer = (value >> 4) & 0xF;
         let mods = value & 0xF;
         let m = mod_name(mods, false);
-        return format!("LM({}, {}) — activate {} with {} held while key is pressed", layer, m, layer_display(layer), m);
+        return format!(
+            "LM({}, {}) — activate {} with {} held while key is pressed",
+            layer,
+            m,
+            layer_display(layer),
+            m
+        );
     }
 
     // ── QK_LAYER_TAP 0x4000..0x4FFF ─────────────────────────────────────────
@@ -1036,7 +2470,11 @@ pub fn keycode_tooltip(value: u16, custom: &[CustomKeycode], layer_names: &[Stri
         let kc_str = find_keycode(kc)
             .map(simple_key_name)
             .unwrap_or_else(|| format!("0x{:02X}", kc));
-        return format!("Layer Tap — tap for {}, hold to activate {}", kc_str, layer_display(layer));
+        return format!(
+            "Layer Tap — tap for {}, hold to activate {}",
+            kc_str,
+            layer_display(layer)
+        );
     }
 
     // ── QK_MOD_TAP 0x2000..0x3FFF ───────────────────────────────────────────
@@ -1070,7 +2508,13 @@ pub fn keycode_tooltip(value: u16, custom: &[CustomKeycode], layer_names: &[Stri
             0x07 => "Meh (Ctrl+Shift+Alt)+",
             0x09 => return format!("Shortcut: Ctrl+{}+{}", gui_mod_name(), kc_str),
             0x0C => return format!("Shortcut: Alt+{}+{}", gui_mod_name(), kc_str),
-            0x0F => return format!("Shortcut: Hyper (Ctrl+Shift+Alt+{})+{}", gui_mod_name(), kc_str),
+            0x0F => {
+                return format!(
+                    "Shortcut: Hyper (Ctrl+Shift+Alt+{})+{}",
+                    gui_mod_name(),
+                    kc_str
+                )
+            }
             0x0A => return format!("Shortcut: Shift+{}+{}", gui_mod_name(), kc_str),
             0x11 => "Right Ctrl+",
             0x12 => "Right Shift+",
@@ -1104,7 +2548,10 @@ pub fn keycode_tooltip(value: u16, custom: &[CustomKeycode], layer_names: &[Stri
     }
     // Tap Dance keycodes
     if (0x5700..=0x57FF).contains(&value) {
-        return format!("Tap Dance {} — different actions on tap, hold, double tap", value - 0x5700);
+        return format!(
+            "Tap Dance {} — different actions on tap, hold, double tap",
+            value - 0x5700
+        );
     }
 
     format!("Unknown keycode (0x{:04X})", value)
@@ -1117,14 +2564,14 @@ fn simple_key_name(kc: &Keycode) -> String {
     }
 
     match kc.name {
-        "KC_SPACE"  => "Space".to_string(),
-        "KC_ENTER"  => "Enter".to_string(),
+        "KC_SPACE" => "Space".to_string(),
+        "KC_ENTER" => "Enter".to_string(),
         "KC_ESCAPE" => "Escape".to_string(),
         "KC_BSPACE" => "Backspace".to_string(),
-        "KC_TAB"    => "Tab".to_string(),
+        "KC_TAB" => "Tab".to_string(),
         "KC_DELETE" => "Delete".to_string(),
-        "KC_LGUI"   => gui_label(false).to_string(),
-        "KC_RGUI"   => gui_label(true).to_string(),
+        "KC_LGUI" => gui_label(false).to_string(),
+        "KC_RGUI" => gui_label(true).to_string(),
         _ => kc.label.replace('\n', "/"),
     }
 }
@@ -1133,53 +2580,53 @@ fn simple_key_name(kc: &Keycode) -> String {
 fn simple_key_tooltip(kc: &Keycode) -> String {
     let desc: &str = match kc.name {
         // Special
-        "KC_NO"          => "No key — this key does nothing",
-        "KC_TRNS"        => "Transparent — uses the key assigned on the layer below",
+        "KC_NO" => "No key — this key does nothing",
+        "KC_TRNS" => "Transparent — uses the key assigned on the layer below",
         // Control
-        "KC_ENTER"       => "Enter — confirm / new line",
-        "KC_ESCAPE"      => "Escape — cancel / close",
-        "KC_BSPACE"      => "Backspace — delete character before cursor",
-        "KC_TAB"         => "Tab — indent / move focus forward",
-        "KC_SPACE"       => "Space",
-        "KC_CAPSLOCK"    => "Caps Lock — toggle uppercase input",
+        "KC_ENTER" => "Enter — confirm / new line",
+        "KC_ESCAPE" => "Escape — cancel / close",
+        "KC_BSPACE" => "Backspace — delete character before cursor",
+        "KC_TAB" => "Tab — indent / move focus forward",
+        "KC_SPACE" => "Space",
+        "KC_CAPSLOCK" => "Caps Lock — toggle uppercase input",
         "KC_APPLICATION" => "Menu key — open right-click context menu",
         // Punctuation
-        "KC_MINUS"      => "Minus — type -, Shift gives underscore (_)",
-        "KC_EQUAL"      => "Equals — type =, Shift gives plus (+)",
-        "KC_LBRACKET"   => "Left bracket — type [, Shift gives left brace ({)",
-        "KC_RBRACKET"   => "Right bracket — type ], Shift gives right brace (})",
-        "KC_BSLASH"     => "Backslash — type \\, Shift gives pipe (|)",
+        "KC_MINUS" => "Minus — type -, Shift gives underscore (_)",
+        "KC_EQUAL" => "Equals — type =, Shift gives plus (+)",
+        "KC_LBRACKET" => "Left bracket — type [, Shift gives left brace ({)",
+        "KC_RBRACKET" => "Right bracket — type ], Shift gives right brace (})",
+        "KC_BSLASH" => "Backslash — type \\, Shift gives pipe (|)",
         "KC_NONUS_HASH" => "Non-US hash key — type #, Shift gives tilde (~)",
-        "KC_SCOLON"     => "Semicolon key — tap for semicolon (;), Shift gives colon (:)",
-        "KC_QUOTE"      => "Quote — type apostrophe ('), Shift gives double quote (\")",
-        "KC_GRAVE"      => "Grave accent — type `, Shift gives tilde (~)",
-        "KC_COMMA"      => "Comma — type comma (,), Shift gives less-than (<)",
-        "KC_DOT"        => "Period — type dot (.), Shift gives greater-than (>)",
-        "KC_SLASH"      => "Slash — type /, Shift gives question mark (?)",
+        "KC_SCOLON" => "Semicolon key — tap for semicolon (;), Shift gives colon (:)",
+        "KC_QUOTE" => "Quote — type apostrophe ('), Shift gives double quote (\")",
+        "KC_GRAVE" => "Grave accent — type `, Shift gives tilde (~)",
+        "KC_COMMA" => "Comma — type comma (,), Shift gives less-than (<)",
+        "KC_DOT" => "Period — type dot (.), Shift gives greater-than (>)",
+        "KC_SLASH" => "Slash — type /, Shift gives question mark (?)",
         "KC_NONUS_BSLASH" => "Non-US backslash key — type \\, Shift gives pipe (|)",
         // Modifiers
-        "KC_LCTRL"  => "Left Ctrl — modifier key (hold to activate shortcuts)",
-        "KC_RCTRL"  => "Right Ctrl — modifier key (hold to activate shortcuts)",
+        "KC_LCTRL" => "Left Ctrl — modifier key (hold to activate shortcuts)",
+        "KC_RCTRL" => "Right Ctrl — modifier key (hold to activate shortcuts)",
         "KC_LSHIFT" => "Left Shift — hold to type uppercase / shifted symbols",
         "KC_RSHIFT" => "Right Shift — hold to type uppercase / shifted symbols",
-        "KC_LALT"   => "Left Alt — modifier key (hold to activate shortcuts)",
-        "KC_RALT"   => "Right Alt / AltGr — access special characters",
-        "KC_LGUI"   => return gui_key_tooltip(false),
-        "KC_RGUI"   => return gui_key_tooltip(true),
+        "KC_LALT" => "Left Alt — modifier key (hold to activate shortcuts)",
+        "KC_RALT" => "Right Alt / AltGr — access special characters",
+        "KC_LGUI" => return gui_key_tooltip(false),
+        "KC_RGUI" => return gui_key_tooltip(true),
         // Navigation
-        "KC_UP"       => "Arrow Up",
-        "KC_DOWN"     => "Arrow Down",
-        "KC_LEFT"     => "Arrow Left",
-        "KC_RIGHT"    => "Arrow Right",
-        "KC_HOME"     => "Home — jump to beginning of line",
-        "KC_END"      => "End — jump to end of line",
-        "KC_PGUP"     => "Page Up — scroll up one page",
-        "KC_PGDOWN"   => "Page Down — scroll down one page",
-        "KC_INSERT"   => "Insert — toggle insert/overwrite mode",
-        "KC_DELETE"   => "Delete — delete character after cursor",
-        "KC_PSCREEN"  => "Print Screen — take a screenshot",
+        "KC_UP" => "Arrow Up",
+        "KC_DOWN" => "Arrow Down",
+        "KC_LEFT" => "Arrow Left",
+        "KC_RIGHT" => "Arrow Right",
+        "KC_HOME" => "Home — jump to beginning of line",
+        "KC_END" => "End — jump to end of line",
+        "KC_PGUP" => "Page Up — scroll up one page",
+        "KC_PGDOWN" => "Page Down — scroll down one page",
+        "KC_INSERT" => "Insert — toggle insert/overwrite mode",
+        "KC_DELETE" => "Delete — delete character after cursor",
+        "KC_PSCREEN" => "Print Screen — take a screenshot",
         "KC_SCROLLLOCK" => "Scroll Lock",
-        "KC_PAUSE"    => "Pause / Break",
+        "KC_PAUSE" => "Pause / Break",
         // Media
         "KC_MUTE" => "Mute / Unmute audio",
         "KC_VOLU" => "Volume Up",
@@ -1203,7 +2650,7 @@ fn simple_key_tooltip(kc: &Keycode) -> String {
         "KC_WAKE" => "Wake — wake computer from sleep",
         "KC_BRIU" => "Brightness Up",
         "KC_BRID" => "Brightness Down",
-        "KC_PWR"  => "Power — system power button",
+        "KC_PWR" => "Power — system power button",
         "KC_EXEC" => "Execute — run the currently selected action or file",
         "KC_HELP" => "Help — open help for the current app or context",
         "KC_SELECT" => "Select — select the current item",
@@ -1240,56 +2687,61 @@ fn simple_key_tooltip(kc: &Keycode) -> String {
         "KC_MS_ACCEL1" => "Mouse acceleration 1 — medium cursor speed profile",
         "KC_MS_ACCEL2" => "Mouse acceleration 2 — fastest cursor speed profile",
         // Numpad
-        "KC_NUMLOCK"     => "Num Lock — toggle numpad number input",
-        "KC_KP_SLASH"    => "Numpad ÷ (divide)",
+        "KC_NUMLOCK" => "Num Lock — toggle numpad number input",
+        "KC_KP_SLASH" => "Numpad ÷ (divide)",
         "KC_KP_ASTERISK" => "Numpad × (multiply)",
-        "KC_KP_MINUS"    => "Numpad − (minus)",
-        "KC_KP_PLUS"     => "Numpad + (plus)",
-        "KC_KP_ENTER"    => "Numpad Enter",
-        "KC_KP_DOT"      => "Numpad . (decimal point)",
-        "KC_KP_EQUAL"    => "Numpad = (equals)",
-        "KC_KP_COMMA"    => "Numpad , (comma)",
+        "KC_KP_MINUS" => "Numpad − (minus)",
+        "KC_KP_PLUS" => "Numpad + (plus)",
+        "KC_KP_ENTER" => "Numpad Enter",
+        "KC_KP_DOT" => "Numpad . (decimal point)",
+        "KC_KP_EQUAL" => "Numpad = (equals)",
+        "KC_KP_COMMA" => "Numpad , (comma)",
         // QMK special
-        "KC_GESC"   => return format!("Grave/Escape — sends Esc normally, ` when Shift or {} is held", gui_mod_name()),
-        "QK_BOOT"   => "Bootloader — put device into flash mode",
-        "DB_TOGG"   => "Debug toggle — enable/disable debug output",
-        "QK_LOCK"   => "Lock — lock a key in pressed state until pressed again",
-        "KC_LSPO"   => "Left Shift when held, ( when tapped",
-        "KC_RSPC"   => "Right Shift when held, ) when tapped",
-        "KC_LCPO"   => "Left Control when held, ( when tapped",
-        "KC_RCPC"   => "Right Control when held, ) when tapped",
-        "KC_LAPO"   => "Left Alt when held, ( when tapped",
-        "KC_RAPC"   => "Right Alt when held, ) when tapped",
+        "KC_GESC" => {
+            return format!(
+                "Grave/Escape — sends Esc normally, ` when Shift or {} is held",
+                gui_mod_name()
+            )
+        }
+        "QK_BOOT" => "Bootloader — put device into flash mode",
+        "DB_TOGG" => "Debug toggle — enable/disable debug output",
+        "QK_LOCK" => "Lock — lock a key in pressed state until pressed again",
+        "KC_LSPO" => "Left Shift when held, ( when tapped",
+        "KC_RSPC" => "Right Shift when held, ) when tapped",
+        "KC_LCPO" => "Left Control when held, ( when tapped",
+        "KC_RCPC" => "Right Control when held, ) when tapped",
+        "KC_LAPO" => "Left Alt when held, ( when tapped",
+        "KC_RAPC" => "Right Alt when held, ) when tapped",
         "KC_SFTENT" => "Right Shift when held, Enter when tapped",
-        "KC_RO"     => "JIS \\ and _",
-        "KC_KANA"   => "JIS Katakana/Hiragana",
-        "KC_JYEN"   => "JIS ¥ and |",
-        "KC_HENK"   => "JIS Henkan",
-        "KC_MHEN"   => "JIS Muhenkan",
-        "KC_INT6"   => "JIS Numpad ,",
-        "KC_LANG1"  => "Hangul/English",
-        "KC_LANG2"  => "Hanja",
-        "KC_LANG3"  => "JIS Katakana",
-        "KC_LANG4"  => "JIS Hiragana",
-        "KC_LANG5"  => "JIS Zenkaku/Hankaku",
-        "QK_MAKE"             => "Compile firmware",
-        "KC_ASTG"             => "Toggles the state of the Auto Shift feature",
-        "CMB_TOG"             => "Toggles Combo feature on and off",
+        "KC_RO" => "JIS \\ and _",
+        "KC_KANA" => "JIS Katakana/Hiragana",
+        "KC_JYEN" => "JIS ¥ and |",
+        "KC_HENK" => "JIS Henkan",
+        "KC_MHEN" => "JIS Muhenkan",
+        "KC_INT6" => "JIS Numpad ,",
+        "KC_LANG1" => "Hangul/English",
+        "KC_LANG2" => "Hanja",
+        "KC_LANG3" => "JIS Katakana",
+        "KC_LANG4" => "JIS Hiragana",
+        "KC_LANG5" => "JIS Zenkaku/Hankaku",
+        "QK_MAKE" => "Compile firmware",
+        "KC_ASTG" => "Toggles the state of the Auto Shift feature",
+        "CMB_TOG" => "Toggles Combo feature on and off",
         "QK_CAPS_WORD_TOGGLE" => "Capitalizes until end of current word",
-        "QK_REPEAT_KEY"       => "Repeats the last pressed key",
-        "QK_ALT_REPEAT_KEY"   => "Alt repeats the last pressed key",
+        "QK_REPEAT_KEY" => "Repeats the last pressed key",
+        "QK_ALT_REPEAT_KEY" => "Alt repeats the last pressed key",
         // RGB
-        "RGB_TOG"  => "RGB lighting — toggle on/off",
-        "RGB_MOD"  => "RGB lighting — next animation mode",
+        "RGB_TOG" => "RGB lighting — toggle on/off",
+        "RGB_MOD" => "RGB lighting — next animation mode",
         "RGB_RMOD" => "RGB lighting — previous animation mode",
-        "RGB_HUI"  => "RGB lighting — hue +",
-        "RGB_HUD"  => "RGB lighting — hue −",
-        "RGB_SAI"  => "RGB lighting — saturation +",
-        "RGB_SAD"  => "RGB lighting — saturation −",
-        "RGB_VAI"  => "RGB lighting — brightness +",
-        "RGB_VAD"  => "RGB lighting — brightness −",
-        "RGB_SPI"  => "RGB lighting — animation speed +",
-        "RGB_SPD"  => "RGB lighting — animation speed −",
+        "RGB_HUI" => "RGB lighting — hue +",
+        "RGB_HUD" => "RGB lighting — hue −",
+        "RGB_SAI" => "RGB lighting — saturation +",
+        "RGB_SAD" => "RGB lighting — saturation −",
+        "RGB_VAI" => "RGB lighting — brightness +",
+        "RGB_VAD" => "RGB lighting — brightness −",
+        "RGB_SPI" => "RGB lighting — animation speed +",
+        "RGB_SPD" => "RGB lighting — animation speed −",
         _ => "",
     };
 
@@ -1304,7 +2756,7 @@ fn simple_key_tooltip(kc: &Keycode) -> String {
             format!("Key: {}", label)
         }
         KeycodeCategory::Function => format!("{} function key", kc.label),
-        KeycodeCategory::Numpad   => format!("Numpad {}", kc.label.trim_start_matches("Num")),
+        KeycodeCategory::Numpad => format!("Numpad {}", kc.label.trim_start_matches("Num")),
         _ => kc.label.replace('\n', " / "),
     }
 }

--- a/src/keycode_picker.rs
+++ b/src/keycode_picker.rs
@@ -865,9 +865,10 @@ impl KeycodePicker {
                             }
                         } else if qmk > 0 && qmk < 0x0100 {
                             if (self.regular_key_pick_allow_mod_key || !modifiers.any())
-                                && self.is_regular_key_pick_value(qmk) {
-                                    self.finish_regular_key_pick(qmk);
-                                }
+                                && self.is_regular_key_pick_value(qmk)
+                            {
+                                self.finish_regular_key_pick(qmk);
+                            }
                         } else if self.regular_key_pick_allow_mod_key
                             && (0x0100..0x2000).contains(&qmk)
                             && self.is_regular_key_pick_value(qmk & 0x00FF)

--- a/src/keycode_picker_special.rs
+++ b/src/keycode_picker_special.rs
@@ -41,7 +41,9 @@ impl KeycodePicker {
             let t = parts.next().unwrap_or("");
             let b = parts.next().unwrap_or(label);
             (Some(t), b)
-        } else if let Some(pos) = label.find('/').filter(|pos| *pos > 0 && *pos + 1 < label.len())
+        } else if let Some(pos) = label
+            .find('/')
+            .filter(|pos| *pos > 0 && *pos + 1 < label.len())
         {
             (Some(&label[..pos]), &label[pos + 1..])
         } else {

--- a/src/keycode_picker_tap_dance_picker.rs
+++ b/src/keycode_picker_tap_dance_picker.rs
@@ -164,9 +164,7 @@ impl KeycodePicker {
                     } else {
                         let key_choices: Vec<&'static crate::keycode::Keycode> = KEYCODES
                             .iter()
-                            .filter(|kc| {
-                                is_8bit_tap_key_choice(kc) && !kc.name.starts_with("RGB_")
-                            })
+                            .filter(|kc| is_8bit_tap_key_choice(kc) && !kc.name.starts_with("RGB_"))
                             .collect();
                         if let Some(value) = show_grouped_popup_key_buttons(
                             ui,
@@ -193,12 +191,7 @@ impl KeycodePicker {
         }
     }
 
-    fn show_tap_dance_hold_picker_content(
-        &mut self,
-        ui: &mut egui::Ui,
-        td_idx: usize,
-        field: u8,
-    ) {
+    fn show_tap_dance_hold_picker_content(&mut self, ui: &mut egui::Ui, td_idx: usize, field: u8) {
         ui.label(
             RichText::new(tr_picker(
                 self.language,
@@ -212,12 +205,7 @@ impl KeycodePicker {
         ui.horizontal_wrapped(|ui| {
             let plain_modifiers = [
                 ("Ctrl".to_owned(), 0x00E0u16, 0x00E4u16, "Ctrl".to_owned()),
-                (
-                    "Shift".to_owned(),
-                    0x00E1u16,
-                    0x00E5u16,
-                    "Shift".to_owned(),
-                ),
+                ("Shift".to_owned(), 0x00E1u16, 0x00E5u16, "Shift".to_owned()),
                 ("Alt".to_owned(), 0x00E2u16, 0x00E6u16, "Alt".to_owned()),
                 (
                     gui_label(false).to_string(),
@@ -227,17 +215,12 @@ impl KeycodePicker {
                 ),
             ];
             for (label, left_value, right_value, mod_name) in plain_modifiers {
-                let resp = picker_keycap_button(
-                    ui,
-                    &label,
-                    Self::picker_key_size(ui.ctx()),
-                    true,
-                    false,
-                )
-                .on_hover_text(crate::i18n::tr_text(
-                    self.language,
-                    &plain_modifier_tooltip(&mod_name),
-                ));
+                let resp =
+                    picker_keycap_button(ui, &label, Self::picker_key_size(ui.ctx()), true, false)
+                        .on_hover_text(crate::i18n::tr_text(
+                            self.language,
+                            &plain_modifier_tooltip(&mod_name),
+                        ));
                 if resp.clicked_by(egui::PointerButton::Primary) {
                     self.set_tap_dance_field(td_idx, field, left_value);
                     self.td_key_pick = None;
@@ -363,12 +346,7 @@ impl KeycodePicker {
         ui.add_space(4.0);
         let shortcuts: Vec<(String, u16, u16, String)> = vec![
             (picker_mod_key_label(0x0100), 0x0100, 0x1100, "Ctrl".into()),
-            (
-                picker_mod_key_label(0x0200),
-                0x0200,
-                0x1200,
-                "Shift".into(),
-            ),
+            (picker_mod_key_label(0x0200), 0x0200, 0x1200, "Shift".into()),
             (picker_mod_key_label(0x0400), 0x0400, 0x1400, "Alt".into()),
             (
                 picker_mod_key_label(0x0800),

--- a/src/ui/alt_repeat_settings.rs
+++ b/src/ui/alt_repeat_settings.rs
@@ -90,7 +90,8 @@ impl EntropyApp {
 
     fn open_alt_repeat_picker(&mut self, target: AltRepeatPickField) {
         self.alt_repeat_pick_target = Some(target);
-        self.keycode_picker.open_regular_key_picker_with_mod_key(true);
+        self.keycode_picker
+            .open_regular_key_picker_with_mod_key(true);
     }
 
     pub(super) fn open_alt_repeat_window_compact(&mut self) {
@@ -381,12 +382,18 @@ impl EntropyApp {
                                                 name,
                                                 control_width,
                                                 metrics.settings_control_height(),
-                                                crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.name"),
+                                                crate::i18n::tr_catalog(
+                                                    self.app_settings.language,
+                                                    "alt_repeat_editor.name",
+                                                ),
                                                 12,
                                                 egui::Align::Center,
                                             );
                                             name_changed = resp.changed();
-                                            resp.clone().on_hover_text(crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.stored_locally_in_entropy"));
+                                            resp.clone().on_hover_text(crate::i18n::tr_catalog(
+                                                self.app_settings.language,
+                                                "alt_repeat_editor.stored_locally_in_entropy",
+                                            ));
                                         }
                                     },
                                 );
@@ -463,19 +470,28 @@ impl EntropyApp {
                             4..=7 => {
                                 let (row_label, left_bit, right_bit) = match row_idx {
                                     4 => (
-                                        crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.ctrl_mods")
+                                        crate::i18n::tr_catalog(
+                                            self.app_settings.language,
+                                            "alt_repeat_editor.ctrl_mods",
+                                        )
                                         .to_string(),
                                         0,
                                         4,
                                     ),
                                     5 => (
-                                        crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.shift_mods")
+                                        crate::i18n::tr_catalog(
+                                            self.app_settings.language,
+                                            "alt_repeat_editor.shift_mods",
+                                        )
                                         .to_string(),
                                         1,
                                         5,
                                     ),
                                     6 => (
-                                        crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.alt_mods")
+                                        crate::i18n::tr_catalog(
+                                            self.app_settings.language,
+                                            "alt_repeat_editor.alt_mods",
+                                        )
                                         .to_string(),
                                         2,
                                         6,
@@ -500,10 +516,22 @@ impl EntropyApp {
                                     row_label.as_str(),
                                     true,
                                     Some(match row_idx {
-                                        4 => crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.allowed_ctrl_modifiers"),
-                                        5 => crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.allowed_shift_modifiers"),
-                                        6 => crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.allowed_alt_modifiers"),
-                                        _ => crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.allowed_os_modifiers"),
+                                        4 => crate::i18n::tr_catalog(
+                                            self.app_settings.language,
+                                            "alt_repeat_editor.allowed_ctrl_modifiers",
+                                        ),
+                                        5 => crate::i18n::tr_catalog(
+                                            self.app_settings.language,
+                                            "alt_repeat_editor.allowed_shift_modifiers",
+                                        ),
+                                        6 => crate::i18n::tr_catalog(
+                                            self.app_settings.language,
+                                            "alt_repeat_editor.allowed_alt_modifiers",
+                                        ),
+                                        _ => crate::i18n::tr_catalog(
+                                            self.app_settings.language,
+                                            "alt_repeat_editor.allowed_os_modifiers",
+                                        ),
                                     }),
                                     mod_control_width,
                                     |ui| {
@@ -537,7 +565,10 @@ impl EntropyApp {
                                                         .set_cursor_icon(egui::CursorIcon::Help);
                                                 }
                                                 right_label_resp.on_hover_text(
-                                                    crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.right_side_modifier"),
+                                                    crate::i18n::tr_catalog(
+                                                        self.app_settings.language,
+                                                        "alt_repeat_editor.right_side_modifier",
+                                                    ),
                                                 );
                                                 ui.add_space(metrics.value(10.0));
                                                 let mut left_checked =
@@ -567,7 +598,10 @@ impl EntropyApp {
                                                         .set_cursor_icon(egui::CursorIcon::Help);
                                                 }
                                                 left_label_resp.on_hover_text(
-                                                    crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.left_side_modifier"),
+                                                    crate::i18n::tr_catalog(
+                                                        self.app_settings.language,
+                                                        "alt_repeat_editor.left_side_modifier",
+                                                    ),
                                                 );
                                             },
                                         );
@@ -579,9 +613,15 @@ impl EntropyApp {
                                     ui,
                                     row_content_width,
                                     row_height,
-                                    crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.default_alt_key"),
+                                    crate::i18n::tr_catalog(
+                                        self.app_settings.language,
+                                        "alt_repeat_editor.default_alt_key",
+                                    ),
                                     true,
-                                    Some(crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.use_this_alt_key_by_default")),
+                                    Some(crate::i18n::tr_catalog(
+                                        self.app_settings.language,
+                                        "alt_repeat_editor.use_this_alt_key_by_default",
+                                    )),
                                     metrics.value(46.0),
                                     |ui| {
                                         crate::ui_style::settings_switch_sized(
@@ -597,9 +637,15 @@ impl EntropyApp {
                                     ui,
                                     row_content_width,
                                     row_height,
-                                    crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.bidirectional"),
+                                    crate::i18n::tr_catalog(
+                                        self.app_settings.language,
+                                        "alt_repeat_editor.bidirectional",
+                                    ),
                                     true,
-                                    Some(crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.allow_both_keys_to_alternate_each_other")),
+                                    Some(crate::i18n::tr_catalog(
+                                        self.app_settings.language,
+                                        "alt_repeat_editor.allow_both_keys_to_alternate_each_other",
+                                    )),
                                     metrics.value(46.0),
                                     |ui| {
                                         crate::ui_style::settings_switch_sized(

--- a/src/ui/combo_settings.rs
+++ b/src/ui/combo_settings.rs
@@ -56,10 +56,12 @@ impl EntropyApp {
     }
 
     fn handle_combo_editor_input(&mut self, ctx: &egui::Context, allow_close: bool) -> bool {
-        if !self.keycode_picker.open && ctx.input(|i| i.key_pressed(egui::Key::Escape))
-            && allow_close {
-                return true;
-            }
+        if !self.keycode_picker.open
+            && ctx.input(|i| i.key_pressed(egui::Key::Escape))
+            && allow_close
+        {
+            return true;
+        }
         false
     }
 

--- a/src/ui/key_override_settings.rs
+++ b/src/ui/key_override_settings.rs
@@ -469,7 +469,7 @@ impl EntropyApp {
                     ui.set_min_size(list.content_rect.size());
                     ui.spacing_mut().item_spacing.y = 0.0;
                     for row_idx in list.first_visible_row..list.last_visible_row {
-                                    match row_idx {
+                        match row_idx {
                                         0 => {
                                             crate::ui_style::settings_list_row_with_tooltip(
                                                 ui,
@@ -720,7 +720,7 @@ impl EntropyApp {
                                         13 => crate::ui_style::settings_list_row_with_tooltip(ui, row_content_width, row_height, crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.stay_active"), true, Some(crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.stay_active_when_another_key_is_pressed")), switch_width, |ui| { crate::ui_style::settings_switch_sized_stable(ui, ("key_override_settings", "stay_active"), &mut edited.options.no_unregister_on_other_key_down, switch_size); }),
                                         _ => {}
                                     }
-                                }
+                    }
                 });
 
                 if list.has_scrollbar {

--- a/src/ui/layout_indicator_window.rs
+++ b/src/ui/layout_indicator_window.rs
@@ -491,47 +491,56 @@ impl EntropyApp {
                         );
                     }
 
-                    crate::ui_style::allocate_ui_at_rect(ui, title_rect.shrink2(Vec2::new(6.0, 4.0)), |ui| {
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            if sticky_layout_window_icon_button(
-                                ui,
-                                dark,
-                                StickyLayoutWindowButton::Close,
-                                false,
-                                crate::i18n::tr_catalog(
-                                    lang,
-                                    "ui.sticky_layout_window_close_tooltip",
-                                ),
-                            )
-                            .clicked()
-                            {
-                                *should_close = true;
-                            }
-                            ui.add_space(4.0);
-                            if sticky_layout_window_icon_button(
-                                ui,
-                                dark,
-                                StickyLayoutWindowButton::Pin,
-                                sticky_always_on_top,
-                                crate::i18n::tr_catalog(
-                                    lang,
-                                    "ui.sticky_layout_window_pin_tooltip",
-                                ),
-                            )
-                            .clicked()
-                            {
-                                sticky_always_on_top = !sticky_always_on_top;
-                                should_save_settings = true;
-                                viewport_ctx.send_viewport_cmd(egui::ViewportCommand::WindowLevel(
-                                    if sticky_always_on_top {
-                                        egui::WindowLevel::AlwaysOnTop
-                                    } else {
-                                        egui::WindowLevel::Normal
-                                    },
-                                ));
-                            }
-                        });
-                    });
+                    crate::ui_style::allocate_ui_at_rect(
+                        ui,
+                        title_rect.shrink2(Vec2::new(6.0, 4.0)),
+                        |ui| {
+                            ui.with_layout(
+                                egui::Layout::right_to_left(egui::Align::Center),
+                                |ui| {
+                                    if sticky_layout_window_icon_button(
+                                        ui,
+                                        dark,
+                                        StickyLayoutWindowButton::Close,
+                                        false,
+                                        crate::i18n::tr_catalog(
+                                            lang,
+                                            "ui.sticky_layout_window_close_tooltip",
+                                        ),
+                                    )
+                                    .clicked()
+                                    {
+                                        *should_close = true;
+                                    }
+                                    ui.add_space(4.0);
+                                    if sticky_layout_window_icon_button(
+                                        ui,
+                                        dark,
+                                        StickyLayoutWindowButton::Pin,
+                                        sticky_always_on_top,
+                                        crate::i18n::tr_catalog(
+                                            lang,
+                                            "ui.sticky_layout_window_pin_tooltip",
+                                        ),
+                                    )
+                                    .clicked()
+                                    {
+                                        sticky_always_on_top = !sticky_always_on_top;
+                                        should_save_settings = true;
+                                        viewport_ctx.send_viewport_cmd(
+                                            egui::ViewportCommand::WindowLevel(
+                                                if sticky_always_on_top {
+                                                    egui::WindowLevel::AlwaysOnTop
+                                                } else {
+                                                    egui::WindowLevel::Normal
+                                                },
+                                            ),
+                                        );
+                                    }
+                                },
+                            );
+                        },
+                    );
 
                     let footer_rect = egui::Rect::from_min_max(
                         egui::pos2(

--- a/src/ui/matrix_tester.rs
+++ b/src/ui/matrix_tester.rs
@@ -179,7 +179,8 @@ impl EntropyApp {
             })
             .count();
 
-        crate::ui_style::allocate_ui_at_rect(ui, 
+        crate::ui_style::allocate_ui_at_rect(
+            ui,
             egui::Rect::from_min_max(
                 egui::pos2(content_rect.left(), content_rect.top()),
                 egui::pos2(content_rect.right(), desc_y + 10.0),

--- a/src/ui/onboarding_tour.rs
+++ b/src/ui/onboarding_tour.rs
@@ -174,98 +174,104 @@ impl EntropyApp {
                     Stroke::new(1.0, app_border_color(dark)),
                     egui::StrokeKind::Inside,
                 );
-                crate::ui_style::allocate_ui_at_rect(ui, card_rect.shrink2(Vec2::new(18.0, 16.0)), |ui| {
-                    ui.vertical(|ui| {
-                        ui.horizontal(|ui| {
-                            ui.label(
-                                RichText::new(progress.as_str())
-                                    .size(11.5)
-                                    .color(app_muted_text(dark)),
+                crate::ui_style::allocate_ui_at_rect(
+                    ui,
+                    card_rect.shrink2(Vec2::new(18.0, 16.0)),
+                    |ui| {
+                        ui.vertical(|ui| {
+                            ui.horizontal(|ui| {
+                                ui.label(
+                                    RichText::new(progress.as_str())
+                                        .size(11.5)
+                                        .color(app_muted_text(dark)),
+                                );
+                                ui.with_layout(
+                                    egui::Layout::right_to_left(egui::Align::Center),
+                                    |ui| {
+                                        let close = ui.add(
+                                            egui::Label::new(
+                                                RichText::new("×")
+                                                    .size(18.0)
+                                                    .color(app_muted_text(dark)),
+                                            )
+                                            .selectable(false)
+                                            .sense(Sense::click()),
+                                        );
+                                        if close.hovered() {
+                                            ui.ctx()
+                                                .set_cursor_icon(egui::CursorIcon::PointingHand);
+                                        }
+                                        if close.clicked() {
+                                            self.complete_onboarding_tour();
+                                        }
+                                    },
+                                );
+                            });
+                            ui.add_space(10.0);
+                            ui.label(RichText::new(title.as_str()).size(20.0).strong());
+                            ui.add_space(8.0);
+                            ui.add(
+                                egui::Label::new(RichText::new(body.as_str()).size(13.5).color(
+                                    if dark {
+                                        Color32::from_gray(205)
+                                    } else {
+                                        Color32::from_gray(66)
+                                    },
+                                ))
+                                .wrap(),
                             );
-                            ui.with_layout(
-                                egui::Layout::right_to_left(egui::Align::Center),
-                                |ui| {
-                                    let close = ui.add(
-                                        egui::Label::new(
-                                            RichText::new("×")
-                                                .size(18.0)
-                                                .color(app_muted_text(dark)),
-                                        )
-                                        .selectable(false)
-                                        .sense(Sense::click()),
-                                    );
-                                    if close.hovered() {
-                                        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
-                                    }
-                                    if close.clicked() {
-                                        self.complete_onboarding_tour();
-                                    }
-                                },
-                            );
-                        });
-                        ui.add_space(10.0);
-                        ui.label(RichText::new(title.as_str()).size(20.0).strong());
-                        ui.add_space(8.0);
-                        ui.add(
-                            egui::Label::new(RichText::new(body.as_str()).size(13.5).color(
-                                if dark {
-                                    Color32::from_gray(205)
-                                } else {
-                                    Color32::from_gray(66)
-                                },
-                            ))
-                            .wrap(),
-                        );
-                        ui.add_space(10.0);
-                        let button_row_height = 32.0;
-                        let spacer_height = (ui.available_height() - button_row_height).max(0.0);
-                        ui.add_space(spacer_height);
-                        ui.horizontal(|ui| {
-                            if crate::ui_style::modern_button(
-                                ui,
-                                skip_label.as_str(),
-                                Vec2::new(96.0, button_row_height),
-                                true,
-                            )
-                            .clicked()
-                            {
-                                self.complete_onboarding_tour();
-                            }
-
-                            let trailing_width = 88.0 + 94.0 + ui.spacing().item_spacing.x;
-                            ui.add_space((ui.available_width() - trailing_width).max(0.0));
-
-                            let prev_enabled = self.tour_state.step > 0;
-                            if crate::ui_style::modern_button(
-                                ui,
-                                prev_label.as_str(),
-                                Vec2::new(88.0, button_row_height),
-                                prev_enabled,
-                            )
-                            .clicked()
-                                && prev_enabled
-                            {
-                                self.tour_state.step -= 1;
-                                ctx.request_repaint();
-                            }
-                            if crate::ui_style::modern_button(
-                                ui,
-                                next_label.as_str(),
-                                Vec2::new(94.0, button_row_height),
-                                true,
-                            )
-                            .clicked()
-                            {
-                                if self.tour_state.step + 1 >= step_count {
+                            ui.add_space(10.0);
+                            let button_row_height = 32.0;
+                            let spacer_height =
+                                (ui.available_height() - button_row_height).max(0.0);
+                            ui.add_space(spacer_height);
+                            ui.horizontal(|ui| {
+                                if crate::ui_style::modern_button(
+                                    ui,
+                                    skip_label.as_str(),
+                                    Vec2::new(96.0, button_row_height),
+                                    true,
+                                )
+                                .clicked()
+                                {
                                     self.complete_onboarding_tour();
-                                } else {
-                                    self.tour_state.step += 1;
+                                }
+
+                                let trailing_width = 88.0 + 94.0 + ui.spacing().item_spacing.x;
+                                ui.add_space((ui.available_width() - trailing_width).max(0.0));
+
+                                let prev_enabled = self.tour_state.step > 0;
+                                if crate::ui_style::modern_button(
+                                    ui,
+                                    prev_label.as_str(),
+                                    Vec2::new(88.0, button_row_height),
+                                    prev_enabled,
+                                )
+                                .clicked()
+                                    && prev_enabled
+                                {
+                                    self.tour_state.step -= 1;
                                     ctx.request_repaint();
                                 }
-                            }
+                                if crate::ui_style::modern_button(
+                                    ui,
+                                    next_label.as_str(),
+                                    Vec2::new(94.0, button_row_height),
+                                    true,
+                                )
+                                .clicked()
+                                {
+                                    if self.tour_state.step + 1 >= step_count {
+                                        self.complete_onboarding_tour();
+                                    } else {
+                                        self.tour_state.step += 1;
+                                        ctx.request_repaint();
+                                    }
+                                }
+                            });
                         });
-                    });
-                });
+                    },
+                );
             });
     }
 }

--- a/src/ui/universal_symbols_setup.rs
+++ b/src/ui/universal_symbols_setup.rs
@@ -336,20 +336,20 @@ impl EntropyApp {
                     self.open_macos_input_monitoring_settings(lang);
                 }
             }
-            10
-                if draw_universal_symbols_action_row_with_tooltip_state(
-                    ui,
-                    metrics,
-                    row_content_width,
-                    row_height,
-                    lang,
-                    "universal_symbols_setup.restart_event_tap",
-                    "universal_symbols_setup.restart_event_tap_tooltip",
-                    "universal_symbols_setup.restart_event_tap_button",
-                    suppress_tooltips,
-                ) => {
-                    self.restart_macos_event_tap(lang);
-                }
+            10 if draw_universal_symbols_action_row_with_tooltip_state(
+                ui,
+                metrics,
+                row_content_width,
+                row_height,
+                lang,
+                "universal_symbols_setup.restart_event_tap",
+                "universal_symbols_setup.restart_event_tap_tooltip",
+                "universal_symbols_setup.restart_event_tap_button",
+                suppress_tooltips,
+            ) =>
+            {
+                self.restart_macos_event_tap(lang);
+            }
             _ => {}
         }
     }


### PR DESCRIPTION
## EN
### Summary
Apply the current cargo fmt baseline without changing behavior.

This makes future Rust changes easier to review and lets formatting become a reliable local gate after the baseline lands.

### Verification
- Local: `git diff --check`
- Local: `cargo build --release`
- Local: `cargo test`
- Local: `cargo fmt -- --check`
- Remote: GitHub Actions `Build` run: https://github.com/ergohaven/entropy/actions/runs/27808731116.

Fixes #16

## RU
### Кратко
Применяет текущий cargo fmt baseline без изменения поведения.

Это упрощает ревью будущих изменений на Rust и позволяет использовать форматирование как новую проверку после установления чистой базы.

### Проверка
- Локально: `git diff --check`
- Локально: `cargo build --release`
- Локально: `cargo test`
- Локально: `cargo fmt -- --check`
- Remote: GitHub Actions `Build` run: https://github.com/ergohaven/entropy/actions/runs/27808731116.

Закрывает #16
