### PR TITLE
Improve connect crash diagnostics

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -13,6 +13,7 @@ static LOGGER: DiagnosticsLogger = DiagnosticsLogger {
     enabled: AtomicBool::new(false),
     file: Mutex::new(None),
 };
+static PANIC_HOOK_INSTALLED: AtomicBool = AtomicBool::new(false);
 
 struct DiagnosticsLogger {
     enabled: AtomicBool,
@@ -65,6 +66,7 @@ pub(crate) fn init(enabled: bool) {
     if log::set_logger(&LOGGER).is_ok() {
         log::set_max_level(LevelFilter::Info);
     }
+    install_panic_hook();
     set_enabled(enabled);
     log::info!(
         "Entropy v{} starting on {} {}",
@@ -120,6 +122,49 @@ pub(crate) fn set_enabled(enabled: bool) {
         "Diagnostics mode {}",
         if enabled { "enabled" } else { "disabled" }
     );
+}
+
+fn install_panic_hook() {
+    if PANIC_HOOK_INSTALLED
+        .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+        .is_err()
+    {
+        return;
+    }
+
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        log::error!("{}", panic_hook_message(info));
+        previous_hook(info);
+    }));
+}
+
+fn panic_hook_message(info: &std::panic::PanicHookInfo<'_>) -> String {
+    let payload = if let Some(message) = info.payload().downcast_ref::<&str>() {
+        (*message).to_owned()
+    } else if let Some(message) = info.payload().downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "non-string panic payload".to_owned()
+    };
+    let location = info.location().map(|location| {
+        format!(
+            "{}:{}:{}",
+            location.file(),
+            location.line(),
+            location.column()
+        )
+    });
+
+    panic_log_message(&payload, location.as_deref())
+}
+
+fn panic_log_message(payload: &str, location: Option<&str>) -> String {
+    format!(
+        "panic at {}: {}",
+        location.unwrap_or("unknown location"),
+        payload
+    )
 }
 
 pub(crate) fn settings_file_enabled() -> bool {
@@ -215,4 +260,30 @@ fn display_path(path: &std::path::Path) -> String {
         }
     }
     raw.into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn panic_log_message_includes_payload_and_location() {
+        let message = panic_log_message(
+            "connect failed",
+            Some("src/ui/device_connect_apply.rs:42:9"),
+        );
+
+        assert_eq!(
+            message,
+            "panic at src/ui/device_connect_apply.rs:42:9: connect failed"
+        );
+    }
+
+    #[test]
+    fn panic_log_message_handles_missing_location() {
+        assert_eq!(
+            panic_log_message("connect failed", None),
+            "panic at unknown location: connect failed"
+        );
+    }
 }

--- a/src/ui/device_connect_apply.rs
+++ b/src/ui/device_connect_apply.rs
@@ -15,6 +15,39 @@ fn has_firmware_layer_names(names: &[String]) -> bool {
         .any(|(index, name)| !is_default_layer_name(index, name))
 }
 
+fn connect_apply_start_log(
+    device_name: &str,
+    layer_count: usize,
+    firmware: FirmwareProtocol,
+) -> String {
+    format!("Applying keyboard layout for {device_name} ({layer_count} layers, {firmware:?})")
+}
+
+fn connect_apply_error_log(error: &str) -> String {
+    format!("Connect failed before applying keyboard layout: {error}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn connect_apply_start_log_includes_device_layer_count_and_firmware() {
+        assert_eq!(
+            connect_apply_start_log("HPD2", 4, FirmwareProtocol::Vial),
+            "Applying keyboard layout for HPD2 (4 layers, Vial)"
+        );
+    }
+
+    #[test]
+    fn connect_apply_error_log_includes_context() {
+        assert_eq!(
+            connect_apply_error_log("Layout parse failed: missing matrix"),
+            "Connect failed before applying keyboard layout: Layout parse failed: missing matrix"
+        );
+    }
+}
+
 impl EntropyApp {
     /// Poll background thread for connect result.
     #[cfg(not(target_arch = "wasm32"))]
@@ -40,13 +73,14 @@ impl EntropyApp {
                     let total_timeout = started_at.elapsed() > CONNECT_TOTAL_TIMEOUT;
                     if idle_timeout || total_timeout {
                         let stage = if self.status_msg.is_empty() {
-                            "unknown stage"
+                            "unknown stage".to_owned()
                         } else {
-                            self.status_msg.as_str()
+                            self.status_msg.clone()
                         };
                         self.status_msg = format!(
                             "Connect timeout — RMK/Vial device did not finish loading while: {stage}"
                         );
+                        log::warn!("Connect timeout while waiting for stage: {stage}");
                         self.connect_state = ConnectState::Idle;
                         return;
                     }
@@ -55,6 +89,7 @@ impl EntropyApp {
                 }
                 Err(mpsc::TryRecvError::Disconnected) => {
                     self.status_msg = "Connect thread died".into();
+                    log::error!("Connect thread died before returning a result");
                     self.connect_state = ConnectState::Idle;
                     return;
                 }
@@ -66,6 +101,10 @@ impl EntropyApp {
 
         match result {
             Ok(r) => {
+                log::info!(
+                    "{}",
+                    connect_apply_start_log(&r.device_name, r.layer_count, r.layout.firmware)
+                );
                 self.layer_count = r.layer_count;
                 self.firmware = r.layout.firmware;
                 self.current_device_name = r.device_name.clone();
@@ -254,6 +293,7 @@ impl EntropyApp {
                 );
             }
             Err(e) => {
+                log::error!("{}", connect_apply_error_log(&e));
                 self.status_msg = e;
             }
         }


### PR DESCRIPTION
## EN
### Summary
- Installs a diagnostics panic hook so panic payloads and source locations are written through the existing diagnostics logger.
- Logs connect apply start, connect-result failures, timeout stages, and connect-thread death around the keyboard layout apply phase.
- Adds regression coverage for panic log formatting and connect apply log messages.

### Verification
- `git diff --check`
- `/Users/igor.arkhipov/.cargo/bin/rustfmt --edition 2021 --check src/diagnostics.rs src/ui/device_connect_apply.rs`
- `/Users/igor.arkhipov/.cargo/bin/cargo test panic_log_message --quiet` passes: 2 tests.
- `/Users/igor.arkhipov/.cargo/bin/cargo test connect_apply --quiet` passes: 2 tests.
- `/Users/igor.arkhipov/.cargo/bin/cargo build --quiet` passes with existing warnings.
- `/Users/igor.arkhipov/.cargo/bin/cargo test --quiet` passes: 61 tests.

## RU
### Кратко
- Добавляет diagnostics panic hook, чтобы передавать расширенный payload, включая место возникновения, в существующий логгер для диагностики.
- Логирует начало фазы connect apply, ошибки connect-result, таймаут и отключение connect thread во время применения раскладки клавиатуры.
- Добавляет тесты для форматирования panic logs и потенциальных сообщений об ошибках.

### Проверка
- `git diff --check`
- `/Users/igor.arkhipov/.cargo/bin/rustfmt --edition 2021 --check src/diagnostics.rs src/ui/device_connect_apply.rs`
- `/Users/igor.arkhipov/.cargo/bin/cargo test panic_log_message --quiet` проходит: 2 теста.
- `/Users/igor.arkhipov/.cargo/bin/cargo test connect_apply --quiet` проходит: 2 теста.
- `/Users/igor.arkhipov/.cargo/bin/cargo build --quiet` проходит с существующими warnings.
- `/Users/igor.arkhipov/.cargo/bin/cargo test --quiet` проходит: 61 тест.
