### PR TITLE
Add standalone macro editor page

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -115,6 +115,8 @@ mod layout_view;
 mod live_features_settings_ui;
 #[path = "ui/magic_settings.rs"]
 mod magic_settings_ui;
+#[path = "ui/macro_settings.rs"]
+mod macro_settings_ui;
 #[path = "ui/matrix_tester.rs"]
 mod matrix_tester;
 #[path = "ui/module_settings.rs"]

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1380,6 +1380,7 @@ pub(crate) enum SettingsTab {
     AppSettings,
     MatrixTester,
     UniversalSymbolsSetup,
+    Macros,
     TextExpander,
     AutoShift,
     Rgb,

--- a/src/keycode_picker_macro.rs
+++ b/src/keycode_picker_macro.rs
@@ -9,6 +9,12 @@ const VIAL_MACRO_EXT_TAP: u8 = 5;
 const VIAL_MACRO_EXT_DOWN: u8 = 6;
 const VIAL_MACRO_EXT_UP: u8 = 7;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MacroEditorCommitMode {
+    AssignKeycodeAndClose,
+    SaveOnly,
+}
+
 fn append_macro_key_action(encoded: &mut Vec<u8>, basic_opcode: u8, ext_opcode: u8, keycode: u16) {
     encoded.push(SS_QMK_PREFIX);
     if keycode < 0x0100 {
@@ -194,6 +200,7 @@ impl KeycodePicker {
         grid_id: &'static str,
         _add_action_id: &'static str,
         _footer_text: &'static str,
+        commit_mode: MacroEditorCommitMode,
     ) -> u8 {
         let slot_count = self.macro_count.min(u8::MAX as usize + 1);
         let mut selected_macro = if slot_count > 0 && (raw_n as usize) < slot_count {
@@ -723,10 +730,7 @@ impl KeycodePicker {
                 )
                 .clicked()
                 {
-                    self.encode_macro(n);
-                    self.result = Some(0x7700 + n as u16);
-                    self.macros_dirty = true;
-                    self.open = false;
+                    self.commit_macro_editor(n, commit_mode);
                 }
             });
         });
@@ -787,6 +791,15 @@ impl KeycodePicker {
         self.macro_texts[n] = encode_macro_actions(&self.macro_actions[n]);
     }
 
+    fn commit_macro_editor(&mut self, n: usize, mode: MacroEditorCommitMode) {
+        self.encode_macro(n);
+        self.macros_dirty = true;
+        if mode == MacroEditorCommitMode::AssignKeycodeAndClose {
+            self.result = Some(0x7700 + n as u16);
+            self.open = false;
+        }
+    }
+
     pub(super) fn show_vial_macros(&mut self, ui: &mut egui::Ui) {
         let previous = self.macro_inline_selected.unwrap_or(0);
         let selected = self.show_macro_editor_contents(
@@ -795,6 +808,24 @@ impl KeycodePicker {
             "macro_grid_inline",
             "add_action_inline",
             "Saved to device when you close the keycode picker",
+            MacroEditorCommitMode::AssignKeycodeAndClose,
+        );
+        if selected != previous && (previous as usize) < self.macro_count {
+            self.encode_macro(previous as usize);
+            self.macros_dirty = true;
+        }
+        self.macro_inline_selected = Some(selected);
+    }
+
+    pub(crate) fn show_macro_settings_page(&mut self, ui: &mut egui::Ui) {
+        let previous = self.macro_inline_selected.unwrap_or(0);
+        let selected = self.show_macro_editor_contents(
+            ui,
+            previous,
+            "macro_grid_settings",
+            "add_action_settings",
+            "Saved to device when you return to the layout",
+            MacroEditorCommitMode::SaveOnly,
         );
         if selected != previous && (previous as usize) < self.macro_count {
             self.encode_macro(previous as usize);
@@ -900,5 +931,34 @@ mod tests {
             vec![MacroAction::Down(0xE0), MacroAction::Up(0xE0)]
         );
         assert_eq!(encode_macro_actions(&actions), raw_macro);
+    }
+
+    #[test]
+    fn standalone_macro_commit_saves_without_assigning_macro_keycode() {
+        let mut picker = KeycodePicker::default();
+        picker.open = true;
+        picker.result = Some(0x0004);
+        picker.macro_actions = vec![vec![MacroAction::Text("hi".into())]];
+
+        picker.commit_macro_editor(0, MacroEditorCommitMode::SaveOnly);
+
+        assert_eq!(picker.macro_texts[0].as_slice(), b"hi");
+        assert!(picker.macros_dirty);
+        assert_eq!(picker.result, Some(0x0004));
+        assert!(picker.open);
+    }
+
+    #[test]
+    fn picker_macro_commit_still_assigns_macro_keycode_and_closes() {
+        let mut picker = KeycodePicker::default();
+        picker.open = true;
+        picker.macro_actions = vec![vec![], vec![], vec![], vec![MacroAction::Text("ok".into())]];
+
+        picker.commit_macro_editor(3, MacroEditorCommitMode::AssignKeycodeAndClose);
+
+        assert_eq!(picker.macro_texts[3].as_slice(), b"ok");
+        assert!(picker.macros_dirty);
+        assert_eq!(picker.result, Some(0x7703));
+        assert!(!picker.open);
     }
 }

--- a/src/ui/layout_settings_dropdown.rs
+++ b/src/ui/layout_settings_dropdown.rs
@@ -40,6 +40,7 @@ impl EntropyApp {
             let show_touchpad_item = self.touchpad_settings.supported;
             let show_bluetooth_item = self.bluetooth_settings.supported;
             let show_live_features_item = self.live_features_available_for_selected_device();
+            let show_macros_item = self.keycode_picker.macro_count > 0;
             let show_magic_item = self.magic_settings.supported;
             let show_tap_hold_item =
                 self.tap_hold_settings.supported || self.one_shot_settings.supported;
@@ -59,6 +60,7 @@ impl EntropyApp {
                 + show_touchpad_item as usize
                 + show_bluetooth_item as usize
                 + show_live_features_item as usize
+                + show_macros_item as usize
                 + show_magic_item as usize
                 + show_tap_hold_item as usize
                 + show_lock_item as usize;
@@ -69,8 +71,12 @@ impl EntropyApp {
                 crate::i18n::tr(lang, TrKey::AppSettingsTitle),
                 crate::i18n::tr(lang, TrKey::UniversalSymbolsTitle),
             ];
+            let macros_label = crate::i18n::tr_text(lang, "Macros");
             if show_matrix_item {
                 settings_menu_labels.push(crate::i18n::tr(lang, TrKey::MatrixTesterTitle));
+            }
+            if show_macros_item {
+                settings_menu_labels.push(&macros_label);
             }
             if show_rgb_item {
                 settings_menu_labels.push(crate::i18n::tr(lang, TrKey::RgbTitle));
@@ -155,6 +161,7 @@ impl EntropyApp {
                         app_hovered,
                         matrix_hovered,
                         universal_symbols_hovered,
+                        macros_hovered,
                         rgb_hovered,
                         layer_leds_hovered,
                         encoders_hovered,
@@ -203,6 +210,16 @@ impl EntropyApp {
                                             && self.settings_tab
                                                 == SettingsTab::UniversalSymbolsSetup,
                                     );
+                                    let macros_resp = show_macros_item.then(|| {
+                                        top_dropdown_item(
+                                            ui,
+                                            item_width,
+                                            &macros_label,
+                                            true,
+                                            self.main_menu_tab == MainMenuTab::Settings
+                                                && self.settings_tab == SettingsTab::Macros,
+                                        )
+                                    });
                                     let rgb_resp = if show_rgb_item {
                                         Some(top_dropdown_item(
                                             ui,
@@ -337,6 +354,10 @@ impl EntropyApp {
                                         self.close_top_dropdowns(ui.ctx());
                                         self.open_universal_symbols_setup_page();
                                     }
+                                    if macros_resp.as_ref().map(|r| r.clicked()).unwrap_or(false) {
+                                        self.close_top_dropdowns(ui.ctx());
+                                        self.open_macro_settings_page();
+                                    }
                                     if let Some(rgb_resp) = &rgb_resp {
                                         if rgb_resp.clicked() && rgb_available {
                                             self.close_top_dropdowns(ui.ctx());
@@ -444,6 +465,10 @@ impl EntropyApp {
                                         app_resp.hovered(),
                                         matrix_resp.as_ref().map(|r| r.hovered()).unwrap_or(false),
                                         universal_symbols_resp.hovered(),
+                                        macros_resp
+                                            .as_ref()
+                                            .map(|r| r.hovered())
+                                            .unwrap_or(false),
                                         rgb_resp
                                             .as_ref()
                                             .map(|resp| resp.hovered())
@@ -486,6 +511,10 @@ impl EntropyApp {
                                                 .map(|r| r.clicked())
                                                 .unwrap_or(false)
                                             || universal_symbols_resp.clicked()
+                                            || macros_resp
+                                                .as_ref()
+                                                .map(|r| r.clicked())
+                                                .unwrap_or(false)
                                             || rgb_resp
                                                 .as_ref()
                                                 .map(|resp| resp.clicked() && rgb_available)
@@ -541,6 +570,7 @@ impl EntropyApp {
                                 || app_hovered
                                 || matrix_hovered
                                 || universal_symbols_hovered
+                                || macros_hovered
                                 || rgb_hovered
                                 || layer_leds_hovered
                                 || encoders_hovered

--- a/src/ui/macro_settings.rs
+++ b/src/ui/macro_settings.rs
@@ -1,0 +1,13 @@
+use super::*;
+
+impl EntropyApp {
+    pub(super) fn draw_macro_settings_page(&mut self, ui: &mut egui::Ui, content_rect: egui::Rect) {
+        ui.allocate_ui_at_rect(content_rect, |ui| {
+            egui::ScrollArea::vertical()
+                .auto_shrink([false, false])
+                .show(ui, |ui| {
+                    self.keycode_picker.show_macro_settings_page(ui);
+                });
+        });
+    }
+}

--- a/src/ui/settings_shell.rs
+++ b/src/ui/settings_shell.rs
@@ -40,6 +40,10 @@ impl EntropyApp {
                 self.draw_universal_symbols_setup_page(ui, content_rect);
                 false
             }
+            SettingsTab::Macros => {
+                self.draw_macro_settings_page(ui, content_rect);
+                false
+            }
             SettingsTab::TextExpander => {
                 self.draw_text_expander_settings_page(ui, content_rect);
                 false
@@ -188,6 +192,11 @@ impl EntropyApp {
 
     pub(super) fn open_about_entropy_page(&mut self) {
         self.settings_tab = SettingsTab::AboutEntropy;
+        self.main_menu_tab = MainMenuTab::Settings;
+    }
+
+    pub(super) fn open_macro_settings_page(&mut self) {
+        self.settings_tab = SettingsTab::Macros;
         self.main_menu_tab = MainMenuTab::Settings;
     }
 


### PR DESCRIPTION
## EN
### Summary
- Adds a standalone Macros page to the Settings dropdown when the connected keyboard exposes macro slots.
- Reuses the existing macro editor so macros can be selected, viewed, and edited without assigning the macro to a key.
- Splits macro editor commit behavior so the key picker still assigns `M<n>`, while the standalone page saves without changing the currently selected keycode.

### Verification
- `git diff --check`
- `/Users/igor.arkhipov/.cargo/bin/cargo build --quiet`
- `/Users/igor.arkhipov/.cargo/bin/cargo test --quiet` passes: 46 tests.

## RU
### Кратко
- Добавляет отдельную страницу Macros в меню настроек, если подключенная клавиатура поддерживает макросы.
- Переиспользует существующий редактор макросов, чтобы макросы можно было выбирать, просматривать и редактировать без назначения макроса на клавишу.
- Разделяет поведение сохранения: пикер клавиш по-прежнему назначает `M<n>`, а отдельная страница сохраняет макрос без изменения выбранного keycode.

### Проверка
- `git diff --check`
- `/Users/igor.arkhipov/.cargo/bin/cargo build --quiet`
- `/Users/igor.arkhipov/.cargo/bin/cargo test --quiet` проходит: 46 тестов.
