### PR TITLE
Sync duplicate layer LED color settings

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -867,7 +867,30 @@ impl GraveEscapeSettingsState {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct LayerLedColorSetting {
     pub(crate) qsid: u16,
+    pub(crate) linked_qsids: Vec<u16>,
     pub(crate) value: u8,
+}
+
+impl LayerLedColorSetting {
+    pub(crate) fn new(qsid: u16, value: u8) -> Self {
+        Self {
+            qsid,
+            linked_qsids: Vec::new(),
+            value,
+        }
+    }
+
+    pub(crate) fn with_linked_qsids(qsid: u16, linked_qsids: Vec<u16>, value: u8) -> Self {
+        Self {
+            qsid,
+            linked_qsids,
+            value,
+        }
+    }
+
+    pub(crate) fn all_qsids(&self) -> impl Iterator<Item = u16> + '_ {
+        std::iter::once(self.qsid).chain(self.linked_qsids.iter().copied())
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/ui/device_settings_helpers.rs
+++ b/src/ui/device_settings_helpers.rs
@@ -452,6 +452,27 @@ impl EntropyApp {
         }
     }
 
+    fn layer_led_color_qsid_groups(
+        mut entries: Vec<(usize, u16)>,
+        layer_count: usize,
+    ) -> Vec<(usize, Vec<u16>)> {
+        entries.sort_by_key(|(layer, qsid)| (*layer, *qsid));
+        let mut groups = Vec::<(usize, Vec<u16>)>::new();
+        for (layer, qsid) in entries {
+            if layer >= layer_count {
+                continue;
+            }
+            if let Some((_, qsids)) = groups.iter_mut().find(|(existing, _)| *existing == layer) {
+                if !qsids.contains(&qsid) {
+                    qsids.push(qsid);
+                }
+            } else {
+                groups.push((layer, vec![qsid]));
+            }
+        }
+        groups
+    }
+
     fn layer_led_field_width(field: &serde_json::Value) -> u8 {
         field
             .get("width")
@@ -606,24 +627,28 @@ impl EntropyApp {
         let bt_profile_colors = bt_profiles
             .into_iter()
             .filter(|(profile, _)| *profile <= 4)
-            .map(|(_, qsid)| LayerLedColorSetting {
-                qsid,
-                value: dev_conn.get_qmk_setting_u8(qsid).unwrap_or_else(|e| {
+            .map(|(_, qsid)| {
+                let value = dev_conn.get_qmk_setting_u8(qsid).unwrap_or_else(|e| {
                     log::warn!("get_qmk_setting_u8(layer_led bt profile qsid {qsid}): {e}");
                     0
-                }),
+                });
+                LayerLedColorSetting::new(qsid, value)
             })
             .collect::<Vec<_>>();
 
-        let layer_colors = layers
+        let layer_colors = Self::layer_led_color_qsid_groups(layers, layer_count)
             .into_iter()
-            .filter(|(layer, _)| *layer < layer_count)
-            .map(|(_, qsid)| LayerLedColorSetting {
-                qsid,
-                value: dev_conn.get_qmk_setting_u8(qsid).unwrap_or_else(|e| {
+            .filter_map(|(_, qsids)| {
+                let (&qsid, linked_qsids) = qsids.split_first()?;
+                let value = dev_conn.get_qmk_setting_u8(qsid).unwrap_or_else(|e| {
                     log::warn!("get_qmk_setting_u8(layer_led layer qsid {qsid}): {e}");
                     0
-                }),
+                });
+                Some(LayerLedColorSetting::with_linked_qsids(
+                    qsid,
+                    linked_qsids.to_vec(),
+                    value,
+                ))
             })
             .collect::<Vec<_>>();
 
@@ -666,7 +691,8 @@ impl EntropyApp {
                 log::warn!("get_qmk_setting_u8(layer_led qsid {qsid}): {e}");
                 0
             });
-            leds.layer_colors.push(LayerLedColorSetting { qsid, value });
+            leds.layer_colors
+                .push(LayerLedColorSetting::new(qsid, value));
         }
         leds.supported = !leds.layer_colors.is_empty();
         if leds.supported {
@@ -1063,5 +1089,30 @@ impl EntropyApp {
             packed = (packed << width.min(31)) | (values.get(idx).copied().unwrap_or(0) & mask);
         }
         packed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn layer_led_color_qsid_groups_collapse_duplicate_layer_entries() {
+        let groups = EntropyApp::layer_led_color_qsid_groups(
+            vec![(0, 300), (1, 301), (0, 400), (1, 401)],
+            4,
+        );
+
+        assert_eq!(groups, vec![(0, vec![300, 400]), (1, vec![301, 401])]);
+    }
+
+    #[test]
+    fn layer_led_color_qsid_groups_ignore_out_of_range_layers_and_duplicate_qsids() {
+        let groups = EntropyApp::layer_led_color_qsid_groups(
+            vec![(0, 300), (2, 302), (1, 301), (1, 301)],
+            2,
+        );
+
+        assert_eq!(groups, vec![(0, vec![300]), (1, vec![301])]);
     }
 }

--- a/src/ui/layer_led_settings.rs
+++ b/src/ui/layer_led_settings.rs
@@ -439,7 +439,7 @@ impl EntropyApp {
         target: LayerLedColorTarget,
         setting: LayerLedColorSetting,
     ) {
-        let qsid = setting.qsid;
+        let qsids = setting.all_qsids().collect::<Vec<_>>();
         let current = setting.value;
         crate::ui_style::settings_list_row_with_tooltip(
             ui,
@@ -594,7 +594,7 @@ impl EntropyApp {
                                                 }
                                             }
                                         }
-                                        self.write_layer_led_color(qsid, color_idx_u8);
+                                        self.write_layer_led_color(&qsids, color_idx_u8);
                                         ui.memory_mut(|m| m.close_popup());
                                     }
                                 }
@@ -606,13 +606,15 @@ impl EntropyApp {
         );
     }
 
-    fn write_layer_led_color(&mut self, qsid: u16, value: u8) {
+    fn write_layer_led_color(&mut self, qsids: &[u16], value: u8) {
         let Some(hid) = &self.hid_device else {
             return;
         };
-        if let Err(e) = hid.set_qmk_setting_u8(qsid, value) {
-            self.status_msg = format!("Failed to save Layer LED color: {}", e);
-            log::warn!("set_qmk_setting_u8(layer_led qsid {qsid}) failed: {e}");
+        for qsid in qsids {
+            if let Err(e) = hid.set_qmk_setting_u8(*qsid, value) {
+                self.status_msg = format!("Failed to save Layer LED color: {}", e);
+                log::warn!("set_qmk_setting_u8(layer_led qsid {qsid}) failed: {e}");
+            }
         }
     }
 


### PR DESCRIPTION
## EN
### Summary
- Collapses duplicate firmware `Layer N color` qsid entries into one visible logical layer row in Layer LEDs settings.
- Keeps linked qsids for that logical layer and writes the selected palette value to all of them, preventing split halves from drifting apart.
- Adds regression coverage for duplicate layer qsid grouping, out-of-range layers, and duplicate qsid filtering.

### Verification
- `git diff --check`
- `/Users/igor.arkhipov/.cargo/bin/cargo build --quiet`
- `/Users/igor.arkhipov/.cargo/bin/cargo test --quiet` passes: 46 tests.

## RU
### Кратко
- Сворачивает повторяющиеся записи `Layer N color` прошивки с разными qsid в одну видимую строку логического слоя в настройках Layer LEDs.
- Сохраняет связанные qsid для этого слоя и записывает выбранный цвет палитры во все из них, чтобы половинки сплита не расходились по цветам.
- Добавляет регрессионные тесты для группировки повторяющихся qsid слоев, пропуска слоёв вне диапазона и фильтрации повторяющихся qsid.

### Проверка
- `git diff --check`
- `/Users/igor.arkhipov/.cargo/bin/cargo build --quiet`
- `/Users/igor.arkhipov/.cargo/bin/cargo test --quiet` проходит: 46 тестов.
