### PR TITLE
Declare objc clippy cfg for Rust checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,3 +77,6 @@ getrandom = { version = "0.2", features = ["js"] }
 opt-level = 3
 lto = true
 strip = true
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cargo-clippy"))'] }


### PR DESCRIPTION
## EN
### Summary
- Reworks the `unexpected_cfgs` / `cargo-clippy` part of the broad PR #28 baseline into a targeted Rust lint configuration.
- Declares the legacy `objc` macro's `feature = "cargo-clippy"` cfg value as expected, so Rust no longer warns when `msg_send!` expands on macOS.
- Keeps `unexpected_cfgs` active for other unexpected cfg values; this is not a crate-wide allow.

### Verification
- `git diff --check`
- `mise x rust@stable -- cargo check` exits 0 and the output has 0 `unexpected_cfgs` / `cargo-clippy` mentions.
- `mise x rust@stable -- cargo test` passes: 44 tests, with 0 `unexpected_cfgs` / `cargo-clippy` mentions.
- GitHub Actions Build run 28064365597 passed on ubuntu-latest, windows-latest, macos-15, and macos-15-intel: https://github.com/ergohaven/entropy/actions/runs/28064365597

Follow-up to the PR #28 review comment asking for targeted fixes instead of a crate-wide warning/clippy allow baseline.

## RU
### Кратко
- PR адресует часть уведомлений из PR #28 для `unexpected_cfgs` / `cargo-clippy` и переводит их в Rust lint-конфигурацию.
- Объявляет cfg-значение `feature = "cargo-clippy"`, которое генерирует legacy macro из `objc`, как ожидаемое; Rust больше не предупреждает при раскрытии `msg_send!` на macOS.
- `unexpected_cfgs` остается активным для остальных неожиданных cfg-значений; это не crate-wide allow.

### Проверка
- `git diff --check`
- `mise x rust@stable -- cargo check` завершается с кодом 0, в выводе 0 упоминаний `unexpected_cfgs` / `cargo-clippy`.
- `mise x rust@stable -- cargo test` проходит: 44 теста, в выводе 0 упоминаний `unexpected_cfgs` / `cargo-clippy`.
- GitHub Actions Build run 28064365597 прошел на ubuntu-latest, windows-latest, macos-15 и macos-15-intel: https://github.com/ergohaven/entropy/actions/runs/28064365597

Follow-up к комментарию в PR #28: точечно адресуем предупреждения.
