### PR TITLE
Apply mechanical clippy cleanup

### DIFF
--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -25,7 +25,7 @@ impl EntropyApp {
         let text_expander_rules_signature =
             text_expander_rules_signature(&app_settings.text_expander_rule_files);
 
-        let mut app = Self {
+        Self {
             #[cfg(not(target_arch = "wasm32"))]
             hid_device: None,
             #[cfg(not(target_arch = "wasm32"))]
@@ -162,8 +162,7 @@ impl EntropyApp {
             connect_state: ConnectState::Idle,
             #[cfg(not(target_arch = "wasm32"))]
             device_scan_state: DeviceScanState::Idle,
-        };
-        app
+        }
     }
 
     /// Assign keycode and immediately write to device (blocking, but single HID op — fast).

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -76,17 +76,14 @@ pub(crate) struct AppSettings {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub(crate) enum CloseToTrayBehavior {
+    #[default]
     Ask,
     Close,
     Tray,
 }
 
-impl Default for CloseToTrayBehavior {
-    fn default() -> Self {
-        Self::Ask
-    }
-}
 
 pub(crate) fn default_show_shifted_number_symbols() -> bool {
     true
@@ -505,7 +502,7 @@ impl KeyOverrideOptionsState {
     }
 
     pub(crate) fn bits(&self) -> u8 {
-        (self.activation_trigger_down as u8) << 0
+        (self.activation_trigger_down as u8)
             | (self.activation_required_mod_down as u8) << 1
             | (self.activation_negative_mod_up as u8) << 2
             | (self.one_mod as u8) << 3
@@ -1341,30 +1338,24 @@ pub(crate) enum SettingsTab {
 
 #[derive(Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub(crate) enum LayoutImageExportTheme {
+    #[default]
     Current,
     Light,
     Dark,
 }
 
-impl Default for LayoutImageExportTheme {
-    fn default() -> Self {
-        Self::Current
-    }
-}
 
 #[derive(Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub(crate) enum LayoutImageExportFormat {
+    #[default]
     Png,
     Svg,
 }
 
-impl Default for LayoutImageExportFormat {
-    fn default() -> Self {
-        Self::Png
-    }
-}
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub(crate) struct LayoutImageExportState {

--- a/src/app_storage.rs
+++ b/src/app_storage.rs
@@ -245,11 +245,11 @@ pub(super) fn open_path_in_system_editor(path: &std::path::Path) -> bool {
     }
     #[cfg(target_os = "macos")]
     {
-        return std::process::Command::new("open")
+        std::process::Command::new("open")
             .arg(path)
             .status()
             .map(|status| status.success())
-            .unwrap_or(false);
+            .unwrap_or(false)
     }
     #[cfg(target_os = "linux")]
     {

--- a/src/entlayout.rs
+++ b/src/entlayout.rs
@@ -2121,45 +2121,6 @@ fn entmacro_bytecode(macros: &EntMacroData) -> Result<Vec<Vec<u8>>> {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn entmacro_bytecode_prefers_base64() {
-        let bytes = vec![0x01, 0x05, 0xA0, 0xFF];
-        let macros = EntMacroData {
-            bytecode_base64: vec![BASE64_STANDARD.encode(&bytes)],
-            texts: vec!["legacy".to_owned()],
-            names: Vec::new(),
-        };
-
-        assert_eq!(entmacro_bytecode(&macros).unwrap(), vec![bytes]);
-    }
-
-    #[test]
-    fn entmacro_bytecode_reads_legacy_texts() {
-        let macros = EntMacroData {
-            bytecode_base64: Vec::new(),
-            texts: vec!["abc".to_owned()],
-            names: Vec::new(),
-        };
-
-        assert_eq!(entmacro_bytecode(&macros).unwrap(), vec![b"abc".to_vec()]);
-    }
-
-    #[test]
-    fn entmacro_bytecode_rejects_invalid_base64() {
-        let macros = EntMacroData {
-            bytecode_base64: vec!["not base64".to_owned()],
-            texts: Vec::new(),
-            names: Vec::new(),
-        };
-
-        assert!(entmacro_bytecode(&macros).is_err());
-    }
-}
-
 fn entlayout_hash(layout: &KeyboardLayout) -> String {
     let mut hash = 0xcbf29ce484222325u64;
     fn feed(hash: &mut u64, bytes: &[u8]) {
@@ -2197,4 +2158,43 @@ fn entlayout_hash(layout: &KeyboardLayout) -> String {
         }
     }
     format!("fnv1a64:{hash:016x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entmacro_bytecode_prefers_base64() {
+        let bytes = vec![0x01, 0x05, 0xA0, 0xFF];
+        let macros = EntMacroData {
+            bytecode_base64: vec![BASE64_STANDARD.encode(&bytes)],
+            texts: vec!["legacy".to_owned()],
+            names: Vec::new(),
+        };
+
+        assert_eq!(entmacro_bytecode(&macros).unwrap(), vec![bytes]);
+    }
+
+    #[test]
+    fn entmacro_bytecode_reads_legacy_texts() {
+        let macros = EntMacroData {
+            bytecode_base64: Vec::new(),
+            texts: vec!["abc".to_owned()],
+            names: Vec::new(),
+        };
+
+        assert_eq!(entmacro_bytecode(&macros).unwrap(), vec![b"abc".to_vec()]);
+    }
+
+    #[test]
+    fn entmacro_bytecode_rejects_invalid_base64() {
+        let macros = EntMacroData {
+            bytecode_base64: vec!["not base64".to_owned()],
+            texts: Vec::new(),
+            names: Vec::new(),
+        };
+
+        assert!(entmacro_bytecode(&macros).is_err());
+    }
 }

--- a/src/hid.rs
+++ b/src/hid.rs
@@ -595,7 +595,7 @@ fn read_response(
         last_error = Some(anyhow::anyhow!(
             "HID stale or unrelated BLE report for command {:02X}: {:02X?}",
             command.first().copied().unwrap_or(0),
-            &resp[..command.len().min(8).max(3)]
+            &resp[..command.len().clamp(3, 8)]
         ));
     }
 

--- a/src/hid_dynamic.rs
+++ b/src/hid_dynamic.rs
@@ -45,8 +45,8 @@ impl HidDevice {
         cmd[1] = CMD_VIAL_DYNAMIC_ENTRY_OP;
         cmd[2] = DYNAMIC_VIAL_COMBO_SET;
         cmd[3] = idx;
-        for i in 0..4 {
-            let [lo, hi] = keys[i].to_le_bytes();
+        for (i, key) in keys.iter().enumerate() {
+            let [lo, hi] = key.to_le_bytes();
             let off = 4 + i * 2;
             cmd[off] = lo;
             cmd[off + 1] = hi;

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -1577,7 +1577,6 @@ pub fn tr_text(language: Language, text: &str) -> String {
             )
         }
         other if other.starts_with("One-Shot ") => other
-            .replace("One-Shot ", "One-Shot ")
             .replace(
                 " — active for the next keypress only",
                 tr_catalog(language, "dynamic_tooltips.one_shot_active_next"),
@@ -1977,7 +1976,6 @@ pub fn tr_text(language: Language, text: &str) -> String {
                 tr_catalog(language, "dynamic_tooltips.hold_for"),
             ),
         other if other.starts_with("Universal Cyrillic ") => other
-            .replace("Universal Cyrillic", "Universal Cyrillic")
             .replace("types", tr_catalog(language, "dynamic_tooltips.types"))
             .replace(
                 "consistently regardless of the active keyboard language",

--- a/src/keycode.rs
+++ b/src/keycode.rs
@@ -1,5 +1,5 @@
-/// QMK/Vial keycode definitions — protocol v6
-/// Reference: vial-gui/src/main/python/keycodes/keycodes_v6.py
+//! QMK/Vial keycode definitions — protocol v6
+//! Reference: vial-gui/src/main/python/keycodes/keycodes_v6.py
 
 /// Returns the platform-appropriate generic label for the GUI/Super/Win/Cmd key.
 /// Side-specific info belongs in tooltips, not the keycap label.
@@ -27,7 +27,9 @@ pub fn gui_mod_name() -> &'static str {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum KeyLegendLayout {
+    #[default]
     English,
     Russian,
     RussianPrimary,
@@ -64,11 +66,6 @@ impl KeyLegendLayout {
     }
 }
 
-impl Default for KeyLegendLayout {
-    fn default() -> Self {
-        KeyLegendLayout::English
-    }
-}
 
 fn osm_mod_bits(value: u16) -> Option<u16> {
     (0x52A0..=0x52BF).contains(&value).then_some(value & 0x1F)
@@ -645,21 +642,18 @@ pub fn keycode_label_with_names_and_layout(
 
 fn compact_compound_key_label(kc: &Keycode) -> String {
     let mut lines = kc.label.lines();
-    match (lines.next(), lines.next(), lines.next()) {
-        (Some(top), Some(bottom), None) => {
-            let is_short_symbol = |line: &str| {
-                let trimmed = line.trim();
-                !trimmed.is_empty()
-                    && trimmed.chars().count() <= 3
-                    && trimmed
-                        .chars()
-                        .all(|c| !c.is_alphanumeric() && !c.is_whitespace())
-            };
-            if is_short_symbol(top) || is_short_symbol(bottom) {
-                return kc.label.to_string();
-            }
+    if let (Some(top), Some(bottom), None) = (lines.next(), lines.next(), lines.next()) {
+        let is_short_symbol = |line: &str| {
+            let trimmed = line.trim();
+            !trimmed.is_empty()
+                && trimmed.chars().count() <= 3
+                && trimmed
+                    .chars()
+                    .all(|c| !c.is_alphanumeric() && !c.is_whitespace())
+        };
+        if is_short_symbol(top) || is_short_symbol(bottom) {
+            return kc.label.to_string();
         }
-        _ => {}
     }
 
     simple_key_name(kc)
@@ -735,7 +729,7 @@ pub fn keycode_label_with_names(value: u16, custom: &[CustomKeycode], layer_name
     // QK_ONE_SHOT_LAYER = 0x5280            → OSL(n)
     // QK_LAYER_TAP_TOG  = 0x52C0            → TT(n)
     // QK_PERSISTENT_DEF = 0x52E0            → PDF(n)
-    if value >= 0x5200 && value < 0x5300 {
+    if (0x5200..0x5300).contains(&value) {
         let sub = value & 0xFF;
         return match (value >> 5) & 0x7 {
             0 => layer_label("TO",  sub & 0x1F),
@@ -751,16 +745,16 @@ pub fn keycode_label_with_names(value: u16, custom: &[CustomKeycode], layer_name
     }
 
     // QK_LAYER_MOD: 0x5000 | (layer << 4) | mods
-    if value >= 0x5000 && value < 0x5200 {
+    if (0x5000..0x5200).contains(&value) {
         let layer = (value >> 4) & 0xF;
-        return format!("LM/{}", layer_name(layer as u16));
+        return format!("LM/{}", layer_name(layer));
     }
 
     // QK_LAYER_TAP: 0x4000 | (layer << 8) | kc  (checked AFTER all 0x5xxx ranges)
     if value & 0xF000 == 0x4000 {
         let layer = (value >> 8) & 0xF;
         let kc = value & 0xFF;
-        return compound_keycode_label(&format!("LT {}", layer_name(layer as u16)), kc as u16);
+        return compound_keycode_label(&format!("LT {}", layer_name(layer)), kc);
     }
 
     // QK_MOD_TAP: 0x2000 | (mods << 8) | kc
@@ -768,15 +762,15 @@ pub fn keycode_label_with_names(value: u16, custom: &[CustomKeycode], layer_name
         let kc = value & 0xFF;
         let mods = (value >> 8) & 0x1F;
         let right = (value >> 12) & 0x1 != 0;
-        let mod_str = decode_mods(mods as u16, right);
-        return compound_keycode_label(&mod_str, kc as u16);
+        let mod_str = decode_mods(mods, right);
+        return compound_keycode_label(&mod_str, kc);
     }
 
     // Modifier+key combos: 0x0100..0x1F00 | kc
     // LCTL=0x0100, LSFT=0x0200, LALT=0x0400, LGUI=0x0800
     // RCTL=0x1100, RSFT=0x1200, RALT=0x1400, RGUI=0x1800
     // MEH=0x0700, HYPR=0x0F00, LSA=0x0600, LCA=0x0500
-    if value >= 0x0100 && value < 0x2000 && (value & 0xFF) != 0 {
+    if (0x0100..0x2000).contains(&value) && (value & 0xFF) != 0 {
         let mods = value >> 8;
         let kc = value & 0xFF;
         let gui = gui_sym();
@@ -799,18 +793,18 @@ pub fn keycode_label_with_names(value: u16, custom: &[CustomKeycode], layer_name
             0x18 => format!("R{}", gui),
             _ => "Mod".into(),
         };
-        return compound_keycode_label(&mod_str, kc as u16);
+        return compound_keycode_label(&mod_str, kc);
     }
 
     if value == 0x0001 { return "▽".to_string(); }
     if value == 0x0000 { return "✕".to_string(); }
 
     // Macro keycodes: 0x7700..0x77FF
-    if value >= 0x7700 && value <= 0x77FF {
+    if (0x7700..=0x77FF).contains(&value) {
         return format!("M{}", value - 0x7700);
     }
     // Tap Dance keycodes: 0x5700..0x57FF
-    if value >= 0x5700 && value <= 0x57FF {
+    if (0x5700..=0x57FF).contains(&value) {
         return format!("TD{}", value - 0x5700);
     }
 
@@ -1009,7 +1003,7 @@ pub fn keycode_tooltip(value: u16, custom: &[CustomKeycode], layer_names: &[Stri
     }
 
     // ── Layer ops 0x5200..0x52FF ─────────────────────────────────────────────
-    if value >= 0x5200 && value < 0x5300 {
+    if (0x5200..0x5300).contains(&value) {
         let sub = value & 0xFF;
         return match (value >> 5) & 0x7 {
             0 => format!("TO({}) — switch to {} and stay there", sub & 0x1F, layer_display(sub & 0x1F)),
@@ -1018,7 +1012,7 @@ pub fn keycode_tooltip(value: u16, custom: &[CustomKeycode], layer_names: &[Stri
             3 => format!("TG({}) — toggle {} on/off", sub & 0x1F, layer_display(sub & 0x1F)),
             4 => format!("OSL({}) — activate {} for next keypress only", sub & 0x1F, layer_display(sub & 0x1F)),
             5 => {
-                let m = mod_name(sub as u16 & 0x1F, sub >= 0x10);
+                let m = mod_name(sub & 0x1F, sub >= 0x10);
                 format!("One-Shot {} — activates {} for the very next keypress only", m, m)
             }
             6 => format!("TT({}) — tap to toggle {}, hold to activate while held", sub & 0x1F, layer_display(sub & 0x1F)),
@@ -1028,21 +1022,21 @@ pub fn keycode_tooltip(value: u16, custom: &[CustomKeycode], layer_names: &[Stri
     }
 
     // ── QK_LAYER_MOD 0x5000..0x51FF ─────────────────────────────────────────
-    if value >= 0x5000 && value < 0x5200 {
+    if (0x5000..0x5200).contains(&value) {
         let layer = (value >> 4) & 0xF;
         let mods = value & 0xF;
-        let m = mod_name(mods as u16, false);
-        return format!("LM({}, {}) — activate {} with {} held while key is pressed", layer, m, layer_display(layer as u16), m);
+        let m = mod_name(mods, false);
+        return format!("LM({}, {}) — activate {} with {} held while key is pressed", layer, m, layer_display(layer), m);
     }
 
     // ── QK_LAYER_TAP 0x4000..0x4FFF ─────────────────────────────────────────
     if value & 0xF000 == 0x4000 {
         let layer = (value >> 8) & 0xF;
         let kc = value & 0xFF;
-        let kc_str = find_keycode(kc as u16)
-            .map(|k| simple_key_name(k))
+        let kc_str = find_keycode(kc)
+            .map(simple_key_name)
             .unwrap_or_else(|| format!("0x{:02X}", kc));
-        return format!("Layer Tap — tap for {}, hold to activate {}", kc_str, layer_display(layer as u16));
+        return format!("Layer Tap — tap for {}, hold to activate {}", kc_str, layer_display(layer));
     }
 
     // ── QK_MOD_TAP 0x2000..0x3FFF ───────────────────────────────────────────
@@ -1050,20 +1044,20 @@ pub fn keycode_tooltip(value: u16, custom: &[CustomKeycode], layer_names: &[Stri
         let kc = value & 0xFF;
         let mods = (value >> 8) & 0x1F;
         let right = (value >> 12) & 0x1 != 0;
-        let kc_str = find_keycode(kc as u16)
-            .map(|k| simple_key_name(k))
+        let kc_str = find_keycode(kc)
+            .map(simple_key_name)
             .unwrap_or_else(|| format!("0x{:02X}", kc));
-        let m = mod_name(mods as u16, right);
-        let side_str = side(mods as u16);
+        let m = mod_name(mods, right);
+        let side_str = side(mods);
         return format!("Mod Tap — tap for {}, hold for {}{}", kc_str, side_str, m);
     }
 
     // ── Modifier+key combos 0x0100..0x1FFF ──────────────────────────────────
-    if value >= 0x0100 && value < 0x2000 && (value & 0xFF) != 0 {
+    if (0x0100..0x2000).contains(&value) && (value & 0xFF) != 0 {
         let mods = value >> 8;
         let kc = value & 0xFF;
-        let kc_str = find_keycode(kc as u16)
-            .map(|k| simple_key_name(k))
+        let kc_str = find_keycode(kc)
+            .map(simple_key_name)
             .unwrap_or_else(|| format!("0x{:02X}", kc));
         let combo = match mods {
             0x01 => "Ctrl+",
@@ -1105,11 +1099,11 @@ pub fn keycode_tooltip(value: u16, custom: &[CustomKeycode], layer_names: &[Stri
     }
 
     // Macro keycodes
-    if value >= 0x7700 && value <= 0x77FF {
+    if (0x7700..=0x77FF).contains(&value) {
         return format!("Macro {} — sends a sequence of keystrokes", value - 0x7700);
     }
     // Tap Dance keycodes
-    if value >= 0x5700 && value <= 0x57FF {
+    if (0x5700..=0x57FF).contains(&value) {
         return format!("Tap Dance {} — different actions on tap, hold, double tap", value - 0x5700);
     }
 

--- a/src/keycode_picker.rs
+++ b/src/keycode_picker.rs
@@ -353,18 +353,13 @@ impl KeycodePicker {
 
     fn set_macro_key_pick_value(&mut self, macro_idx: usize, action_idx: usize, value: u16) {
         let mut changed = false;
-        if let Some(action) = self
+        if let Some(MacroAction::Tap(kc) | MacroAction::Down(kc) | MacroAction::Up(kc)) = self
             .macro_actions
             .get_mut(macro_idx)
             .and_then(|actions| actions.get_mut(action_idx))
         {
-            match action {
-                MacroAction::Tap(kc) | MacroAction::Down(kc) | MacroAction::Up(kc) => {
-                    changed = *kc != value;
-                    *kc = value;
-                }
-                _ => {}
-            }
+            changed = *kc != value;
+            *kc = value;
         }
         if changed {
             self.encode_macro(macro_idx);
@@ -855,14 +850,12 @@ impl KeycodePicker {
                                 self.finish_regular_key_pick(base | qmk);
                             }
                         } else if qmk > 0 && qmk < 0x0100 {
-                            if self.regular_key_pick_allow_mod_key || !modifiers.any() {
-                                if self.is_regular_key_pick_value(qmk) {
+                            if (self.regular_key_pick_allow_mod_key || !modifiers.any())
+                                && self.is_regular_key_pick_value(qmk) {
                                     self.finish_regular_key_pick(qmk);
                                 }
-                            }
                         } else if self.regular_key_pick_allow_mod_key
-                            && qmk >= 0x0100
-                            && qmk < 0x2000
+                            && (0x0100..0x2000).contains(&qmk)
                             && self.is_regular_key_pick_value(qmk & 0x00FF)
                         {
                             self.finish_regular_key_pick(qmk);
@@ -1070,7 +1063,7 @@ impl KeycodePicker {
                 }
             });
             let mut still_open = true;
-            let resp_win = crate::ui_style::centered_modal_window(
+            let _resp_win = crate::ui_style::centered_modal_window(
                 ctx,
                 tr_picker(self.language, "key_picker.pick_layer_title"),
                 self.popup_state.id(PopupKey::PickLayerWindow),
@@ -1173,7 +1166,7 @@ impl KeycodePicker {
             };
             let mut still_open = true;
             let popup_size = key_picker_popup_size(ctx);
-            let resp_win = crate::ui_style::centered_modal_window(
+            let _resp_win = crate::ui_style::centered_modal_window(
                 ctx,
                 title,
                 self.popup_state.id(PopupKey::PendingKeyPickWindow),

--- a/src/keycode_picker_lighting_quantum.rs
+++ b/src/keycode_picker_lighting_quantum.rs
@@ -190,7 +190,7 @@ impl KeycodePicker {
                 if resp.clicked() {
                     self.vial_quantum_pending_mod = Some(*base);
                 }
-                resp.on_hover_text(crate::i18n::tr_text(self.language, &tip));
+                resp.on_hover_text(crate::i18n::tr_text(self.language, tip));
             }
         });
 
@@ -247,7 +247,7 @@ impl KeycodePicker {
                 if resp.clicked() {
                     self.vial_quantum_pending_mt = Some(*base);
                 }
-                resp.on_hover_text(crate::i18n::tr_text(self.language, &tip));
+                resp.on_hover_text(crate::i18n::tr_text(self.language, tip));
             }
         });
     }

--- a/src/keycode_picker_macro.rs
+++ b/src/keycode_picker_macro.rs
@@ -92,7 +92,7 @@ impl KeycodePicker {
                                     self.ensure_macro_meta_len(i as usize);
                                     selected_macro = i;
                                 }
-                                if (i + 1) % 16 == 0 {
+                                if (i + 1).is_multiple_of(16) {
                                     ui.end_row();
                                 }
                             }
@@ -245,7 +245,7 @@ impl KeycodePicker {
                         }
                         MacroAction::Tap(kc) => {
                             let label = keycode_label_with_names_and_layout(
-                                *kc as u16,
+                                *kc ,
                                 &custom_pairs,
                                 &self.layer_names,
                                 self.key_legend_layout,
@@ -268,7 +268,7 @@ impl KeycodePicker {
                         }
                         MacroAction::Down(kc) => {
                             let label = keycode_label_with_names_and_layout(
-                                *kc as u16,
+                                *kc ,
                                 &custom_pairs,
                                 &self.layer_names,
                                 self.key_legend_layout,
@@ -291,7 +291,7 @@ impl KeycodePicker {
                         }
                         MacroAction::Up(kc) => {
                             let label = keycode_label_with_names_and_layout(
-                                *kc as u16,
+                                *kc ,
                                 &custom_pairs,
                                 &self.layer_names,
                                 self.key_legend_layout,
@@ -652,8 +652,10 @@ mod tests {
 
     #[test]
     fn encodes_basic_macro_tap_as_vial_short_action() {
-        let mut picker = KeycodePicker::default();
-        picker.macro_actions = vec![vec![MacroAction::Tap(0x0006)]];
+        let mut picker = KeycodePicker {
+            macro_actions: vec![vec![MacroAction::Tap(0x0006)]],
+            ..Default::default()
+        };
 
         picker.encode_macro(0);
 
@@ -662,8 +664,10 @@ mod tests {
 
     #[test]
     fn encodes_modified_macro_tap_as_vial_extended_action() {
-        let mut picker = KeycodePicker::default();
-        picker.macro_actions = vec![vec![MacroAction::Tap(0x0106)]];
+        let mut picker = KeycodePicker {
+            macro_actions: vec![vec![MacroAction::Tap(0x0106)]],
+            ..Default::default()
+        };
 
         picker.encode_macro(0);
 

--- a/src/keycode_picker_special.rs
+++ b/src/keycode_picker_special.rs
@@ -208,7 +208,7 @@ Repeat"
                 if resp.clicked() {
                     self.assign_keycode_value(*value);
                 }
-                resp.on_hover_text(crate::i18n::tr_text(self.language, &tip));
+                resp.on_hover_text(crate::i18n::tr_text(self.language, tip));
             }
         });
 
@@ -431,7 +431,7 @@ Repeat"
                 if resp.clicked() {
                     self.assign_keycode_value(value);
                 }
-                resp.on_hover_text(crate::i18n::tr_text(self.language, &tip));
+                resp.on_hover_text(crate::i18n::tr_text(self.language, tip));
             }
         });
 
@@ -684,7 +684,7 @@ Repeat"
                 if resp.clicked() {
                     self.assign_keycode_value(*value);
                 }
-                resp = resp.on_hover_text(crate::i18n::tr_text(self.language, &tip));
+                resp = resp.on_hover_text(crate::i18n::tr_text(self.language, tip));
                 let _ = resp;
             }
         });
@@ -757,7 +757,7 @@ Repeat"
                 if resp.clicked() {
                     self.assign_keycode_value(*value);
                 }
-                resp = resp.on_hover_text(crate::i18n::tr_text(self.language, &tip));
+                resp = resp.on_hover_text(crate::i18n::tr_text(self.language, tip));
                 let _ = resp;
             }
         });

--- a/src/keycode_picker_tabs.rs
+++ b/src/keycode_picker_tabs.rs
@@ -339,7 +339,7 @@ impl KeycodePicker {
                 .color(Color32::from_gray(150)),
         );
         ui.add_space(4.0);
-        let mut mt: Vec<(String, u16, Option<u16>, String)> = vec![
+        let mt: Vec<(String, u16, Option<u16>, String)> = vec![
             (
                 picker_mod_tap_label(0x2100),
                 0x2100,
@@ -428,7 +428,7 @@ impl KeycodePicker {
                 .color(Color32::from_gray(150)),
         );
         ui.add_space(4.0);
-        let mut osm: Vec<(String, u16, Option<u16>, String)> = vec![
+        let osm: Vec<(String, u16, Option<u16>, String)> = vec![
             ("OSM\nCtrl".into(), 0x52A1, Some(0x52B1), "Ctrl".into()),
             ("OSM\nShift".into(), 0x52A2, Some(0x52B2), "Shift".into()),
             ("OSM\nAlt".into(), 0x52A4, Some(0x52B4), "Alt".into()),

--- a/src/keycode_picker_tap_dance_picker.rs
+++ b/src/keycode_picker_tap_dance_picker.rs
@@ -49,13 +49,10 @@ impl KeycodePicker {
                     } = event
                     {
                         if let Some(qmk) = egui_key_to_qmk(*key, *modifiers) {
-                            if qmk > 0 && qmk < 0x0100 {
-                                self.set_tap_dance_field(td_idx, field, qmk);
-                                self.td_key_pick = None;
-                            } else if qmk >= 0x0100
-                                && qmk < 0x2000
-                                && self.is_tap_dance_regular_key(qmk & 0x00FF)
-                            {
+                            let is_basic_key = qmk > 0 && qmk < 0x0100;
+                            let is_regular_key = (0x0100..0x2000).contains(&qmk)
+                                && self.is_tap_dance_regular_key(qmk & 0x00FF);
+                            if is_basic_key || is_regular_key {
                                 self.set_tap_dance_field(td_idx, field, qmk);
                                 self.td_key_pick = None;
                             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,6 +178,7 @@ fn try_acquire_single_instance() -> bool {
 
     let Ok(file) = OpenOptions::new()
         .create(true)
+        .truncate(false)
         .read(true)
         .write(true)
         .open(dir.join("single_instance.lock"))

--- a/src/smart_input.rs
+++ b/src/smart_input.rs
@@ -8,7 +8,7 @@ mod smart_input_symbols;
 #[cfg(target_os = "windows")]
 #[path = "smart_input_windows.rs"]
 mod smart_input_windows;
-pub use smart_input_symbols::{smart_symbol_for_keycode, SmartSymbol, SMART_SYMBOLS};
+pub use smart_input_symbols::{smart_symbol_for_keycode, SMART_SYMBOLS};
 use smart_input_symbols::{KC_F13, MOD_ALT, MOD_CTRL, MOD_SHIFT};
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TextExpanderAppCandidate {

--- a/src/text_expander.rs
+++ b/src/text_expander.rs
@@ -60,7 +60,7 @@ impl TextExpansionEngine {
         Self {
             rules,
             buffer: String::new(),
-            max_buffer_chars: max_trigger_chars.max(64).min(128),
+            max_buffer_chars: max_trigger_chars.clamp(64, 128),
         }
     }
 

--- a/src/ui/combo_settings.rs
+++ b/src/ui/combo_settings.rs
@@ -56,11 +56,10 @@ impl EntropyApp {
     }
 
     fn handle_combo_editor_input(&mut self, ctx: &egui::Context, allow_close: bool) -> bool {
-        if !self.keycode_picker.open && ctx.input(|i| i.key_pressed(egui::Key::Escape)) {
-            if allow_close {
+        if !self.keycode_picker.open && ctx.input(|i| i.key_pressed(egui::Key::Escape))
+            && allow_close {
                 return true;
             }
-        }
         false
     }
 

--- a/src/ui/device_connect_apply.rs
+++ b/src/ui/device_connect_apply.rs
@@ -27,38 +27,36 @@ impl EntropyApp {
                 rx,
                 started_at,
                 last_progress_at,
-            } => loop {
-                match rx.try_recv() {
-                    Ok(ConnectTaskMessage::Progress(message)) => {
-                        self.status_msg = message;
-                        *last_progress_at = std::time::Instant::now();
-                        ctx.request_repaint();
-                        return;
-                    }
-                    Ok(ConnectTaskMessage::Done(result)) => break result,
-                    Err(mpsc::TryRecvError::Empty) => {
-                        let idle_timeout = last_progress_at.elapsed() > CONNECT_IDLE_TIMEOUT;
-                        let total_timeout = started_at.elapsed() > CONNECT_TOTAL_TIMEOUT;
-                        if idle_timeout || total_timeout {
-                            let stage = if self.status_msg.is_empty() {
-                                "unknown stage"
-                            } else {
-                                self.status_msg.as_str()
-                            };
-                            self.status_msg = format!(
-                                "Connect timeout — RMK/Vial device did not finish loading while: {stage}"
-                            );
-                            self.connect_state = ConnectState::Idle;
-                            return;
-                        }
-                        ctx.request_repaint(); // keep polling
-                        return;
-                    }
-                    Err(mpsc::TryRecvError::Disconnected) => {
-                        self.status_msg = "Connect thread died".into();
+            } => match rx.try_recv() {
+                Ok(ConnectTaskMessage::Progress(message)) => {
+                    self.status_msg = message;
+                    *last_progress_at = std::time::Instant::now();
+                    ctx.request_repaint();
+                    return;
+                }
+                Ok(ConnectTaskMessage::Done(result)) => result,
+                Err(mpsc::TryRecvError::Empty) => {
+                    let idle_timeout = last_progress_at.elapsed() > CONNECT_IDLE_TIMEOUT;
+                    let total_timeout = started_at.elapsed() > CONNECT_TOTAL_TIMEOUT;
+                    if idle_timeout || total_timeout {
+                        let stage = if self.status_msg.is_empty() {
+                            "unknown stage"
+                        } else {
+                            self.status_msg.as_str()
+                        };
+                        self.status_msg = format!(
+                            "Connect timeout — RMK/Vial device did not finish loading while: {stage}"
+                        );
                         self.connect_state = ConnectState::Idle;
                         return;
                     }
+                    ctx.request_repaint(); // keep polling
+                    return;
+                }
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    self.status_msg = "Connect thread died".into();
+                    self.connect_state = ConnectState::Idle;
+                    return;
                 }
             },
             ConnectState::Idle => return,

--- a/src/ui/key_assignment.rs
+++ b/src/ui/key_assignment.rs
@@ -192,7 +192,7 @@ impl EntropyApp {
                 return;
             }
         }
-        if kc >= 0x7700 && kc <= 0x77FF {
+        if (0x7700..=0x77FF).contains(&kc) {
             let macro_n = (kc - 0x7700) as u8;
             self.open_picker_for_target(key_target, encoder_target);
             self.keycode_picker.selected_tab = crate::keycode_picker::KeycodeTab::Macro;
@@ -200,7 +200,7 @@ impl EntropyApp {
             self.secondary_click_handled = true;
             return;
         }
-        if kc >= 0x5700 && kc <= 0x57FF {
+        if (0x5700..=0x57FF).contains(&kc) {
             let td_n = (kc - 0x5700) as u8;
             self.open_picker_for_target(key_target, encoder_target);
             self.keycode_picker.selected_tab = crate::keycode_picker::KeycodeTab::TapDance;
@@ -221,9 +221,9 @@ impl EntropyApp {
         let is_layer_key = vial_layer_target(kc).is_some();
         let pending_base: Option<u16> = if is_layer_key {
             None
-        } else if kc >= 0x2000 && kc < 0x4000 {
+        } else if (0x2000..0x4000).contains(&kc) {
             Some(kc & 0xFF00)
-        } else if kc >= 0x0100 && kc < 0x2000 && (kc & 0xFF) != 0 {
+        } else if (0x0100..0x2000).contains(&kc) && (kc & 0xFF) != 0 {
             Some(kc & 0xFF00)
         } else {
             None

--- a/src/ui/layout_hints.rs
+++ b/src/ui/layout_hints.rs
@@ -147,19 +147,19 @@ impl EntropyApp {
                                     | 0x52B8
                             );
                         let is_mod = is_plain_mod
-                            || (kc >= 0x2000 && kc < 0x4000)
-                            || (kc >= 0x0100 && kc < 0x2000 && (kc & 0xFF) != 0);
+                            || (0x2000..0x4000).contains(&kc)
+                            || ((0x0100..0x2000).contains(&kc) && (kc & 0xFF) != 0);
                         let can_swap_side = toggle_handed_modifier(kc).is_some();
-                        let is_macro = kc >= 0x7700 && kc <= 0x77FF;
-                        let is_tap_dance = kc >= 0x5700 && kc <= 0x57FF;
+                        let is_macro = (0x7700..=0x77FF).contains(&kc);
+                        let is_tap_dance = (0x5700..=0x57FF).contains(&kc);
                         let is_mouse = is_mouse_keycode(kc);
                         let is_alt_repeat = is_alt_repeat_keycode(kc);
                         let is_grave_escape = kc == 0x7C16;
                         let is_layer = vial_layer_target(kc).is_some();
                         let is_lt = kc & 0xF000 == 0x4000;
                         let can_retarget_mod_key = !is_layer
-                            && ((kc >= 0x2000 && kc < 0x4000)
-                                || (kc >= 0x0100 && kc < 0x2000 && (kc & 0xFF) != 0));
+                            && ((0x2000..0x4000).contains(&kc)
+                                || ((0x0100..0x2000).contains(&kc) && (kc & 0xFF) != 0));
                         (
                             is_mod,
                             can_swap_side,

--- a/src/ui/layout_indicator_preview.rs
+++ b/src/ui/layout_indicator_preview.rs
@@ -180,7 +180,7 @@ fn draw_sticky_key_label(
         );
         paint_centered_text_rotated(
             &clipped,
-            center + rotated_offset(0.0, -1.0 * rect_scale, rotation),
+            center + rotated_offset(0.0, -rect_scale, rotation),
             middle,
             FontId::proportional(middle_font),
             top_color,
@@ -286,10 +286,7 @@ impl EntropyApp {
             .keys
             .iter()
             .enumerate()
-            .filter_map(|(ki, key)| {
-                Self::layout_condition_visible(layout, key.layout_condition, layout_options_value)
-                    .then(|| (ki, layout_physical_key_rect(key, geometry)))
-            })
+            .filter(|&(_ki, key)| Self::layout_condition_visible(layout, key.layout_condition, layout_options_value)).map(|(ki, key)| (ki, layout_physical_key_rect(key, geometry)))
             .collect();
 
         let mut encoder_groups: Vec<(u8, egui::Rect, Option<(usize, u16)>, Option<(usize, u16)>)> =

--- a/src/ui/layout_keyboard.rs
+++ b/src/ui/layout_keyboard.rs
@@ -360,7 +360,7 @@ impl EntropyApp {
                         self.app_settings.key_legend_layout,
                     );
                     draw_key_label_dimmed(
-                        &painter,
+                        painter,
                         draw_rect,
                         &label,
                         dark,
@@ -383,7 +383,7 @@ impl EntropyApp {
                     self.app_settings.show_shifted_number_symbols,
                     self.app_settings.key_legend_layout,
                 );
-                draw_key_label(&painter, draw_rect, &label, dark, key.rotation.to_radians());
+                draw_key_label(painter, draw_rect, &label, dark, key.rotation.to_radians());
             }
 
             if let Some(colors) = combo_colors {

--- a/src/ui/layout_shared.rs
+++ b/src/ui/layout_shared.rs
@@ -434,7 +434,7 @@ fn draw_key_label_with_colors(
         );
         paint_centered_text_rotated(
             &clipped,
-            center + rotated_offset(0.0, -1.0 * scale, rotation),
+            center + rotated_offset(0.0, -scale, rotation),
             middle,
             FontId::proportional(middle_fit),
             top_color,

--- a/src/ui/universal_symbols_setup.rs
+++ b/src/ui/universal_symbols_setup.rs
@@ -336,7 +336,7 @@ impl EntropyApp {
                     self.open_macos_input_monitoring_settings(lang);
                 }
             }
-            10 => {
+            10
                 if draw_universal_symbols_action_row_with_tooltip_state(
                     ui,
                     metrics,
@@ -347,10 +347,9 @@ impl EntropyApp {
                     "universal_symbols_setup.restart_event_tap_tooltip",
                     "universal_symbols_setup.restart_event_tap_button",
                     suppress_tooltips,
-                ) {
+                ) => {
                     self.restart_macos_event_tap(lang);
                 }
-            }
             _ => {}
         }
     }

--- a/src/vial/unlock.rs
+++ b/src/vial/unlock.rs
@@ -21,11 +21,8 @@ impl EntropyApp {
             if !self.vial_unlock_polling {
                 if let Some(hid) = &self.hid_device {
                     // Get unlock keys from get_unlock_status
-                    match hid.get_unlock_status() {
-                        Ok((_, keys)) => {
-                            self.vial_unlock_keys = keys;
-                        }
-                        Err(_) => {}
+                    if let Ok((_, keys)) = hid.get_unlock_status() {
+                        self.vial_unlock_keys = keys;
                     }
                     // Start the unlock process
                     match hid.unlock_start() {


### PR DESCRIPTION
## EN
### Summary
- Reworks part of the broad clippy warning baseline from #28 into direct source cleanup.
- Applies machine-applicable `cargo clippy --fix` changes for redundant casts, manual range checks, needless borrows, redundant closures, simple `let`/`return` simplifications, and related mechanical lints.
- Adds a few similarly focused manual fixes: explicit lock-file truncate behavior, module-level keycode docs, no-op replacement removal, tap-dance/key-picker control-flow cleanup, and the `never_loop` connect polling cleanup.

### Verification
- `git diff --check`
- `mise x rust@stable -- cargo clippy --all-targets --all-features` exits 0; remaining warnings are intentionally left for follow-up cleanup branches.
- `mise x rust@stable -- cargo test` passes: 44 tests.
- GitHub Actions Build run 28064518576 passed on ubuntu-latest, windows-latest, macos-15, and macos-15-intel: https://github.com/ergohaven/entropy/actions/runs/28064518576

Follow-up to the PR #28 review comment asking for targeted fixes instead of a crate-wide warning/clippy allow baseline.

## RU
### Кратко
- Эти изменения адресуют часть найденных предупреждений clippy из #28.
- PR применяет автоматически применимые правки `cargo clippy --fix`: лишние приведения типов, ручные проверки диапазонов, лишние заимствования, лишние closures, упрощения `let`/`return` и похожие исправления в соответствие с правилами линтера.
- Добавляет несколько таких же точечных исправлений: явное поведение lock-файла для truncate, module-level документацию keycode, удаление no-op replacement, упрощение control-flow для tap-dance/key-picker и cleanup для `never_loop` в connect polling.

### Проверка
- `git diff --check`
- `mise x rust@stable -- cargo clippy --all-targets --all-features` завершается с кодом 0; оставшиеся warnings намеренно оставлены для следующих cleanup-веток.
- `mise x rust@stable -- cargo test` проходит: 44 теста.
- GitHub Actions Build run 28064518576 прошел на ubuntu-latest, windows-latest, macos-15 и macos-15-intel: https://github.com/ergohaven/entropy/actions/runs/28064518576

Follow-up к комментарию в PR #28: вместо crate-wide warning / clippy allow baseline адресуем их через изменения в коде.