### PR TITLE
Box connect task completion message

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -289,7 +289,7 @@ pub(crate) struct ConnectResult {
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) enum ConnectTaskMessage {
     Progress(String),
-    Done(Result<ConnectResult, String>),
+    Done(Box<Result<ConnectResult, String>>),
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/src/ui/device_connect_apply.rs
+++ b/src/ui/device_connect_apply.rs
@@ -34,7 +34,7 @@ impl EntropyApp {
                     ctx.request_repaint();
                     return;
                 }
-                Ok(ConnectTaskMessage::Done(result)) => result,
+                Ok(ConnectTaskMessage::Done(result)) => *result,
                 Err(mpsc::TryRecvError::Empty) => {
                     let idle_timeout = last_progress_at.elapsed() > CONNECT_IDLE_TIMEOUT;
                     let total_timeout = started_at.elapsed() > CONNECT_TOTAL_TIMEOUT;

--- a/src/ui/device_connect_task.rs
+++ b/src/ui/device_connect_task.rs
@@ -801,7 +801,7 @@ impl EntropyApp {
                 })
             })();
 
-            let _ = tx.send(ConnectTaskMessage::Done(result));
+            let _ = tx.send(ConnectTaskMessage::Done(Box::new(result)));
         });
     }
 }


### PR DESCRIPTION
## EN

### Summary
This draft PR keeps the `large_enum_variant` cleanup separate from the broader #17 clippy baseline discussion and the #29 / #30 split.

It boxes the `ConnectTaskMessage::Done` payload so the enum no longer stores the much larger completion result inline. The change is intentionally narrow: the message shape changes, while connect task behavior and result handling remain the same.

### Verification
Rebased onto current `origin/main` at `2e4b5f0`.

- `git diff --check`
- `mise x rust@stable -- cargo test` — 53 tests passed
- `mise x rust@stable -- cargo clippy --all-targets --all-features` — exits successfully with the expected remaining baseline warnings
- Current local main baseline: 170 clippy warnings
- Local warning count on this branch: 169
- `large_enum_variant` warnings: 1 -> 0

Refs #17
Follow-up to #29 and #30

## RU

### Кратко
Этот PR адресует `large_enum_variant` предупреждения отдельно от имеющихся #17 и #29 / #30.

Он помещает `ConnectTaskMessage::Done` payload в `Box`, чтобы enum больше не хранил заметно больший результат выполнения inline.
Меняется только форма сообщения, а процессинг остается прежним.

### Проверка
Rebased на current `origin/main` at `2e4b5f0`.

- `git diff --check`
- `mise x rust@stable -- cargo test` — 53 теста прошли
- `mise x rust@stable -- cargo clippy --all-targets --all-features` — завершается успешно с ожидаемыми оставшимися baseline warnings
- Current local main baseline: 170 clippy warnings
- Локальный счетчик warnings на этой ветке: 169
- `large_enum_variant` warnings: 1 -> 0

Refs #17
Follow-up to #29 and #30
