### PR TITLE
Add universal arrow symbols

### DIFF
--- a/src/keycode_picker.rs
+++ b/src/keycode_picker.rs
@@ -176,9 +176,21 @@ const UNIVERSAL_MAIN_SYMBOL_ORDER: &[char] = &[
 ];
 
 const UNIVERSAL_EXTRA_SYMBOL_ORDER: &[char] = &[
-    '₽', '€', '«', '»', '‘', '’', '„', '“', '”', '—', '–', '•', '×', '±', '≠', '≈', '✓', '§', '°',
-    '‰', '′', '″', '™', '№',
+    '₽', '€', '«', '»', '‘', '’', '„', '“', '”', '—', '–', '←', '↑', '→', '↓', '↔', '•', '×', '±',
+    '≠', '≈', '✓', '§', '°', '‰', '′', '″', '™', '№',
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn universal_extra_symbols_include_common_arrows() {
+        for symbol in ['←', '↑', '→', '↓', '↔'] {
+            assert!(UNIVERSAL_EXTRA_SYMBOL_ORDER.contains(&symbol));
+        }
+    }
+}
 
 fn show_universal_symbol_section(
     ui: &mut egui::Ui,

--- a/src/smart_input_symbols.rs
+++ b/src/smart_input_symbols.rs
@@ -230,6 +230,31 @@ pub const SMART_SYMBOLS: &[SmartSymbol] = &[
         symbol: '^',
         name: "Caret",
     },
+    SmartSymbol {
+        trigger_keycode: MOD_ALT | (KC_F13 + 7),
+        symbol: '←',
+        name: "Leftwards arrow",
+    },
+    SmartSymbol {
+        trigger_keycode: MOD_ALT | (KC_F13 + 8),
+        symbol: '↑',
+        name: "Upwards arrow",
+    },
+    SmartSymbol {
+        trigger_keycode: MOD_ALT | (KC_F13 + 9),
+        symbol: '→',
+        name: "Rightwards arrow",
+    },
+    SmartSymbol {
+        trigger_keycode: MOD_ALT | (KC_F13 + 10),
+        symbol: '↓',
+        name: "Downwards arrow",
+    },
+    SmartSymbol {
+        trigger_keycode: MOD_ALT | (KC_F13 + 11),
+        symbol: '↔',
+        name: "Left right arrow",
+    },
     // Ctrl+Alt+F13..F19
     SmartSymbol {
         trigger_keycode: MOD_CTRL | MOD_ALT | KC_F13,
@@ -370,4 +395,27 @@ pub fn smart_symbol_for_keycode(keycode: u16) -> Option<SmartSymbol> {
         .iter()
         .copied()
         .find(|symbol| symbol.trigger_keycode == keycode)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn arrow_symbols_use_unused_alt_function_key_slots() {
+        let expected = [
+            (MOD_ALT | (KC_F13 + 7), '←'),
+            (MOD_ALT | (KC_F13 + 8), '↑'),
+            (MOD_ALT | (KC_F13 + 9), '→'),
+            (MOD_ALT | (KC_F13 + 10), '↓'),
+            (MOD_ALT | (KC_F13 + 11), '↔'),
+        ];
+
+        for (keycode, symbol) in expected {
+            assert_eq!(
+                smart_symbol_for_keycode(keycode).map(|smart_symbol| smart_symbol.symbol),
+                Some(symbol)
+            );
+        }
+    }
 }


### PR DESCRIPTION
## EN
### Summary
- Adds common arrow characters to the Universal Symbols catalog: `←`, `↑`, `→`, `↓`, and `↔`.
- Uses the currently unused Alt+F20..F24 service keycode slots for the new arrow triggers.
- Shows the arrows in the Extra universal symbols picker section and adds regression coverage for the trigger mappings and picker list.

### Verification
- `git diff --check`
- `/Users/igor.arkhipov/.cargo/bin/cargo build --quiet`
- `/Users/igor.arkhipov/.cargo/bin/cargo test --quiet` passes: 46 tests.

## RU
### Кратко
- Добавляет часто используемые стрелки в каталог универсальных символов: `←`, `↑`, `→`, `↓` и `↔`.
- Использует для новых стрелок свободные служебные keycode-слоты Alt+F20..F24.
- Показывает стрелки в секции дополнительных универсальных символов и добавляет регрессионные тесты для маппинга keycode и списка пикера.

### Проверка
- `git diff --check`
- `/Users/igor.arkhipov/.cargo/bin/cargo build --quiet`
- `/Users/igor.arkhipov/.cargo/bin/cargo test --quiet` проходит: 46 тестов.
