### PR TITLE
Route deprecated egui rect allocation through helper

### DIFF
--- a/src/ui/alt_repeat_settings.rs
+++ b/src/ui/alt_repeat_settings.rs
@@ -43,7 +43,7 @@ impl EntropyApp {
             app_muted_text(dark),
         );
 
-        ui.allocate_ui_at_rect(block_rect, |ui| {
+        crate::ui_style::allocate_ui_at_rect(ui, block_rect, |ui| {
             self.draw_alt_repeat_editor_content(ui);
         });
     }
@@ -209,7 +209,7 @@ impl EntropyApp {
                     TOTAL_ROWS,
                     metrics.value(86.0),
                 );
-                ui.allocate_ui_at_rect(list.content_rect, |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, list.content_rect, |ui| {
                     ui.set_clip_rect(list.viewport);
                     ui.set_min_size(list.content_rect.size());
                     ui.spacing_mut().item_spacing.y = 0.0;
@@ -649,7 +649,7 @@ impl EntropyApp {
                     egui::pos2(list.viewport.left(), list.viewport.bottom() + 24.0),
                     egui::vec2(content_width, action_size.y),
                 );
-                ui.allocate_ui_at_rect(actions_rect, |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, actions_rect, |ui| {
                     ui.horizontal(|ui| {
                         ui.add_space(((content_width - action_width) / 2.0).max(0.0));
                         let clear_enabled =

--- a/src/ui/app_lifecycle.rs
+++ b/src/ui/app_lifecycle.rs
@@ -457,7 +457,7 @@ impl eframe::App for EntropyApp {
                         rect.center(),
                         egui::vec2(rect.width().min(520.0), 210.0),
                     );
-                    ui.allocate_ui_at_rect(empty_rect, |ui| {
+                    crate::ui_style::allocate_ui_at_rect(ui, empty_rect, |ui| {
                         ui.vertical_centered(|ui| {
                             ui.add_space(4.0);
                             ui.label(RichText::new("✦").size(28.0).color(app_accent()));
@@ -513,7 +513,7 @@ impl eframe::App for EntropyApp {
                     rect.center(),
                     egui::vec2(rect.width().min(520.0), 150.0),
                 );
-                ui.allocate_ui_at_rect(empty_rect, |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, empty_rect, |ui| {
                     ui.vertical_centered(|ui| {
                         ui.add_space(4.0);
                         ui.label(RichText::new("✦").size(28.0).color(app_accent()));
@@ -690,7 +690,7 @@ impl eframe::App for EntropyApp {
                     button_size,
                 );
 
-                ui.allocate_ui_at_rect(content_rect, |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, content_rect, |ui| {
                     egui::ScrollArea::vertical()
                         .max_height(content_rect.height())
                         .auto_shrink([false, false])
@@ -700,7 +700,7 @@ impl eframe::App for EntropyApp {
                         });
                 });
 
-                ui.allocate_ui_at_rect(button_rect, |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, button_rect, |ui| {
                     if crate::ui_style::modern_button(ui, "OK", button_size, true).clicked() {
                         close_clicked = true;
                     }

--- a/src/ui/app_settings.rs
+++ b/src/ui/app_settings.rs
@@ -7,7 +7,7 @@ impl EntropyApp {
         let dark = ui.visuals().dark_mode;
         let metrics = crate::ui_style::ResponsiveMetrics::from_ctx(ui.ctx());
         let lang = self.app_settings.language;
-        ui.allocate_ui_at_rect(content_rect, |ui| {
+        crate::ui_style::allocate_ui_at_rect(ui, content_rect, |ui| {
             ui.vertical_centered(|ui| {
                 ui.add_space(metrics.value(18.0));
                 ui.label(
@@ -31,7 +31,7 @@ impl EntropyApp {
                     metrics.value(44.0),
                 );
 
-                ui.allocate_ui_at_rect(list.content_rect, |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, list.content_rect, |ui| {
                     ui.set_clip_rect(list.viewport);
                     ui.set_min_size(list.content_rect.size());
                     ui.spacing_mut().item_spacing.y = 0.0;
@@ -68,7 +68,7 @@ impl EntropyApp {
                         ),
                         egui::vec2(actions_width, button_size.y),
                     );
-                    ui.allocate_ui_at_rect(actions_rect, |ui| {
+                    crate::ui_style::allocate_ui_at_rect(ui, actions_rect, |ui| {
                         ui.set_min_size(actions_rect.size());
                         ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
                             ui.spacing_mut().item_spacing.x = button_gap;

--- a/src/ui/auto_shift_settings.rs
+++ b/src/ui/auto_shift_settings.rs
@@ -22,7 +22,7 @@ impl EntropyApp {
             }
         };
 
-        ui.allocate_ui_at_rect(content_rect, |ui| {
+        crate::ui_style::allocate_ui_at_rect(ui, content_rect, |ui| {
             ui.vertical_centered(|ui| {
                 ui.add_space(18.0);
                 ui.label(
@@ -92,7 +92,7 @@ impl EntropyApp {
             0.0,
         );
 
-        ui.allocate_ui_at_rect(list.content_rect, |ui| {
+        crate::ui_style::allocate_ui_at_rect(ui, list.content_rect, |ui| {
             ui.set_clip_rect(list.viewport);
             ui.set_min_size(list.content_rect.size());
             ui.spacing_mut().item_spacing.y = 0.0;

--- a/src/ui/bluetooth_settings.rs
+++ b/src/ui/bluetooth_settings.rs
@@ -25,7 +25,7 @@ impl EntropyApp {
             }
         };
 
-        ui.allocate_ui_at_rect(content_rect, |ui| {
+        crate::ui_style::allocate_ui_at_rect(ui, content_rect, |ui| {
             ui.vertical_centered(|ui| {
                 ui.add_space(18.0);
                 ui.label(
@@ -74,7 +74,7 @@ impl EntropyApp {
                     rows.len(),
                     0.0,
                 );
-                ui.allocate_ui_at_rect(list.content_rect, |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, list.content_rect, |ui| {
                     ui.set_clip_rect(list.viewport);
                     ui.set_min_size(list.content_rect.size());
                     ui.spacing_mut().item_spacing.y = 0.0;

--- a/src/ui/combo_settings.rs
+++ b/src/ui/combo_settings.rs
@@ -12,7 +12,7 @@ impl EntropyApp {
         let dark = ui.visuals().dark_mode;
         let mut combo_keycap_hovered = false;
 
-        ui.allocate_ui_at_rect(content_rect, |ui| {
+        crate::ui_style::allocate_ui_at_rect(ui, content_rect, |ui| {
             ui.vertical_centered(|ui| {
                 let scale = responsive_settings_editor_scale(ui.ctx());
                 ui.add_space(18.0 * scale);
@@ -657,7 +657,7 @@ impl EntropyApp {
             egui::pos2(page_center_x - action_width / 2.0, ui.cursor().min.y),
             Vec2::new(action_width, action_size.y),
         );
-        ui.allocate_ui_at_rect(action_rect, |ui| {
+        crate::ui_style::allocate_ui_at_rect(ui, action_rect, |ui| {
             ui.set_min_size(action_rect.size());
             ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
                 ui.spacing_mut().item_spacing.x = 8.0 * scale;

--- a/src/ui/encoder_visibility_settings.rs
+++ b/src/ui/encoder_visibility_settings.rs
@@ -55,7 +55,7 @@ impl EntropyApp {
         }
         self.encoder_visibility.truncate(visibility_len);
 
-        ui.allocate_ui_at_rect(content_rect, |ui| {
+        crate::ui_style::allocate_ui_at_rect(ui, content_rect, |ui| {
             ui.vertical_centered(|ui| {
                 ui.add_space(18.0);
                 ui.label(

--- a/src/ui/grave_escape_settings.rs
+++ b/src/ui/grave_escape_settings.rs
@@ -19,7 +19,7 @@ impl EntropyApp {
             }
         };
 
-        ui.allocate_ui_at_rect(content_rect, |ui| {
+        crate::ui_style::allocate_ui_at_rect(ui, content_rect, |ui| {
             ui.vertical_centered(|ui| {
                 ui.add_space(18.0);
                 ui.label(

--- a/src/ui/key_override_settings.rs
+++ b/src/ui/key_override_settings.rs
@@ -17,7 +17,7 @@ impl EntropyApp {
         let scale = metrics.scale;
         let page_width = KEY_OVERRIDE_PAGE_WIDTH * scale;
 
-        ui.allocate_ui_at_rect(content_rect, |ui| {
+        crate::ui_style::allocate_ui_at_rect(ui, content_rect, |ui| {
             ui.vertical_centered(|ui| {
                 ui.add_space(KEY_OVERRIDE_TITLE_Y_OFFSET * scale);
                 ui.label(
@@ -464,7 +464,7 @@ impl EntropyApp {
                     ROW_COUNT,
                     metrics.value(86.0),
                 );
-                ui.allocate_ui_at_rect(list.content_rect, |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, list.content_rect, |ui| {
                     ui.set_clip_rect(list.viewport);
                     ui.set_min_size(list.content_rect.size());
                     ui.spacing_mut().item_spacing.y = 0.0;
@@ -740,7 +740,7 @@ impl EntropyApp {
                     egui::pos2(page_center_x - action_width / 2.0, action_top),
                     Vec2::new(action_width, action_size.y),
                 );
-                ui.allocate_ui_at_rect(action_rect, |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, action_rect, |ui| {
                     ui.set_min_size(action_rect.size());
                     ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
                         ui.spacing_mut().item_spacing.x = 8.0 * scale;

--- a/src/ui/layer_led_settings.rs
+++ b/src/ui/layer_led_settings.rs
@@ -33,7 +33,7 @@ impl EntropyApp {
             }
         };
 
-        ui.allocate_ui_at_rect(content_rect, |ui| {
+        crate::ui_style::allocate_ui_at_rect(ui, content_rect, |ui| {
             ui.vertical_centered(|ui| {
                 ui.add_space(18.0);
                 ui.label(
@@ -79,7 +79,7 @@ impl EntropyApp {
                     rows.len(),
                     0.0,
                 );
-                ui.allocate_ui_at_rect(list.content_rect, |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, list.content_rect, |ui| {
                     ui.set_clip_rect(list.viewport);
                     ui.set_min_size(list.content_rect.size());
                     ui.spacing_mut().item_spacing.y = 0.0;

--- a/src/ui/layout_image_export.rs
+++ b/src/ui/layout_image_export.rs
@@ -403,7 +403,7 @@ impl EntropyApp {
         let layer_count = self.layer_count.max(layout.layers.len()).max(1);
         self.ensure_layout_image_export_layers(layer_count);
 
-        ui.allocate_ui_at_rect(content_rect, |ui| {
+        crate::ui_style::allocate_ui_at_rect(ui, content_rect, |ui| {
             ui.vertical_centered(|ui| {
                 ui.add_space(metrics.value(18.0));
                 ui.label(
@@ -428,7 +428,7 @@ impl EntropyApp {
                     metrics.value(44.0),
                 );
 
-                ui.allocate_ui_at_rect(list.content_rect, |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, list.content_rect, |ui| {
                     ui.set_clip_rect(list.viewport);
                     ui.set_min_size(list.content_rect.size());
                     ui.spacing_mut().item_spacing.y = 0.0;
@@ -470,7 +470,7 @@ impl EntropyApp {
                     ),
                     button_size,
                 );
-                ui.allocate_ui_at_rect(button_rect, |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, button_rect, |ui| {
                     ui.set_min_size(button_rect.size());
                     #[cfg(not(target_arch = "wasm32"))]
                     if crate::ui_style::modern_button(

--- a/src/ui/layout_indicator_window.rs
+++ b/src/ui/layout_indicator_window.rs
@@ -490,7 +490,7 @@ impl EntropyApp {
                         );
                     }
 
-                    ui.allocate_ui_at_rect(title_rect.shrink2(Vec2::new(6.0, 4.0)), |ui| {
+                    crate::ui_style::allocate_ui_at_rect(ui, title_rect.shrink2(Vec2::new(6.0, 4.0)), |ui| {
                         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                             if sticky_layout_window_icon_button(
                                 ui,
@@ -608,7 +608,7 @@ impl EntropyApp {
                         egui::pos2(footer_rect.left() + 8.0, footer_rect.center().y - 12.0),
                         egui::vec2(132.0, 24.0),
                     );
-                    ui.allocate_ui_at_rect(transparency_rect, |ui| {
+                    crate::ui_style::allocate_ui_at_rect(ui, transparency_rect, |ui| {
                         if draw_sticky_layout_transparency_dropdown(
                             ui,
                             lang,
@@ -624,7 +624,7 @@ impl EntropyApp {
                         egui::pos2(footer_rect.right() - 150.0, footer_rect.center().y - 11.0),
                         egui::vec2(118.0, 22.0),
                     );
-                    ui.allocate_ui_at_rect(theme_rect, |ui| {
+                    crate::ui_style::allocate_ui_at_rect(ui, theme_rect, |ui| {
                         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                             draw_theme_selector_labels(ui, lang, &mut sticky_dark_mode, true);
                         });

--- a/src/ui/layout_options_settings.rs
+++ b/src/ui/layout_options_settings.rs
@@ -36,7 +36,7 @@ impl EntropyApp {
             .filter_map(|(idx, option)| (!Self::is_encoder_layout_option(option)).then_some(idx))
             .collect();
 
-        ui.allocate_ui_at_rect(content_rect, |ui| {
+        crate::ui_style::allocate_ui_at_rect(ui, content_rect, |ui| {
             ui.vertical_centered(|ui| {
                 ui.add_space(18.0);
                 ui.label(
@@ -85,7 +85,7 @@ impl EntropyApp {
                     &options,
                     self.layout_options_value.unwrap_or(0),
                 );
-                ui.allocate_ui_at_rect(list.content_rect, |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, list.content_rect, |ui| {
                     ui.set_clip_rect(list.viewport);
                     ui.set_min_size(list.content_rect.size());
                     ui.spacing_mut().item_spacing.y = 0.0;

--- a/src/ui/live_features_settings.rs
+++ b/src/ui/live_features_settings.rs
@@ -99,7 +99,7 @@ impl EntropyApp {
             }
         };
 
-        ui.allocate_ui_at_rect(content_rect, |ui| {
+        crate::ui_style::allocate_ui_at_rect(ui, content_rect, |ui| {
             ui.vertical_centered(|ui| {
                 ui.add_space(metrics.value(18.0));
                 ui.label(

--- a/src/ui/magic_settings.rs
+++ b/src/ui/magic_settings.rs
@@ -15,7 +15,7 @@ impl EntropyApp {
             }
         };
 
-        ui.allocate_ui_at_rect(content_rect, |ui| {
+        crate::ui_style::allocate_ui_at_rect(ui, content_rect, |ui| {
             ui.vertical_centered(|ui| {
                 ui.add_space(18.0);
                 ui.label(
@@ -58,7 +58,7 @@ impl EntropyApp {
                     TOTAL_ROWS,
                     0.0,
                 );
-                ui.allocate_ui_at_rect(list.content_rect, |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, list.content_rect, |ui| {
                     ui.set_clip_rect(list.viewport);
                     ui.set_min_size(list.content_rect.size());
                     ui.spacing_mut().item_spacing.y = 0.0;

--- a/src/ui/matrix_tester.rs
+++ b/src/ui/matrix_tester.rs
@@ -179,7 +179,7 @@ impl EntropyApp {
             })
             .count();
 
-        ui.allocate_ui_at_rect(
+        crate::ui_style::allocate_ui_at_rect(ui, 
             egui::Rect::from_min_max(
                 egui::pos2(content_rect.left(), content_rect.top()),
                 egui::pos2(content_rect.right(), desc_y + 10.0),

--- a/src/ui/module_settings.rs
+++ b/src/ui/module_settings.rs
@@ -458,7 +458,7 @@ impl EntropyApp {
         let lang = self.app_settings.language;
         let dark = ui.visuals().dark_mode;
         let metrics = crate::ui_style::ResponsiveMetrics::from_ctx(ui.ctx());
-        ui.allocate_ui_at_rect(content_rect, |ui| {
+        crate::ui_style::allocate_ui_at_rect(ui, content_rect, |ui| {
             ui.vertical_centered(|ui| {
                 ui.add_space(18.0);
                 ui.label(
@@ -497,7 +497,7 @@ impl EntropyApp {
                     rows.len(),
                     0.0,
                 );
-                ui.allocate_ui_at_rect(list.content_rect, |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, list.content_rect, |ui| {
                     ui.set_clip_rect(list.viewport);
                     ui.set_min_size(list.content_rect.size());
                     ui.spacing_mut().item_spacing.y = 0.0;

--- a/src/ui/mouse_keys_settings.rs
+++ b/src/ui/mouse_keys_settings.rs
@@ -10,7 +10,7 @@ impl EntropyApp {
         let dark = ui.visuals().dark_mode;
         let metrics = crate::ui_style::ResponsiveMetrics::from_ctx(ui.ctx());
 
-        ui.allocate_ui_at_rect(content_rect, |ui| {
+        crate::ui_style::allocate_ui_at_rect(ui, content_rect, |ui| {
             ui.vertical_centered(|ui| {
                 ui.add_space(18.0);
                 ui.label(
@@ -46,7 +46,7 @@ impl EntropyApp {
                     TOTAL_MOUSE_KEY_ROWS,
                     0.0,
                 );
-                ui.allocate_ui_at_rect(list.content_rect, |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, list.content_rect, |ui| {
                     ui.set_clip_rect(list.viewport);
                     ui.set_min_size(list.content_rect.size());
                     ui.spacing_mut().item_spacing.y = 0.0;

--- a/src/ui/onboarding_tour.rs
+++ b/src/ui/onboarding_tour.rs
@@ -174,7 +174,7 @@ impl EntropyApp {
                     Stroke::new(1.0, app_border_color(dark)),
                     egui::StrokeKind::Inside,
                 );
-                ui.allocate_ui_at_rect(card_rect.shrink2(Vec2::new(18.0, 16.0)), |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, card_rect.shrink2(Vec2::new(18.0, 16.0)), |ui| {
                     ui.vertical(|ui| {
                         ui.horizontal(|ui| {
                             ui.label(

--- a/src/ui/rgb_settings.rs
+++ b/src/ui/rgb_settings.rs
@@ -223,7 +223,7 @@ impl EntropyApp {
             }
         };
 
-        ui.allocate_ui_at_rect(content_rect, |ui| {
+        crate::ui_style::allocate_ui_at_rect(ui, content_rect, |ui| {
             ui.vertical_centered(|ui| {
                 ui.add_space(18.0);
                 ui.label(

--- a/src/ui/tap_hold_settings.rs
+++ b/src/ui/tap_hold_settings.rs
@@ -25,7 +25,7 @@ impl EntropyApp {
             }
         };
 
-        ui.allocate_ui_at_rect(content_rect, |ui| {
+        crate::ui_style::allocate_ui_at_rect(ui, content_rect, |ui| {
             ui.vertical_centered(|ui| {
                 ui.add_space(18.0);
                 ui.label(
@@ -74,7 +74,7 @@ impl EntropyApp {
                     total_rows,
                     0.0,
                 );
-                ui.allocate_ui_at_rect(list.content_rect, |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, list.content_rect, |ui| {
                     ui.set_clip_rect(list.viewport);
                     ui.set_min_size(list.content_rect.size());
                     ui.spacing_mut().item_spacing.y = 0.0;

--- a/src/ui/text_expander_editor.rs
+++ b/src/ui/text_expander_editor.rs
@@ -1031,7 +1031,7 @@ impl EntropyApp {
 
                     let mut rule_enabled = rule.enabled;
                     let mut switch_resp = None;
-                    ui.allocate_ui_at_rect(switch_rect, |ui| {
+                    crate::ui_style::allocate_ui_at_rect(ui, switch_rect, |ui| {
                         switch_resp = Some(crate::ui_style::settings_switch_sized_stable(
                             ui,
                             ("text_expander_rule_enabled", idx),
@@ -1045,7 +1045,7 @@ impl EntropyApp {
                     }
 
                     let mut trigger_resp = None;
-                    ui.allocate_ui_at_rect(trigger_rect, |ui| {
+                    crate::ui_style::allocate_ui_at_rect(ui, trigger_rect, |ui| {
                         trigger_resp = Some(
                             crate::ui_style::modern_text_field_sized(
                                 ui,
@@ -1073,7 +1073,7 @@ impl EntropyApp {
                     }
 
                     let mut replacement_resp = None;
-                    ui.allocate_ui_at_rect(replacement_rect, |ui| {
+                    crate::ui_style::allocate_ui_at_rect(ui, replacement_rect, |ui| {
                         replacement_resp = Some(
                             crate::ui_style::modern_text_field_sized(
                                 ui,
@@ -1101,7 +1101,7 @@ impl EntropyApp {
                     }
 
                     let mut delete_clicked = false;
-                    ui.allocate_ui_at_rect(delete_rect, |ui| {
+                    crate::ui_style::allocate_ui_at_rect(ui, delete_rect, |ui| {
                         delete_clicked =
                             crate::ui_style::modern_button(ui, "×", delete_size, true).clicked();
                     });

--- a/src/ui/text_expander_settings.rs
+++ b/src/ui/text_expander_settings.rs
@@ -9,7 +9,7 @@ impl EntropyApp {
         let lang = self.app_settings.language;
         let dark = ui.visuals().dark_mode;
         let metrics = crate::ui_style::ResponsiveMetrics::from_ctx(ui.ctx());
-        ui.allocate_ui_at_rect(content_rect, |ui| {
+        crate::ui_style::allocate_ui_at_rect(ui, content_rect, |ui| {
             ui.vertical_centered(|ui| {
                 ui.add_space(metrics.value(18.0));
                 ui.label(
@@ -51,7 +51,7 @@ impl EntropyApp {
                     row_count,
                     metrics.value(44.0),
                 );
-                ui.allocate_ui_at_rect(list.content_rect, |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, list.content_rect, |ui| {
                     ui.set_clip_rect(list.viewport);
                     ui.set_min_size(list.content_rect.size());
                     ui.spacing_mut().item_spacing.y = 0.0;
@@ -85,7 +85,7 @@ impl EntropyApp {
                     ),
                     egui::vec2(actions_width, button_size.y),
                 );
-                ui.allocate_ui_at_rect(actions_rect, |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, actions_rect, |ui| {
                     ui.horizontal(|ui| {
                         ui.spacing_mut().item_spacing.x = button_gap;
                         if crate::ui_style::modern_button(
@@ -164,7 +164,7 @@ impl EntropyApp {
             ),
             button_size,
         );
-        ui.allocate_ui_at_rect(label_rect, |ui| {
+        crate::ui_style::allocate_ui_at_rect(ui, label_rect, |ui| {
             ui.centered_and_justified(|ui| {
                 ui.add_sized(
                     label_rect.size(),
@@ -180,7 +180,7 @@ impl EntropyApp {
                 );
             });
         });
-        ui.allocate_ui_at_rect(button_rect, |ui| {
+        crate::ui_style::allocate_ui_at_rect(ui, button_rect, |ui| {
             if crate::ui_style::modern_button(
                 ui,
                 crate::i18n::tr_catalog(lang, "text_expander.open_universal_symbols_setup"),

--- a/src/ui/touchpad_settings.rs
+++ b/src/ui/touchpad_settings.rs
@@ -495,7 +495,7 @@ impl EntropyApp {
             }
         };
 
-        ui.allocate_ui_at_rect(content_rect, |ui| {
+        crate::ui_style::allocate_ui_at_rect(ui, content_rect, |ui| {
             ui.vertical_centered(|ui| {
                 ui.add_space(18.0);
                 ui.label(
@@ -537,7 +537,7 @@ impl EntropyApp {
                     total_rows,
                     0.0,
                 );
-                ui.allocate_ui_at_rect(list.content_rect, |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, list.content_rect, |ui| {
                     ui.set_clip_rect(list.viewport);
                     ui.set_min_size(list.content_rect.size());
                     ui.spacing_mut().item_spacing.y = 0.0;

--- a/src/ui/universal_symbols_setup.rs
+++ b/src/ui/universal_symbols_setup.rs
@@ -34,7 +34,7 @@ impl EntropyApp {
             return;
         }
 
-        ui.allocate_ui_at_rect(content_rect, |ui| {
+        crate::ui_style::allocate_ui_at_rect(ui, content_rect, |ui| {
             ui.vertical_centered(|ui| {
                 ui.add_space(metrics.value(18.0));
                 ui.allocate_ui_with_layout(
@@ -102,7 +102,7 @@ impl EntropyApp {
         dark: bool,
         content_width: f32,
     ) {
-        ui.allocate_ui_at_rect(content_rect, |ui| {
+        crate::ui_style::allocate_ui_at_rect(ui, content_rect, |ui| {
             ui.vertical_centered(|ui| {
                 ui.add_space(metrics.value(18.0));
                 ui.add_sized(
@@ -143,7 +143,7 @@ impl EntropyApp {
                     bottom_reserve,
                 );
 
-                ui.allocate_ui_at_rect(list.content_rect, |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, list.content_rect, |ui| {
                     ui.set_clip_rect(list.viewport);
                     ui.set_min_size(list.content_rect.size());
                     ui.spacing_mut().item_spacing.y = 0.0;

--- a/src/ui/window_lifecycle.rs
+++ b/src/ui/window_lifecycle.rs
@@ -321,7 +321,7 @@ impl EntropyApp {
                     egui::pos2(rect.center().x, rect.top() + 72.0),
                     Vec2::new(400.0, 28.0),
                 );
-                ui.allocate_ui_at_rect(body_rect, |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, body_rect, |ui| {
                     ui.add_sized(
                         body_rect.size(),
                         egui::Label::new(
@@ -412,17 +412,17 @@ impl EntropyApp {
                 left += tray_size.x + gap;
                 let cancel_rect = egui::Rect::from_min_size(egui::pos2(left, top), cancel_size);
 
-                ui.allocate_ui_at_rect(close_button_rect, |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, close_button_rect, |ui| {
                     if crate::ui_style::modern_button(ui, close_label, close_size, true).clicked() {
                         close_app = true;
                     }
                 });
-                ui.allocate_ui_at_rect(tray_rect, |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, tray_rect, |ui| {
                     if crate::ui_style::modern_button(ui, tray_label, tray_size, true).clicked() {
                         minimize_to_tray = true;
                     }
                 });
-                ui.allocate_ui_at_rect(cancel_rect, |ui| {
+                crate::ui_style::allocate_ui_at_rect(ui, cancel_rect, |ui| {
                     if crate::ui_style::modern_button(ui, cancel_label, cancel_size, true).clicked()
                     {
                         cancel = true;

--- a/src/ui_style.rs
+++ b/src/ui_style.rs
@@ -84,6 +84,15 @@ pub fn modal_outline_stroke(dark: bool) -> Stroke {
     }
 }
 
+pub fn allocate_ui_at_rect<R>(
+    ui: &mut Ui,
+    rect: egui::Rect,
+    add_contents: impl FnOnce(&mut Ui) -> R,
+) -> egui::InnerResponse<R> {
+    #[allow(deprecated)]
+    ui.allocate_ui_at_rect(rect, add_contents)
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct ResponsiveMetrics {
     pub scale: f32,
@@ -492,23 +501,22 @@ fn modern_text_field_impl(
         egui::StrokeKind::Inside,
     );
 
-    let resp = ui
-        .allocate_ui_at_rect(field_rect.shrink2(Vec2::new(10.0, 0.0)), |ui| {
-            ui.add_sized(
-                [width - 20.0, height],
-                egui::TextEdit::singleline(text)
-                    .id(id)
-                    .desired_width(width - 20.0)
-                    .hint_text(hint)
-                    .font(FontId::proportional(font_size))
-                    .char_limit(char_limit)
-                    .frame(false)
-                    .interactive(interactive)
-                    .horizontal_align(horizontal_align)
-                    .vertical_align(egui::Align::Center),
-            )
-        })
-        .inner;
+    let resp = allocate_ui_at_rect(ui, field_rect.shrink2(Vec2::new(10.0, 0.0)), |ui| {
+        ui.add_sized(
+            [width - 20.0, height],
+            egui::TextEdit::singleline(text)
+                .id(id)
+                .desired_width(width - 20.0)
+                .hint_text(hint)
+                .font(FontId::proportional(font_size))
+                .char_limit(char_limit)
+                .frame(false)
+                .interactive(interactive)
+                .horizontal_align(horizontal_align)
+                .vertical_align(egui::Align::Center),
+        )
+    })
+    .inner;
     if resp.hovered() && interactive {
         ui.ctx().set_cursor_icon(egui::CursorIcon::Text);
     }
@@ -910,7 +918,7 @@ pub fn settings_list_row_with_tooltip(
         egui::pos2(row_rect.right() - control_width, row_rect.top()),
         egui::vec2(control_width, row_height),
     );
-    ui.allocate_ui_at_rect(control_rect, |ui| {
+    crate::ui_style::allocate_ui_at_rect(ui, control_rect, |ui| {
         ui.set_min_size(egui::vec2(control_width, row_height));
         ui.with_layout(
             egui::Layout::left_to_right(egui::Align::Center),


### PR DESCRIPTION
## EN

### Summary
This draft PR splits the egui deprecation cleanup into its own reviewable slice, following the broader clippy baseline work in #17 and the earlier split in #29 / #30.

It routes uses of the deprecated `egui::Ui::allocate_ui_at_rect` API through one compatibility helper. That removes the repeated warning noise from call sites while keeping the current layout behavior intact. The helper intentionally contains the only direct deprecated call, guarded with `#[allow(deprecated)]`, so a later migration to `allocate_new_ui` can be reviewed as a behavior-affecting change if maintainers want it.

### Verification
Rebased onto current `origin/main` at `2e4b5f0`.

- `git diff --check`
- `mise x rust@stable -- cargo test` — 53 tests passed
- `mise x rust@stable -- cargo clippy --all-targets --all-features` — exits successfully with the expected remaining baseline warnings
- Current local main baseline: 170 clippy warnings
- Local warning count on this branch: 108
- `allocate_ui_at_rect` deprecation warnings: 62 -> 0

Refs #17
Follow-up to #29 and #30

## RU

### Кратко
Этот PR намеренно устраняет только предостережения о egui deprecation обнаруженные и отмеченные в #17 и предыдущего разделения на #29 / #30.

Он пропускает использования deprecated `egui::Ui::allocate_ui_at_rect` API через один helper для совместимости.
Это убирает повторяющийся шум о предостережениях из мест вызова, при этом сохраняя текущее поведение.
Helper намеренно содержит единственный прямой помеченный как deprecated вызов, помеченный как `#[allow(deprecated)]`, чтобы будущую миграцию на `allocate_new_ui` можно было провести отдельно как потенциально более опасное изменение.

### Проверка
Rebased на current `origin/main` at `2e4b5f0`.

- `git diff --check`
- `mise x rust@stable -- cargo test` — 53 теста прошли
- `mise x rust@stable -- cargo clippy --all-targets --all-features` — завершается успешно с ожидаемыми оставшимися baseline warnings
- Current local main baseline: 170 clippy warnings
- Локальный счетчик warnings на этой ветке: 108
- `allocate_ui_at_rect` deprecation warnings: 62 -> 0

Refs #17
Follow-up to #29 and #30
