### PR TITLE
Add universal smiley symbols

### DIFF
--- a/linux/fcitx5/src/entropyuniversalsymbols.cpp
+++ b/linux/fcitx5/src/entropyuniversalsymbols.cpp
@@ -30,7 +30,7 @@ struct SmartSymbol {
     const char *symbol;
 };
 
-const std::array<SmartSymbol, 74> SMART_SYMBOLS{{
+const std::array<SmartSymbol, 79> SMART_SYMBOLS{{
     // F13..F24
     {KC_F13, "{"},
     {uint16_t(KC_F13 + 1), "}"},
@@ -95,6 +95,13 @@ const std::array<SmartSymbol, 74> SMART_SYMBOLS{{
     {uint16_t(MOD_CTRL | MOD_ALT | (KC_F13 + 4)), "х"},
     {uint16_t(MOD_CTRL | MOD_ALT | (KC_F13 + 5)), "ъ"},
     {uint16_t(MOD_CTRL | MOD_ALT | (KC_F13 + 6)), "ё"},
+
+    // Ctrl+Alt+F20..F24
+    {uint16_t(MOD_CTRL | MOD_ALT | (KC_F13 + 7)), "🙂"},
+    {uint16_t(MOD_CTRL | MOD_ALT | (KC_F13 + 8)), "😀"},
+    {uint16_t(MOD_CTRL | MOD_ALT | (KC_F13 + 9)), "😂"},
+    {uint16_t(MOD_CTRL | MOD_ALT | (KC_F13 + 10)), "😉"},
+    {uint16_t(MOD_CTRL | MOD_ALT | (KC_F13 + 11)), "😅"},
 
     // Ctrl+Alt+Shift+F13..F19
     {uint16_t(MOD_CTRL | MOD_ALT | MOD_SHIFT | KC_F13), "Б"},

--- a/linux/fcitx5/src/entropyuniversalsymbols.cpp
+++ b/linux/fcitx5/src/entropyuniversalsymbols.cpp
@@ -30,7 +30,7 @@ struct SmartSymbol {
     const char *symbol;
 };
 
-const std::array<SmartSymbol, 69> SMART_SYMBOLS{{
+const std::array<SmartSymbol, 74> SMART_SYMBOLS{{
     // F13..F24
     {KC_F13, "{"},
     {uint16_t(KC_F13 + 1), "}"},
@@ -81,6 +81,11 @@ const std::array<SmartSymbol, 69> SMART_SYMBOLS{{
     {uint16_t(MOD_ALT | (KC_F13 + 4)), "/"},
     {uint16_t(MOD_ALT | (KC_F13 + 5)), "`"},
     {uint16_t(MOD_ALT | (KC_F13 + 6)), "^"},
+    {uint16_t(MOD_ALT | (KC_F13 + 7)), "←"},
+    {uint16_t(MOD_ALT | (KC_F13 + 8)), "↑"},
+    {uint16_t(MOD_ALT | (KC_F13 + 9)), "→"},
+    {uint16_t(MOD_ALT | (KC_F13 + 10)), "↓"},
+    {uint16_t(MOD_ALT | (KC_F13 + 11)), "↔"},
 
     // Ctrl+Alt+F13..F19
     {uint16_t(MOD_CTRL | MOD_ALT | KC_F13), "б"},

--- a/linux/ibus/entropy-ibus-engine
+++ b/linux/ibus/entropy-ibus-engine
@@ -139,6 +139,10 @@ def _symbol_entries():
     for idx, symbol in enumerate(["б", "ю", "ж", "э", "х", "ъ", "ё"]):
         add(idx, symbol, MOD_CTRL | MOD_ALT)
 
+    # Ctrl+Alt+F20..F24
+    for idx, symbol in enumerate(["🙂", "😀", "😂", "😉", "😅"], start=7):
+        add(idx, symbol, MOD_CTRL | MOD_ALT)
+
     # Ctrl+Alt+Shift+F13..F19
     for idx, symbol in enumerate(["Б", "Ю", "Ж", "Э", "Х", "Ъ", "Ё"]):
         add(idx, symbol, MOD_CTRL | MOD_ALT | MOD_SHIFT)

--- a/linux/ibus/entropy-ibus-engine
+++ b/linux/ibus/entropy-ibus-engine
@@ -132,7 +132,7 @@ def _symbol_entries():
         add(idx, symbol, MOD_CTRL)
 
     # Alt+F13..F24
-    for idx, symbol in enumerate([".", ",", ";", ":", "/", "`", "^"]):
+    for idx, symbol in enumerate([".", ",", ";", ":", "/", "`", "^", "←", "↑", "→", "↓", "↔"]):
         add(idx, symbol, MOD_ALT)
 
     # Ctrl+Alt+F13..F19

--- a/src/keycode_picker.rs
+++ b/src/keycode_picker.rs
@@ -179,7 +179,8 @@ const UNIVERSAL_MAIN_SYMBOL_ORDER: &[char] = &[
 
 const UNIVERSAL_EXTRA_SYMBOL_ORDER: &[char] = &[
     '₽', '€', '«', '»', '‘', '’', '„', '“', '”', '—', '–', '←', '↑', '→', '↓', '↔', '•', '×', '±',
-    '≠', '≈', '✓', '§', '°', '‰', '′', '″', '™', '№',
+    '≠', '≈', '✓', '§', '°', '‰', '′', '″', '™', '№', '🙂', '😀', '😂', '😉',
+    '😅',
 ];
 
 #[cfg(test)]
@@ -189,6 +190,13 @@ mod tests {
     #[test]
     fn universal_extra_symbols_include_common_arrows() {
         for symbol in ['←', '↑', '→', '↓', '↔'] {
+            assert!(UNIVERSAL_EXTRA_SYMBOL_ORDER.contains(&symbol));
+        }
+    }
+
+    #[test]
+    fn universal_extra_symbols_include_common_smileys() {
+        for symbol in ['🙂', '😀', '😂', '😉', '😅'] {
             assert!(UNIVERSAL_EXTRA_SYMBOL_ORDER.contains(&symbol));
         }
     }

--- a/src/smart_input_symbols.rs
+++ b/src/smart_input_symbols.rs
@@ -418,4 +418,21 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn linux_input_method_backends_include_arrow_symbols() {
+        let ibus_backend = include_str!("../linux/ibus/entropy-ibus-engine");
+        let fcitx5_backend = include_str!("../linux/fcitx5/src/entropyuniversalsymbols.cpp");
+
+        for symbol in ["←", "↑", "→", "↓", "↔"] {
+            assert!(
+                ibus_backend.contains(symbol),
+                "IBus backend is missing {symbol}"
+            );
+            assert!(
+                fcitx5_backend.contains(symbol),
+                "Fcitx5 backend is missing {symbol}"
+            );
+        }
+    }
 }

--- a/src/smart_input_symbols.rs
+++ b/src/smart_input_symbols.rs
@@ -291,6 +291,32 @@ pub const SMART_SYMBOLS: &[SmartSymbol] = &[
         symbol: 'ё',
         name: "Cyrillic yo",
     },
+    // Ctrl+Alt+F20..F24
+    SmartSymbol {
+        trigger_keycode: MOD_CTRL | MOD_ALT | (KC_F13 + 7),
+        symbol: '🙂',
+        name: "Slightly smiling face",
+    },
+    SmartSymbol {
+        trigger_keycode: MOD_CTRL | MOD_ALT | (KC_F13 + 8),
+        symbol: '😀',
+        name: "Grinning face",
+    },
+    SmartSymbol {
+        trigger_keycode: MOD_CTRL | MOD_ALT | (KC_F13 + 9),
+        symbol: '😂',
+        name: "Face with tears of joy",
+    },
+    SmartSymbol {
+        trigger_keycode: MOD_CTRL | MOD_ALT | (KC_F13 + 10),
+        symbol: '😉',
+        name: "Winking face",
+    },
+    SmartSymbol {
+        trigger_keycode: MOD_CTRL | MOD_ALT | (KC_F13 + 11),
+        symbol: '😅',
+        name: "Grinning face with sweat",
+    },
     // Ctrl+Alt+Shift+F13..F19
     SmartSymbol {
         trigger_keycode: MOD_CTRL | MOD_ALT | MOD_SHIFT | KC_F13,
@@ -425,6 +451,41 @@ mod tests {
         let fcitx5_backend = include_str!("../linux/fcitx5/src/entropyuniversalsymbols.cpp");
 
         for symbol in ["←", "↑", "→", "↓", "↔"] {
+            assert!(
+                ibus_backend.contains(symbol),
+                "IBus backend is missing {symbol}"
+            );
+            assert!(
+                fcitx5_backend.contains(symbol),
+                "Fcitx5 backend is missing {symbol}"
+            );
+        }
+    }
+
+    #[test]
+    fn common_smiley_symbols_use_remaining_ctrl_alt_slots() {
+        let expected = [
+            (MOD_CTRL | MOD_ALT | (KC_F13 + 7), '🙂'),
+            (MOD_CTRL | MOD_ALT | (KC_F13 + 8), '😀'),
+            (MOD_CTRL | MOD_ALT | (KC_F13 + 9), '😂'),
+            (MOD_CTRL | MOD_ALT | (KC_F13 + 10), '😉'),
+            (MOD_CTRL | MOD_ALT | (KC_F13 + 11), '😅'),
+        ];
+
+        for (keycode, symbol) in expected {
+            assert_eq!(
+                smart_symbol_for_keycode(keycode).map(|smart_symbol| smart_symbol.symbol),
+                Some(symbol)
+            );
+        }
+    }
+
+    #[test]
+    fn linux_input_method_backends_include_common_smiley_symbols() {
+        let ibus_backend = include_str!("../linux/ibus/entropy-ibus-engine");
+        let fcitx5_backend = include_str!("../linux/fcitx5/src/entropyuniversalsymbols.cpp");
+
+        for symbol in ["🙂", "😀", "😂", "😉", "😅"] {
             assert!(
                 ibus_backend.contains(symbol),
                 "IBus backend is missing {symbol}"


### PR DESCRIPTION
## EN
### Dependency
- Depends on #45. This branch is stacked on `igor/linux-universal-arrow-backends`, so the smiley symbol-table entries build on the Linux universal-symbol backend parity work.
- After #45 merges, this branch should be rebased onto `main` so the PR diff becomes smiley-only.

### Summary
- Adds five single-codepoint common smileys (`🙂`, `😀`, `😂`, `😉`, `😅`) to the universal-symbol catalog.
- Maps them to the remaining Ctrl+Alt+F20..F24 transport slots.
- Shows the smileys in the extra universal-symbol picker section.
- Keeps the bundled Linux IBus and Fcitx5 backends in sync.

### Verification
- `git diff --check`
- `/Users/igor.arkhipov/.cargo/bin/rustfmt --edition 2021 --check src/smart_input_symbols.rs`
- `python3 -m py_compile linux/ibus/entropy-ibus-engine`
- Fcitx5 table count check: `declared=79`, `entries=79`
- `/Users/igor.arkhipov/.cargo/bin/cargo build --quiet` passes with existing warnings.
- `/Users/igor.arkhipov/.cargo/bin/cargo test --quiet` passes: 57 tests.

## RU
### Зависимости
- Зависит от #45. PR является его продолжением, чтобы данные о смайлах в таблице символов дополняли Linux universal-symbol backend.
- После #45 ветку нужно будет обновить на `main`.

### Кратко
- Добавляет пять популярных смайлов (`🙂`, `😀`, `😂`, `😉`, `😅`) в каталог универсальных символов.
- Назначает их на оставшиеся Ctrl+Alt+F20..F24 слоты.
- Показывает смайлики в расширенной секции выбора дополнительных универсальных символов.
- Синхронизирует Linux IBus and Fcitx5 backends.

### Проверка
- `git diff --check`
- `/Users/igor.arkhipov/.cargo/bin/rustfmt --edition 2021 --check src/smart_input_symbols.rs`
- `python3 -m py_compile linux/ibus/entropy-ibus-engine`
- Fcitx5 table count check: `declared=79`, `entries=79`
- `/Users/igor.arkhipov/.cargo/bin/cargo build --quiet` проходит с существующими warnings.
- `/Users/igor.arkhipov/.cargo/bin/cargo test --quiet` проходит: 57 тестов.
