### PR TITLE
Factor complex clippy types

### DIFF
--- a/src/keycode_picker_popups.rs
+++ b/src/keycode_picker_popups.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+type PopupChoice = (u16, String, String);
+type PopupChoiceGroup = (&'static str, Vec<PopupChoice>);
+
 pub(super) fn popup_group_i18n_key(title: &str) -> Option<&'static str> {
     match title {
         "Letters" => Some("key_picker.group_letters"),
@@ -305,7 +308,7 @@ pub(super) fn show_grouped_popup_key_buttons(
 
 pub(super) fn show_grouped_popup_choice_buttons(
     ui: &mut egui::Ui,
-    groups: Vec<(&'static str, Vec<(u16, String, String)>)>,
+    groups: Vec<PopupChoiceGroup>,
     language: crate::i18n::Language,
 ) -> Option<u16> {
     let mut selected = None;

--- a/src/smart_input.rs
+++ b/src/smart_input.rs
@@ -16,6 +16,8 @@ pub struct TextExpanderAppCandidate {
     pub title: String,
 }
 
+type ForegroundCacheState = Option<(std::time::Instant, Option<TextExpanderAppCandidate>)>;
+
 static TEXT_EXPANDER_CONFIG: OnceLock<RwLock<TextExpansionConfig>> = OnceLock::new();
 static TEXT_EXPANDER_ENGINE: OnceLock<Mutex<TextExpansionEngine>> = OnceLock::new();
 static RECENT_FOREGROUND_APPS: OnceLock<Mutex<Vec<TextExpanderAppCandidate>>> = OnceLock::new();
@@ -472,8 +474,7 @@ mod macos {
     const MAC_KEY_UP: u16 = 0x7E;
 
     static MACOS_EXPANDING_TEXT: AtomicBool = AtomicBool::new(false);
-    static FOREGROUND_CACHE: OnceLock<Mutex<Option<(Instant, Option<TextExpanderAppCandidate>)>>> =
-        OnceLock::new();
+    static FOREGROUND_CACHE: OnceLock<Mutex<ForegroundCacheState>> = OnceLock::new();
     static TAP_THREAD_RUNNING: AtomicBool = AtomicBool::new(false);
     static EVENT_TAP_ACTIVE: AtomicBool = AtomicBool::new(false);
     static TAP_PORT_ADDR: AtomicUsize = AtomicUsize::new(0);

--- a/src/ui/layout_indicator_preview.rs
+++ b/src/ui/layout_indicator_preview.rs
@@ -14,6 +14,8 @@ fn sticky_layout_should_draw_key(
     ) || is_pressed
 }
 
+type EncoderGroup = (u8, egui::Rect, Option<(usize, u16)>, Option<(usize, u16)>);
+
 fn sticky_rect_text_scale(rect: egui::Rect) -> f32 {
     (rect.width().min(rect.height()) / STICKY_LAYOUT_BASE_KEY_H).clamp(0.52, 2.4)
 }
@@ -300,8 +302,7 @@ impl EntropyApp {
             .filter(|&(_ki, key)| Self::layout_condition_visible(layout, key.layout_condition, layout_options_value)).map(|(ki, key)| (ki, layout_physical_key_rect(key, geometry)))
             .collect();
 
-        let mut encoder_groups: Vec<(u8, egui::Rect, Option<(usize, u16)>, Option<(usize, u16)>)> =
-            Vec::new();
+        let mut encoder_groups: Vec<EncoderGroup> = Vec::new();
         for (encoder_idx, encoder) in layout.encoders.iter().enumerate() {
             if !Self::layout_condition_visible(
                 layout,

--- a/src/ui/layout_keyboard.rs
+++ b/src/ui/layout_keyboard.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+type EncoderGroup = (u8, egui::Rect, Option<(usize, u16)>, Option<(usize, u16)>);
+
 impl EntropyApp {
     pub(super) fn draw_layout_keyboard_canvas(
         &mut self,
@@ -75,8 +77,7 @@ impl EntropyApp {
                 Vec2::new(ui.max_rect().width().min(560.0), 52.0),
             ),
         );
-        let mut encoder_groups: Vec<(u8, egui::Rect, Option<(usize, u16)>, Option<(usize, u16)>)> =
-            Vec::new();
+        let mut encoder_groups: Vec<EncoderGroup> = Vec::new();
         for (ei, rect) in &encoder_rects {
             let encoder = &layout.encoders[*ei];
             if !self


### PR DESCRIPTION
## EN

### Summary
This draft PR continues the clippy cleanup work split from the broader #17 discussion after #29 and #30.

It factors repeated complex tuple/cache shapes into local type aliases so the remaining `type_complexity` warnings become easier to read and review without changing runtime behavior.

### Verification
Rebased onto current `origin/main` at `2e4b5f0`.

- `git diff --check`
- `mise x rust@stable -- cargo test` — 53 tests passed
- `mise x rust@stable -- cargo clippy --all-targets --all-features` — exits successfully with the expected remaining baseline warnings
- Current local main baseline: 170 clippy warnings
- Local warning count on this branch: 166
- `type_complexity` warnings: 4 -> 0

Refs #17
Follow-up to #29 and #30

## RU

### Кратко
Этот PR продолжает адресную работу с предупреждениями clippy, выделенными из более широкого обсуждения #17 после #29 и #30.

Он выносит повторяющиеся сложные tuple/cache формы в локальные алиасы типов, чтобы оставшиеся `type_complexity` предостережения были проще для чтения и ревью без изменения поведения программы.

### Проверка
Rebased на current `origin/main` at `2e4b5f0`.

- `git diff --check`
- `mise x rust@stable -- cargo test` — 53 теста прошли
- `mise x rust@stable -- cargo clippy --all-targets --all-features` — завершается успешно с ожидаемыми оставшимися baseline warnings
- Current local main baseline: 170 clippy warnings
- Локальный счетчик warnings на этой ветке: 166
- `type_complexity` warnings: 4 -> 0

Refs #17
Follow-up to #29 and #30
