### PR TITLE
Clean up low-risk clippy warnings

### DIFF
--- a/src/app_storage.rs
+++ b/src/app_storage.rs
@@ -353,7 +353,7 @@ pub(super) fn compact_dropdown_popup_height(
     option_height: f32,
     spacing_y: f32,
 ) -> f32 {
-    let visible = option_count.max(1).min(5) as f32;
+    let visible = option_count.clamp(1, 5) as f32;
     option_height * visible + spacing_y * (visible - 1.0).max(0.0)
 }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -43,12 +43,19 @@ pub struct DeviceManager {
 
 impl DeviceManager {
     pub fn new() -> Self {
-        let mut manager = Self { devices: vec![] };
+        #[cfg(not(target_os = "macos"))]
+        {
+            let mut manager = Self { devices: vec![] };
+            manager.scan();
+            manager
+        }
+
         // Do not scan here on macOS: hidapi pumps the run loop during enumeration,
         // which can re-enter winit while its event handler is still active.
-        #[cfg(not(target_os = "macos"))]
-        manager.scan();
-        manager
+        #[cfg(target_os = "macos")]
+        {
+            Self { devices: vec![] }
+        }
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/src/entlayout.rs
+++ b/src/entlayout.rs
@@ -1643,9 +1643,7 @@ fn universal_key_mapping(bundle: &EntLayoutFile, layout: &KeyboardLayout) -> Vec
                     best = Some((target_idx, score));
                 }
             }
-            let Some((target_idx, score)) = best else {
-                return None;
-            };
+            let (target_idx, score) = best?;
             let threshold = if source.keys.len() == layout.keys.len() {
                 0.045
             } else {
@@ -1699,9 +1697,7 @@ fn universal_encoder_mapping(
                     best = Some((target_idx, score));
                 }
             }
-            let Some((target_idx, score)) = best else {
-                return None;
-            };
+            let (target_idx, score) = best?;
             if score <= 0.05 {
                 used[target_idx] = true;
                 Some(target_idx)

--- a/src/ui/device_connect_task.rs
+++ b/src/ui/device_connect_task.rs
@@ -411,9 +411,11 @@ impl EntropyApp {
                     let encoder_count = layout.encoder_count();
                     for layer in 0..layer_count {
                         let mut per_encoder = vec![(0u16, 0u16); encoder_count];
-                        for encoder_idx in 0..encoder_count {
+                        for (encoder_idx, encoder_values) in
+                            per_encoder.iter_mut().enumerate().take(encoder_count)
+                        {
                             match dev_conn.get_encoder(layer as u8, encoder_idx as u8) {
-                                Ok((ccw, cw)) => per_encoder[encoder_idx] = (ccw, cw),
+                                Ok((ccw, cw)) => *encoder_values = (ccw, cw),
                                 Err(e) => log::warn!(
                                     "get_encoder(layer={}, idx={}): {}",
                                     layer,

--- a/src/ui/key_assignment.rs
+++ b/src/ui/key_assignment.rs
@@ -233,9 +233,9 @@ impl EntropyApp {
         let is_layer_key = vial_layer_target(kc).is_some();
         let pending_base: Option<u16> = if is_layer_key {
             None
-        } else if (0x2000..0x4000).contains(&kc) {
-            Some(kc & 0xFF00)
-        } else if (0x0100..0x2000).contains(&kc) && (kc & 0xFF) != 0 {
+        } else if (0x2000..0x4000).contains(&kc)
+            || ((0x0100..0x2000).contains(&kc) && (kc & 0xFF) != 0)
+        {
             Some(kc & 0xFF00)
         } else {
             None

--- a/src/ui/matrix_tester.rs
+++ b/src/ui/matrix_tester.rs
@@ -351,9 +351,7 @@ impl EntropyApp {
             } else {
                 idle_fill
             };
-            let stroke = if is_pressed {
-                app_accent()
-            } else if was_pressed {
+            let stroke = if is_pressed || was_pressed {
                 app_accent()
             } else {
                 app_border_color(dark)

--- a/src/ui/universal_symbols_setup.rs
+++ b/src/ui/universal_symbols_setup.rs
@@ -31,9 +31,9 @@ impl EntropyApp {
                 dark,
                 content_width,
             );
-            return;
         }
 
+        #[cfg(not(target_os = "macos"))]
         crate::ui_style::allocate_ui_at_rect(ui, content_rect, |ui| {
             ui.vertical_centered(|ui| {
                 ui.add_space(metrics.value(18.0));

--- a/src/ui_style.rs
+++ b/src/ui_style.rs
@@ -909,11 +909,7 @@ pub fn modal_intro(ui: &mut Ui, text: &str) {
     ui.label(
         RichText::new(text)
             .size(11.0)
-            .color(Color32::from_gray(if ui.visuals().dark_mode {
-                140
-            } else {
-                140
-            })),
+            .color(Color32::from_gray(140)),
     );
 }
 


### PR DESCRIPTION
## EN

### Summary
This PR is a small follow-up to the clippy baseline split in #29 and #30, tied to the broader tracker in #17.

It cleans up low-risk warnings that have direct mechanical fixes, including:
- `question_mark`
- `needless_range_loop`
- `if_same_then_else`
- platform-specific `unused` / `unreachable` warnings

The intent is to reduce baseline noise without changing behavior or mixing in larger API/design cleanup.

### Verification
Rebased onto current `origin/main` at `3306c1b`.

- `git diff --check`
- `mise x rust@stable -- cargo test` — 57 tests passed
- `mise x rust@stable -- cargo clippy --all-targets --all-features` — exits successfully with the expected remaining baseline warnings
- Current local main baseline: 104 clippy warnings
- Local warning count on this branch: 96
- Targeted warning families: `question_mark` 2 -> 0, `needless_range_loop` 1 -> 0, `if_same_then_else` 3 -> 0

Refs #17
Follow-up to #29, #30, #40, #41, and #43

## RU

### Кратко
Это небольшой PR после разделения clippy-baseline на #29 и #30, связанный с общим трекером #17.

Он убирает низкорисковые предупреждения с прямыми механическими исправлениями, включая:
- `question_mark`
- `needless_range_loop`
- `if_same_then_else`
- platform-specific `unused` / `unreachable` warnings

Цель — уменьшить шум в baseline без изменения поведения и без смешивания с более крупной API/design cleanup работой.

### Проверка
Rebased на current `origin/main` at `3306c1b`.

- `git diff --check`
- `mise x rust@stable -- cargo test` — 57 тестов прошли
- `mise x rust@stable -- cargo clippy --all-targets --all-features` — завершается успешно с ожидаемыми оставшимися baseline warnings
- Current local main baseline: 104 clippy warnings
- Локальный счетчик warnings на этой ветке: 96
- Targeted warning families: `question_mark` 2 -> 0, `needless_range_loop` 1 -> 0, `if_same_then_else` 3 -> 0

Refs #17
Follow-up to #29, #30, #40, #41, and #43
