### PR TITLE
Use clipboard fallback for EditPlus universal symbols

### DIFF
--- a/src/smart_input.rs
+++ b/src/smart_input.rs
@@ -387,6 +387,25 @@ fn smart_symbol_for_transport(
     smart_symbol_for_keycode(trigger_keycode).map(|symbol| (symbol.symbol, trigger_keycode))
 }
 
+#[cfg(any(target_os = "windows", test))]
+fn app_prefers_clipboard_unicode_input(exe: &str) -> bool {
+    matches!(
+        exe.strip_suffix(".exe").unwrap_or(exe),
+        "brave"
+            | "chrome"
+            | "editplus"
+            | "firefox"
+            | "librewolf"
+            | "msedge"
+            | "opera"
+            | "opera_gx"
+            | "thunderbird"
+            | "vivaldi"
+            | "waterfox"
+            | "yandex"
+    )
+}
+
 #[cfg(target_os = "windows")]
 pub fn start() {
     smart_input_windows::start();
@@ -1175,5 +1194,10 @@ mod tests {
         set_text_expander_config(false, vec![rule(":hello", "Привет")], Vec::new());
 
         assert!(!text_expander_enabled());
+    }
+
+    #[test]
+    fn editplus_uses_clipboard_fallback_for_universal_symbols() {
+        assert!(app_prefers_clipboard_unicode_input("editplus.exe"));
     }
 }

--- a/src/smart_input_windows.rs
+++ b/src/smart_input_windows.rs
@@ -584,26 +584,8 @@ unsafe fn send_unicode_char(symbol: char, trigger_keycode: u16) {
 fn should_paste_universal_symbol_for_foreground_app() -> bool {
     foreground_process_name_lower()
         .as_deref()
-        .map(app_prefers_clipboard_unicode_input)
+        .map(super::app_prefers_clipboard_unicode_input)
         .unwrap_or(false)
-}
-
-#[cfg(target_os = "windows")]
-fn app_prefers_clipboard_unicode_input(exe: &str) -> bool {
-    matches!(
-        exe.strip_suffix(".exe").unwrap_or(exe),
-        "brave"
-            | "chrome"
-            | "firefox"
-            | "librewolf"
-            | "msedge"
-            | "opera"
-            | "opera_gx"
-            | "thunderbird"
-            | "vivaldi"
-            | "waterfox"
-            | "yandex"
-    )
 }
 
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
## EN
### Summary
- Adds EditPlus to the Windows universal-symbol compatibility fallback list, matching the report where `,`, `.`, and `'` worked in Telegram but not EditPlus under Bulgarian BDS input.
- Moves the app fallback policy into the shared smart input module so it can be covered by portable tests while Windows keeps using the same clipboard-restore path for affected apps.
- Adds regression coverage for the EditPlus fallback decision.

### Verification
- `git diff --check`
- `/Users/igor.arkhipov/.cargo/bin/rustfmt --edition 2021 --check src/smart_input.rs src/smart_input_windows.rs`
- `/Users/igor.arkhipov/.cargo/bin/cargo build --quiet`
- `/Users/igor.arkhipov/.cargo/bin/cargo test --quiet` passes: 54 tests.

## RU
### Кратко
- Добавляет EditPlus в Windows fallback-список для универсальных символов: это адресует жалобу в чате обратной связи, где `,`, `.`, и `'` работали в Telegram, но не в EditPlus на Bulgarian BDS input.
- Переносит политику fallback-приложений в общий smart input модуль, чтобы её можно было покрыть тестами; Windows продолжает использовать существующий clipboard-restore путь для таких приложений.
- Добавляет regression test для EditPlus fallback.

### Проверка
- `git diff --check`
- `/Users/igor.arkhipov/.cargo/bin/rustfmt --edition 2021 --check src/smart_input.rs src/smart_input_windows.rs`
- `/Users/igor.arkhipov/.cargo/bin/cargo build --quiet`
- `/Users/igor.arkhipov/.cargo/bin/cargo test --quiet` проходит: 54 теста.
