### PR TITLE
Remap universal symbol transport to F13-F20

### DIFF
--- a/linux/fcitx5/README.md
+++ b/linux/fcitx5/README.md
@@ -1,6 +1,6 @@
 # Entropy Fcitx5 backend
 
-This is the Fcitx5 module backend for Entropy Universal Symbols on Wayland/Linux. It watches only Entropy's reserved transport chords (`F13..F24` with `Shift`, `Ctrl`, `Alt`, and `Ctrl+Alt`) and commits the matching Unicode text through Fcitx5.
+This is the Fcitx5 module backend for Entropy Universal Symbols on Wayland/Linux. It watches only Entropy's reserved transport chords (`F13..F20` with `Shift`, `Ctrl`, `Alt`, and `Super`) and commits the matching Unicode text through Fcitx5.
 
 Unlike the X11 helper path, this does not use global X grabs or `xdotool`, and unlike `evdev/uinput`, it does not need access to `/dev/input`.
 

--- a/linux/fcitx5/src/entropyuniversalsymbols.cpp
+++ b/linux/fcitx5/src/entropyuniversalsymbols.cpp
@@ -24,6 +24,7 @@ constexpr uint16_t KC_F13 = 0x0068;
 constexpr uint16_t MOD_CTRL = 0x0100;
 constexpr uint16_t MOD_SHIFT = 0x0200;
 constexpr uint16_t MOD_ALT = 0x0400;
+constexpr uint16_t MOD_GUI = 0x0800;
 
 struct SmartSymbol {
     uint16_t trigger;
@@ -31,7 +32,7 @@ struct SmartSymbol {
 };
 
 const std::array<SmartSymbol, 74> SMART_SYMBOLS{{
-    // F13..F24
+    // F13..F20
     {KC_F13, "{"},
     {uint16_t(KC_F13 + 1), "}"},
     {uint16_t(KC_F13 + 2), "["},
@@ -40,12 +41,8 @@ const std::array<SmartSymbol, 74> SMART_SYMBOLS{{
     {uint16_t(KC_F13 + 5), ")"},
     {uint16_t(KC_F13 + 6), "<"},
     {uint16_t(KC_F13 + 7), ">"},
-    {uint16_t(KC_F13 + 8), "#"},
-    {uint16_t(KC_F13 + 9), "@"},
-    {uint16_t(KC_F13 + 10), "№"},
-    {uint16_t(KC_F13 + 11), "₽"},
 
-    // Shift+F13..F24
+    // Shift+F13..F20
     {uint16_t(MOD_SHIFT | KC_F13), "!"},
     {uint16_t(MOD_SHIFT | (KC_F13 + 1)), "\""},
     {uint16_t(MOD_SHIFT | (KC_F13 + 2)), "$"},
@@ -54,12 +51,8 @@ const std::array<SmartSymbol, 74> SMART_SYMBOLS{{
     {uint16_t(MOD_SHIFT | (KC_F13 + 5)), "'"},
     {uint16_t(MOD_SHIFT | (KC_F13 + 6)), "*"},
     {uint16_t(MOD_SHIFT | (KC_F13 + 7)), "+"},
-    {uint16_t(MOD_SHIFT | (KC_F13 + 8)), "="},
-    {uint16_t(MOD_SHIFT | (KC_F13 + 9)), "?"},
-    {uint16_t(MOD_SHIFT | (KC_F13 + 10)), "|"},
-    {uint16_t(MOD_SHIFT | (KC_F13 + 11)), "\\"},
 
-    // Ctrl+F13..F24
+    // Ctrl+F13..F20
     {uint16_t(MOD_CTRL | KC_F13), "«"},
     {uint16_t(MOD_CTRL | (KC_F13 + 1)), "»"},
     {uint16_t(MOD_CTRL | (KC_F13 + 2)), "€"},
@@ -68,12 +61,8 @@ const std::array<SmartSymbol, 74> SMART_SYMBOLS{{
     {uint16_t(MOD_CTRL | (KC_F13 + 5)), "•"},
     {uint16_t(MOD_CTRL | (KC_F13 + 6)), "×"},
     {uint16_t(MOD_CTRL | (KC_F13 + 7)), "±"},
-    {uint16_t(MOD_CTRL | (KC_F13 + 8)), "≠"},
-    {uint16_t(MOD_CTRL | (KC_F13 + 9)), "≈"},
-    {uint16_t(MOD_CTRL | (KC_F13 + 10)), "✓"},
-    {uint16_t(MOD_CTRL | (KC_F13 + 11)), "§"},
 
-    // Alt+F13..F24
+    // Alt+F13..F20
     {uint16_t(MOD_ALT | KC_F13), "."},
     {uint16_t(MOD_ALT | (KC_F13 + 1)), ","},
     {uint16_t(MOD_ALT | (KC_F13 + 2)), ";"},
@@ -81,13 +70,19 @@ const std::array<SmartSymbol, 74> SMART_SYMBOLS{{
     {uint16_t(MOD_ALT | (KC_F13 + 4)), "/"},
     {uint16_t(MOD_ALT | (KC_F13 + 5)), "`"},
     {uint16_t(MOD_ALT | (KC_F13 + 6)), "^"},
-    {uint16_t(MOD_ALT | (KC_F13 + 7)), "←"},
-    {uint16_t(MOD_ALT | (KC_F13 + 8)), "↑"},
-    {uint16_t(MOD_ALT | (KC_F13 + 9)), "→"},
-    {uint16_t(MOD_ALT | (KC_F13 + 10)), "↓"},
-    {uint16_t(MOD_ALT | (KC_F13 + 11)), "↔"},
+    {uint16_t(MOD_ALT | (KC_F13 + 7)), "≠"},
 
-    // Ctrl+Alt+F13..F19
+    // Alt+Shift+F13..F20
+    {uint16_t(MOD_ALT | MOD_SHIFT | KC_F13), "#"},
+    {uint16_t(MOD_ALT | MOD_SHIFT | (KC_F13 + 1)), "@"},
+    {uint16_t(MOD_ALT | MOD_SHIFT | (KC_F13 + 2)), "№"},
+    {uint16_t(MOD_ALT | MOD_SHIFT | (KC_F13 + 3)), "₽"},
+    {uint16_t(MOD_ALT | MOD_SHIFT | (KC_F13 + 4)), "="},
+    {uint16_t(MOD_ALT | MOD_SHIFT | (KC_F13 + 5)), "?"},
+    {uint16_t(MOD_ALT | MOD_SHIFT | (KC_F13 + 6)), "|"},
+    {uint16_t(MOD_ALT | MOD_SHIFT | (KC_F13 + 7)), "\\"},
+
+    // Ctrl+Alt+F13..F20
     {uint16_t(MOD_CTRL | MOD_ALT | KC_F13), "б"},
     {uint16_t(MOD_CTRL | MOD_ALT | (KC_F13 + 1)), "ю"},
     {uint16_t(MOD_CTRL | MOD_ALT | (KC_F13 + 2)), "ж"},
@@ -95,8 +90,9 @@ const std::array<SmartSymbol, 74> SMART_SYMBOLS{{
     {uint16_t(MOD_CTRL | MOD_ALT | (KC_F13 + 4)), "х"},
     {uint16_t(MOD_CTRL | MOD_ALT | (KC_F13 + 5)), "ъ"},
     {uint16_t(MOD_CTRL | MOD_ALT | (KC_F13 + 6)), "ё"},
+    {uint16_t(MOD_CTRL | MOD_ALT | (KC_F13 + 7)), "≈"},
 
-    // Ctrl+Alt+Shift+F13..F19
+    // Ctrl+Alt+Shift+F13..F20
     {uint16_t(MOD_CTRL | MOD_ALT | MOD_SHIFT | KC_F13), "Б"},
     {uint16_t(MOD_CTRL | MOD_ALT | MOD_SHIFT | (KC_F13 + 1)), "Ю"},
     {uint16_t(MOD_CTRL | MOD_ALT | MOD_SHIFT | (KC_F13 + 2)), "Ж"},
@@ -104,8 +100,9 @@ const std::array<SmartSymbol, 74> SMART_SYMBOLS{{
     {uint16_t(MOD_CTRL | MOD_ALT | MOD_SHIFT | (KC_F13 + 4)), "Х"},
     {uint16_t(MOD_CTRL | MOD_ALT | MOD_SHIFT | (KC_F13 + 5)), "Ъ"},
     {uint16_t(MOD_CTRL | MOD_ALT | MOD_SHIFT | (KC_F13 + 6)), "Ё"},
+    {uint16_t(MOD_CTRL | MOD_ALT | MOD_SHIFT | (KC_F13 + 7)), "✓"},
 
-    // Ctrl+Shift+F13..F24
+    // Ctrl+Shift+F13..F20
     {uint16_t(MOD_CTRL | MOD_SHIFT | KC_F13), "°"},
     {uint16_t(MOD_CTRL | MOD_SHIFT | (KC_F13 + 1)), "‰"},
     {uint16_t(MOD_CTRL | MOD_SHIFT | (KC_F13 + 2)), "′"},
@@ -114,14 +111,24 @@ const std::array<SmartSymbol, 74> SMART_SYMBOLS{{
     {uint16_t(MOD_CTRL | MOD_SHIFT | (KC_F13 + 5)), "’"},
     {uint16_t(MOD_CTRL | MOD_SHIFT | (KC_F13 + 6)), "„"},
     {uint16_t(MOD_CTRL | MOD_SHIFT | (KC_F13 + 7)), "“"},
-    {uint16_t(MOD_CTRL | MOD_SHIFT | (KC_F13 + 8)), "”"},
-    {uint16_t(MOD_CTRL | MOD_SHIFT | (KC_F13 + 9)), "™"},
-    {uint16_t(MOD_CTRL | MOD_SHIFT | (KC_F13 + 10)), "~"},
-    {uint16_t(MOD_CTRL | MOD_SHIFT | (KC_F13 + 11)), "_"},
+
+    // Super+F13..F17
+    {uint16_t(MOD_GUI | KC_F13), "§"},
+    {uint16_t(MOD_GUI | (KC_F13 + 1)), "”"},
+    {uint16_t(MOD_GUI | (KC_F13 + 2)), "™"},
+    {uint16_t(MOD_GUI | (KC_F13 + 3)), "~"},
+    {uint16_t(MOD_GUI | (KC_F13 + 4)), "_"},
+
+    // Super+Shift+F13..F17
+    {uint16_t(MOD_GUI | MOD_SHIFT | KC_F13), "←"},
+    {uint16_t(MOD_GUI | MOD_SHIFT | (KC_F13 + 1)), "↑"},
+    {uint16_t(MOD_GUI | MOD_SHIFT | (KC_F13 + 2)), "→"},
+    {uint16_t(MOD_GUI | MOD_SHIFT | (KC_F13 + 3)), "↓"},
+    {uint16_t(MOD_GUI | MOD_SHIFT | (KC_F13 + 4)), "↔"},
 }};
 
 std::optional<uint16_t> baseKeycodeForSym(KeySym sym) {
-    if (sym >= FcitxKey_F13 && sym <= FcitxKey_F24) {
+    if (sym >= FcitxKey_F13 && sym <= FcitxKey_F20) {
         return uint16_t(KC_F13 + (sym - FcitxKey_F13));
     }
     return std::nullopt;
@@ -137,6 +144,9 @@ uint16_t transportModifiers(KeyStates states) {
     }
     if (states.test(KeyState::Alt)) {
         modifiers |= MOD_ALT;
+    }
+    if (states.test(KeyState::Super)) {
+        modifiers |= MOD_GUI;
     }
     return modifiers;
 }

--- a/linux/ibus/README.md
+++ b/linux/ibus/README.md
@@ -1,6 +1,6 @@
 # Entropy IBus backend
 
-Wayland does not allow a normal application to globally intercept keys and inject text. This IBus backend is the safe Wayland-native path for Entropy Universal Symbols and Text Expander: it consumes the reserved `F13..F24` transport chords, watches ordinary typing while selected as an input method, and commits matching text through IBus.
+Wayland does not allow a normal application to globally intercept keys and inject text. This IBus backend is the safe Wayland-native path for Entropy Universal Symbols and Text Expander: it consumes the reserved `F13..F20` transport chords, watches ordinary typing while selected as an input method, and commits matching text through IBus.
 
 ## Install for current user
 
@@ -37,7 +37,7 @@ Required distro packages are usually:
 
 ## Behavior
 
-- Handles only Entropy transport keys: `F13..F24` with `Shift`, `Ctrl`, `Alt`, and `Ctrl+Alt`
+- Handles only Entropy transport keys: `F13..F20` with `Shift`, `Ctrl`, `Alt`, and `Super`
 - Commits the same Unicode symbols as Entropy Smart Input
 - Loads Text Expander settings from `~/.config/entropy/app_settings.json`
 - Loads primary and selected extra rules from `~/.config/entropy/text_expander_rules/`

--- a/linux/ibus/entropy-ibus-engine
+++ b/linux/ibus/entropy-ibus-engine
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """IBus engine for Entropy Universal Symbols and Text Expander.
 
-The backend consumes Entropy transport keys (F13..F24 plus Ctrl/Shift/Alt
+The backend consumes Entropy transport keys (F13..F20 plus Ctrl/Shift/Alt/Super
 banks) and can also expand configured Text Expander triggers through IBus.
 Other keys continue through the normal input stack.
 """
@@ -97,6 +97,7 @@ KC_F13 = 0x0068
 MOD_CTRL = 0x0100
 MOD_SHIFT = 0x0200
 MOD_ALT = 0x0400
+MOD_GUI = 0x0800
 EVDEV_F13_KEYCODE = 183
 XKB_F13_KEYCODE = EVDEV_F13_KEYCODE + 8
 TERMINAL_CLIENT_MARKERS = (
@@ -119,33 +120,45 @@ def _symbol_entries():
     def add(offset, symbol, modifiers=0):
         entries.append((KC_F13 + offset, modifiers, symbol))
 
-    # F13..F24
-    for idx, symbol in enumerate(["{", "}", "[", "]", "(", ")", "<", ">", "#", "@", "№", "₽"]):
+    # F13..F20
+    for idx, symbol in enumerate(["{", "}", "[", "]", "(", ")", "<", ">"]):
         add(idx, symbol)
 
-    # Shift+F13..F24
-    for idx, symbol in enumerate(["!", '"', "$", "%", "&", "'", "*", "+", "=", "?", "|", "\\"]):
+    # Shift+F13..F20
+    for idx, symbol in enumerate(["!", '"', "$", "%", "&", "'", "*", "+"]):
         add(idx, symbol, MOD_SHIFT)
 
-    # Ctrl+F13..F24
-    for idx, symbol in enumerate(["«", "»", "€", "—", "–", "•", "×", "±", "≠", "≈", "✓", "§"]):
+    # Ctrl+F13..F20
+    for idx, symbol in enumerate(["«", "»", "€", "—", "–", "•", "×", "±"]):
         add(idx, symbol, MOD_CTRL)
 
-    # Alt+F13..F24
-    for idx, symbol in enumerate([".", ",", ";", ":", "/", "`", "^", "←", "↑", "→", "↓", "↔"]):
+    # Alt+F13..F20
+    for idx, symbol in enumerate([".", ",", ";", ":", "/", "`", "^", "≠"]):
         add(idx, symbol, MOD_ALT)
 
-    # Ctrl+Alt+F13..F19
-    for idx, symbol in enumerate(["б", "ю", "ж", "э", "х", "ъ", "ё"]):
+    # Alt+Shift+F13..F20
+    for idx, symbol in enumerate(["#", "@", "№", "₽", "=", "?", "|", "\\"]):
+        add(idx, symbol, MOD_ALT | MOD_SHIFT)
+
+    # Ctrl+Alt+F13..F20
+    for idx, symbol in enumerate(["б", "ю", "ж", "э", "х", "ъ", "ё", "≈"]):
         add(idx, symbol, MOD_CTRL | MOD_ALT)
 
-    # Ctrl+Alt+Shift+F13..F19
-    for idx, symbol in enumerate(["Б", "Ю", "Ж", "Э", "Х", "Ъ", "Ё"]):
+    # Ctrl+Alt+Shift+F13..F20
+    for idx, symbol in enumerate(["Б", "Ю", "Ж", "Э", "Х", "Ъ", "Ё", "✓"]):
         add(idx, symbol, MOD_CTRL | MOD_ALT | MOD_SHIFT)
 
-    # Ctrl+Shift+F13..F24
-    for idx, symbol in enumerate(["°", "‰", "′", "″", "‘", "’", "„", "“", "”", "™", "~", "_"]):
+    # Ctrl+Shift+F13..F20
+    for idx, symbol in enumerate(["°", "‰", "′", "″", "‘", "’", "„", "“"]):
         add(idx, symbol, MOD_CTRL | MOD_SHIFT)
+
+    # Super+F13..F17
+    for idx, symbol in enumerate(["§", "”", "™", "~", "_"]):
+        add(idx, symbol, MOD_GUI)
+
+    # Super+Shift+F13..F17
+    for idx, symbol in enumerate(["←", "↑", "→", "↓", "↔"]):
+        add(idx, symbol, MOD_GUI | MOD_SHIFT)
 
     return entries
 
@@ -624,7 +637,7 @@ SHARED_TEXT_EXPANDER_RUNTIME = TextExpanderRuntime()
 
 
 def _transport_keycode_from_keyval(keyval):
-    if XK_F13 <= keyval <= XK_F13 + 11:
+    if XK_F13 <= keyval <= XK_F13 + 7:
         return KC_F13 + (keyval - XK_F13)
     return None
 
@@ -633,9 +646,9 @@ def _transport_keycode_from_event(keyval, keycode):
     by_keyval = _transport_keycode_from_keyval(keyval)
     if by_keyval is not None:
         return by_keyval, "keyval"
-    if EVDEV_F13_KEYCODE <= keycode <= EVDEV_F13_KEYCODE + 11:
+    if EVDEV_F13_KEYCODE <= keycode <= EVDEV_F13_KEYCODE + 7:
         return KC_F13 + (keycode - EVDEV_F13_KEYCODE), "evdev-keycode"
-    if XKB_F13_KEYCODE <= keycode <= XKB_F13_KEYCODE + 11:
+    if XKB_F13_KEYCODE <= keycode <= XKB_F13_KEYCODE + 7:
         return KC_F13 + (keycode - XKB_F13_KEYCODE), "xkb-keycode"
     return None, None
 
@@ -648,6 +661,8 @@ def _transport_modifiers(state):
         modifiers |= MOD_SHIFT
     if state & IBus.ModifierType.MOD1_MASK:
         modifiers |= MOD_ALT
+    if state & getattr(IBus.ModifierType, "SUPER_MASK", 0):
+        modifiers |= MOD_GUI
     return modifiers
 
 

--- a/src/smart_input.rs
+++ b/src/smart_input.rs
@@ -9,7 +9,7 @@ mod smart_input_symbols;
 #[path = "smart_input_windows.rs"]
 mod smart_input_windows;
 pub use smart_input_symbols::{smart_symbol_for_keycode, SMART_SYMBOLS};
-use smart_input_symbols::{KC_F13, MOD_ALT, MOD_CTRL, MOD_SHIFT};
+use smart_input_symbols::{KC_F13, MOD_ALT, MOD_CTRL, MOD_GUI, MOD_SHIFT};
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TextExpanderAppCandidate {
     pub exe: String,
@@ -375,6 +375,7 @@ fn smart_symbol_for_transport(
     ctrl: bool,
     shift: bool,
     alt: bool,
+    gui: bool,
 ) -> Option<(char, u16)> {
     let mut trigger_keycode = base_keycode;
     if ctrl {
@@ -385,6 +386,9 @@ fn smart_symbol_for_transport(
     }
     if alt {
         trigger_keycode |= MOD_ALT;
+    }
+    if gui {
+        trigger_keycode |= MOD_GUI;
     }
     smart_symbol_for_keycode(trigger_keycode).map(|symbol| (symbol.symbol, trigger_keycode))
 }
@@ -694,10 +698,11 @@ mod macos {
         let ctrl = flags & K_CG_EVENT_FLAG_MASK_CONTROL != 0;
         let shift = flags & K_CG_EVENT_FLAG_MASK_SHIFT != 0;
         let alt = flags & K_CG_EVENT_FLAG_MASK_ALTERNATE != 0;
+        let command = flags & K_CG_EVENT_FLAG_MASK_COMMAND != 0;
 
         if let Some(base_keycode) = mac_keycode_to_qmk_f_key(keycode) {
             if let Some((symbol, _trigger_keycode)) =
-                smart_symbol_for_transport(base_keycode, ctrl, shift, alt)
+                smart_symbol_for_transport(base_keycode, ctrl, shift, alt, command)
             {
                 if event_type == K_CG_EVENT_KEY_DOWN {
                     schedule_unicode_char(symbol);
@@ -943,12 +948,6 @@ end tell"#;
             0x4F => 5, // F18
             0x50 => 6, // F19
             0x5A => 7, // F20
-            // F21..F24 are not declared by HIToolbox, but external keyboards
-            // may still surface them through CGEvent with these adjacent codes.
-            0x5B => 8,
-            0x5C => 9,
-            0x5D => 10,
-            0x5E => 11,
             _ => return None,
         };
         Some(KC_F13 + offset)
@@ -1039,6 +1038,7 @@ mod linux_x11 {
     const LOCK_MASK: u32 = 2;
     const CONTROL_MASK: u32 = 4;
     const MOD1_MASK: u32 = 8;
+    const MOD4_MASK: u32 = 64;
     const KEY_PRESS: i32 = 2;
     const KEY_RELEASE: i32 = 3;
 
@@ -1092,8 +1092,9 @@ mod linux_x11 {
                 let ctrl = xkey.state & CONTROL_MASK != 0;
                 let shift = xkey.state & SHIFT_MASK != 0;
                 let alt = xkey.state & MOD1_MASK != 0;
+                let gui = xkey.state & MOD4_MASK != 0;
                 if let Some((symbol, _trigger_keycode)) =
-                    smart_symbol_for_transport(*base_keycode, ctrl, shift, alt)
+                    smart_symbol_for_transport(*base_keycode, ctrl, shift, alt, gui)
                 {
                     if event_type == KEY_PRESS {
                         type_unicode(symbol);
@@ -1113,6 +1114,14 @@ mod linux_x11 {
             CONTROL_MASK | MOD1_MASK,
             SHIFT_MASK | MOD1_MASK,
             CONTROL_MASK | SHIFT_MASK | MOD1_MASK,
+            MOD4_MASK,
+            SHIFT_MASK | MOD4_MASK,
+            CONTROL_MASK | MOD4_MASK,
+            MOD1_MASK | MOD4_MASK,
+            CONTROL_MASK | SHIFT_MASK | MOD4_MASK,
+            CONTROL_MASK | MOD1_MASK | MOD4_MASK,
+            SHIFT_MASK | MOD1_MASK | MOD4_MASK,
+            CONTROL_MASK | SHIFT_MASK | MOD1_MASK | MOD4_MASK,
         ];
         let lock_masks = [0, LOCK_MASK];
         let mut masks = Vec::with_capacity(base_masks.len() * lock_masks.len());

--- a/src/smart_input_symbols.rs
+++ b/src/smart_input_symbols.rs
@@ -9,9 +9,10 @@ pub(super) const KC_F13: u16 = 0x0068;
 pub(super) const MOD_CTRL: u16 = 0x0100;
 pub(super) const MOD_SHIFT: u16 = 0x0200;
 pub(super) const MOD_ALT: u16 = 0x0400;
+pub(super) const MOD_GUI: u16 = 0x0800;
 
 pub const SMART_SYMBOLS: &[SmartSymbol] = &[
-    // F13..F24
+    // F13..F20
     SmartSymbol {
         trigger_keycode: KC_F13,
         symbol: '{',
@@ -52,27 +53,7 @@ pub const SMART_SYMBOLS: &[SmartSymbol] = &[
         symbol: '>',
         name: "Greater-than",
     },
-    SmartSymbol {
-        trigger_keycode: KC_F13 + 8,
-        symbol: '#',
-        name: "Number sign",
-    },
-    SmartSymbol {
-        trigger_keycode: KC_F13 + 9,
-        symbol: '@',
-        name: "At sign",
-    },
-    SmartSymbol {
-        trigger_keycode: KC_F13 + 10,
-        symbol: '№',
-        name: "Numero sign",
-    },
-    SmartSymbol {
-        trigger_keycode: KC_F13 + 11,
-        symbol: '₽',
-        name: "Ruble sign",
-    },
-    // Shift+F13..F24
+    // Shift+F13..F20
     SmartSymbol {
         trigger_keycode: MOD_SHIFT | KC_F13,
         symbol: '!',
@@ -113,27 +94,7 @@ pub const SMART_SYMBOLS: &[SmartSymbol] = &[
         symbol: '+',
         name: "Plus sign",
     },
-    SmartSymbol {
-        trigger_keycode: MOD_SHIFT | (KC_F13 + 8),
-        symbol: '=',
-        name: "Equals sign",
-    },
-    SmartSymbol {
-        trigger_keycode: MOD_SHIFT | (KC_F13 + 9),
-        symbol: '?',
-        name: "Question mark",
-    },
-    SmartSymbol {
-        trigger_keycode: MOD_SHIFT | (KC_F13 + 10),
-        symbol: '|',
-        name: "Vertical bar",
-    },
-    SmartSymbol {
-        trigger_keycode: MOD_SHIFT | (KC_F13 + 11),
-        symbol: '\\',
-        name: "Backslash",
-    },
-    // Ctrl+F13..F24
+    // Ctrl+F13..F20
     SmartSymbol {
         trigger_keycode: MOD_CTRL | KC_F13,
         symbol: '«',
@@ -174,27 +135,7 @@ pub const SMART_SYMBOLS: &[SmartSymbol] = &[
         symbol: '±',
         name: "Plus-minus sign",
     },
-    SmartSymbol {
-        trigger_keycode: MOD_CTRL | (KC_F13 + 8),
-        symbol: '≠',
-        name: "Not equal sign",
-    },
-    SmartSymbol {
-        trigger_keycode: MOD_CTRL | (KC_F13 + 9),
-        symbol: '≈',
-        name: "Almost equal sign",
-    },
-    SmartSymbol {
-        trigger_keycode: MOD_CTRL | (KC_F13 + 10),
-        symbol: '✓',
-        name: "Check mark",
-    },
-    SmartSymbol {
-        trigger_keycode: MOD_CTRL | (KC_F13 + 11),
-        symbol: '§',
-        name: "Section sign",
-    },
-    // Alt+F13..F24
+    // Alt+F13..F20
     SmartSymbol {
         trigger_keycode: MOD_ALT | KC_F13,
         symbol: '.',
@@ -232,30 +173,51 @@ pub const SMART_SYMBOLS: &[SmartSymbol] = &[
     },
     SmartSymbol {
         trigger_keycode: MOD_ALT | (KC_F13 + 7),
-        symbol: '←',
-        name: "Leftwards arrow",
+        symbol: '≠',
+        name: "Not equal sign",
+    },
+    // Alt+Shift+F13..F20
+    SmartSymbol {
+        trigger_keycode: MOD_ALT | MOD_SHIFT | KC_F13,
+        symbol: '#',
+        name: "Number sign",
     },
     SmartSymbol {
-        trigger_keycode: MOD_ALT | (KC_F13 + 8),
-        symbol: '↑',
-        name: "Upwards arrow",
+        trigger_keycode: MOD_ALT | MOD_SHIFT | (KC_F13 + 1),
+        symbol: '@',
+        name: "At sign",
     },
     SmartSymbol {
-        trigger_keycode: MOD_ALT | (KC_F13 + 9),
-        symbol: '→',
-        name: "Rightwards arrow",
+        trigger_keycode: MOD_ALT | MOD_SHIFT | (KC_F13 + 2),
+        symbol: '№',
+        name: "Numero sign",
     },
     SmartSymbol {
-        trigger_keycode: MOD_ALT | (KC_F13 + 10),
-        symbol: '↓',
-        name: "Downwards arrow",
+        trigger_keycode: MOD_ALT | MOD_SHIFT | (KC_F13 + 3),
+        symbol: '₽',
+        name: "Ruble sign",
     },
     SmartSymbol {
-        trigger_keycode: MOD_ALT | (KC_F13 + 11),
-        symbol: '↔',
-        name: "Left right arrow",
+        trigger_keycode: MOD_ALT | MOD_SHIFT | (KC_F13 + 4),
+        symbol: '=',
+        name: "Equals sign",
     },
-    // Ctrl+Alt+F13..F19
+    SmartSymbol {
+        trigger_keycode: MOD_ALT | MOD_SHIFT | (KC_F13 + 5),
+        symbol: '?',
+        name: "Question mark",
+    },
+    SmartSymbol {
+        trigger_keycode: MOD_ALT | MOD_SHIFT | (KC_F13 + 6),
+        symbol: '|',
+        name: "Vertical bar",
+    },
+    SmartSymbol {
+        trigger_keycode: MOD_ALT | MOD_SHIFT | (KC_F13 + 7),
+        symbol: '\\',
+        name: "Backslash",
+    },
+    // Ctrl+Alt+F13..F20
     SmartSymbol {
         trigger_keycode: MOD_CTRL | MOD_ALT | KC_F13,
         symbol: 'б',
@@ -291,7 +253,12 @@ pub const SMART_SYMBOLS: &[SmartSymbol] = &[
         symbol: 'ё',
         name: "Cyrillic yo",
     },
-    // Ctrl+Alt+Shift+F13..F19
+    SmartSymbol {
+        trigger_keycode: MOD_CTRL | MOD_ALT | (KC_F13 + 7),
+        symbol: '≈',
+        name: "Almost equal sign",
+    },
+    // Ctrl+Alt+Shift+F13..F20
     SmartSymbol {
         trigger_keycode: MOD_CTRL | MOD_ALT | MOD_SHIFT | KC_F13,
         symbol: 'Б',
@@ -327,7 +294,12 @@ pub const SMART_SYMBOLS: &[SmartSymbol] = &[
         symbol: 'Ё',
         name: "Cyrillic Yo",
     },
-    // Ctrl+Shift+F13..F24
+    SmartSymbol {
+        trigger_keycode: MOD_CTRL | MOD_ALT | MOD_SHIFT | (KC_F13 + 7),
+        symbol: '✓',
+        name: "Check mark",
+    },
+    // Ctrl+Shift+F13..F20
     SmartSymbol {
         trigger_keycode: MOD_CTRL | MOD_SHIFT | KC_F13,
         symbol: '°',
@@ -369,24 +341,54 @@ pub const SMART_SYMBOLS: &[SmartSymbol] = &[
         name: "Left double quotation mark",
     },
     SmartSymbol {
-        trigger_keycode: MOD_CTRL | MOD_SHIFT | (KC_F13 + 8),
+        trigger_keycode: MOD_GUI | KC_F13,
+        symbol: '§',
+        name: "Section sign",
+    },
+    SmartSymbol {
+        trigger_keycode: MOD_GUI | (KC_F13 + 1),
         symbol: '”',
         name: "Right double quotation mark",
     },
     SmartSymbol {
-        trigger_keycode: MOD_CTRL | MOD_SHIFT | (KC_F13 + 9),
+        trigger_keycode: MOD_GUI | (KC_F13 + 2),
         symbol: '™',
         name: "Trade mark sign",
     },
     SmartSymbol {
-        trigger_keycode: MOD_CTRL | MOD_SHIFT | (KC_F13 + 10),
+        trigger_keycode: MOD_GUI | (KC_F13 + 3),
         symbol: '~',
         name: "Tilde",
     },
     SmartSymbol {
-        trigger_keycode: MOD_CTRL | MOD_SHIFT | (KC_F13 + 11),
+        trigger_keycode: MOD_GUI | (KC_F13 + 4),
         symbol: '_',
         name: "Underscore",
+    },
+    SmartSymbol {
+        trigger_keycode: MOD_GUI | MOD_SHIFT | KC_F13,
+        symbol: '←',
+        name: "Leftwards arrow",
+    },
+    SmartSymbol {
+        trigger_keycode: MOD_GUI | MOD_SHIFT | (KC_F13 + 1),
+        symbol: '↑',
+        name: "Upwards arrow",
+    },
+    SmartSymbol {
+        trigger_keycode: MOD_GUI | MOD_SHIFT | (KC_F13 + 2),
+        symbol: '→',
+        name: "Rightwards arrow",
+    },
+    SmartSymbol {
+        trigger_keycode: MOD_GUI | MOD_SHIFT | (KC_F13 + 3),
+        symbol: '↓',
+        name: "Downwards arrow",
+    },
+    SmartSymbol {
+        trigger_keycode: MOD_GUI | MOD_SHIFT | (KC_F13 + 4),
+        symbol: '↔',
+        name: "Left right arrow",
     },
 ];
 
@@ -402,13 +404,48 @@ mod tests {
     use super::*;
 
     #[test]
-    fn arrow_symbols_use_unused_alt_function_key_slots() {
+    fn arrow_symbols_use_gui_shift_function_key_slots() {
         let expected = [
-            (MOD_ALT | (KC_F13 + 7), '←'),
-            (MOD_ALT | (KC_F13 + 8), '↑'),
-            (MOD_ALT | (KC_F13 + 9), '→'),
-            (MOD_ALT | (KC_F13 + 10), '↓'),
-            (MOD_ALT | (KC_F13 + 11), '↔'),
+            (MOD_GUI | MOD_SHIFT | KC_F13, '←'),
+            (MOD_GUI | MOD_SHIFT | (KC_F13 + 1), '↑'),
+            (MOD_GUI | MOD_SHIFT | (KC_F13 + 2), '→'),
+            (MOD_GUI | MOD_SHIFT | (KC_F13 + 3), '↓'),
+            (MOD_GUI | MOD_SHIFT | (KC_F13 + 4), '↔'),
+        ];
+
+        for (keycode, symbol) in expected {
+            assert_eq!(
+                smart_symbol_for_keycode(keycode).map(|smart_symbol| smart_symbol.symbol),
+                Some(symbol)
+            );
+        }
+    }
+
+    #[test]
+    fn universal_symbol_triggers_use_f13_through_f20_only() {
+        for symbol in SMART_SYMBOLS {
+            let base_keycode = symbol.trigger_keycode & 0x00FF;
+            assert!(
+                (KC_F13..=KC_F13 + 7).contains(&base_keycode),
+                "{} uses F{}",
+                symbol.name,
+                base_keycode - KC_F13 + 13
+            );
+        }
+    }
+
+    #[test]
+    fn remapped_universal_symbols_use_mac_friendly_transport_slots() {
+        let expected = [
+            (MOD_ALT | MOD_SHIFT | KC_F13, '#'),
+            (MOD_ALT | MOD_SHIFT | (KC_F13 + 3), '₽'),
+            (MOD_ALT | MOD_SHIFT | (KC_F13 + 4), '='),
+            (MOD_GUI | KC_F13, '§'),
+            (MOD_GUI | (KC_F13 + 1), '”'),
+            (MOD_GUI | (KC_F13 + 4), '_'),
+            (MOD_ALT | (KC_F13 + 7), '≠'),
+            (MOD_CTRL | MOD_ALT | (KC_F13 + 7), '≈'),
+            (MOD_CTRL | MOD_ALT | MOD_SHIFT | (KC_F13 + 7), '✓'),
         ];
 
         for (keycode, symbol) in expected {

--- a/src/smart_input_windows.rs
+++ b/src/smart_input_windows.rs
@@ -146,6 +146,7 @@ fn symbol_for_vk(vk: u32) -> Option<(char, u16)> {
         modifier_down(VK_CONTROL),
         modifier_down(VK_SHIFT),
         modifier_down(VK_MENU),
+        modifier_down(VK_LWIN) || modifier_down(VK_RWIN),
     )
 }
 
@@ -160,6 +161,7 @@ fn modifier_group_for_vk(vk: u32) -> u32 {
         VK_SHIFT | VK_LSHIFT | VK_RSHIFT => MOD_SHIFT as u32,
         VK_CONTROL | VK_LCONTROL | VK_RCONTROL => MOD_CTRL as u32,
         VK_MENU | VK_LMENU | VK_RMENU => MOD_ALT as u32,
+        VK_LWIN | VK_RWIN => MOD_GUI as u32,
         _ => 0,
     }
 }
@@ -167,7 +169,7 @@ fn modifier_group_for_vk(vk: u32) -> u32 {
 #[cfg(target_os = "windows")]
 fn suppress_transport_modifier_keyups(trigger_keycode: u16) {
     TRANSPORT_MODIFIER_KEYUPS_TO_SUPPRESS.fetch_or(
-        trigger_keycode as u32 & (MOD_CTRL | MOD_SHIFT | MOD_ALT) as u32,
+        trigger_keycode as u32 & (MOD_CTRL | MOD_SHIFT | MOD_ALT | MOD_GUI) as u32,
         std::sync::atomic::Ordering::Relaxed,
     );
 }
@@ -558,6 +560,7 @@ fn schedule_unicode_char(symbol: char, trigger_keycode: u16) {
 #[cfg(target_os = "windows")]
 unsafe fn send_unicode_char(symbol: char, trigger_keycode: u16) {
     neutralize_transport_alt_menu(trigger_keycode);
+    neutralize_transport_gui_menu(trigger_keycode);
     release_transport_modifiers(trigger_keycode);
     let symbol_text = symbol.to_string();
     if should_paste_universal_symbol_for_foreground_app()
@@ -593,8 +596,16 @@ unsafe fn neutralize_transport_alt_menu(trigger_keycode: u16) {
     if trigger_keycode & MOD_ALT == 0 {
         return;
     }
-    // The foreground app already saw Alt down before F13..F24 was suppressed.
+    // The foreground app already saw Alt down before the transport key was suppressed.
     // Send a harmless Alt+F24 tap so Windows does not treat the later Alt up as menu activation.
+    send_vk_tap(VK_F24 as u16);
+}
+
+#[cfg(target_os = "windows")]
+unsafe fn neutralize_transport_gui_menu(trigger_keycode: u16) {
+    if trigger_keycode & MOD_GUI == 0 {
+        return;
+    }
     send_vk_tap(VK_F24 as u16);
 }
 
@@ -608,6 +619,9 @@ unsafe fn release_transport_modifiers(trigger_keycode: u16) {
     }
     if trigger_keycode & MOD_CTRL != 0 {
         release_modifier_pair(VK_CONTROL, VK_LCONTROL, VK_RCONTROL);
+    }
+    if trigger_keycode & MOD_GUI != 0 {
+        release_modifier_pair(VK_LWIN, VK_LWIN, VK_RWIN);
     }
 }
 


### PR DESCRIPTION
## EN
### Summary

This PR remaps Entropy Universal Symbols away from F21-F24 so the transport stays inside F13-F20 with modifier banks that macOS can reliably observe.

- Keeps the same 74 universal symbols, but moves symbols that previously used F21-F24 into Alt+Shift, Ctrl+Alt, Ctrl+Alt+Shift, Command/Super/Win, and Command/Super/Win+Shift combinations over F13-F20.
- Updates the shared symbol catalog and macOS smart-input handling so Command-modified transport chords are recognized on macOS.
- Updates Windows smart input to include Win-key transport modifiers and suppress their key-up events after a symbol trigger.
- Keeps Linux backends in sync by adding Super modifier support to X11, IBus, and Fcitx5 while narrowing accepted transport keys to F13-F20.
- Updates the IBus/Fcitx5 README wording to document the new reserved transport range.

### Verification
- `git diff --check`
- `mise x rust@stable -- rustfmt --edition 2021 --check src/smart_input.rs src/smart_input_symbols.rs src/smart_input_windows.rs`
- `python3 -m py_compile linux/ibus/entropy-ibus-engine`
- `mise x rust@stable -- cargo test smart_input_symbols --quiet` passes: 4 tests.
- Fcitx5 symbol-table count check returns 74 entries.
- Stale transport search for `F13..F24`, `F21..F24`, and `KC_F13 + 8..11` returns 0 matches.
- `mise x rust@stable -- cargo test --quiet` passes: 61 tests, with existing warnings.

## RU
### Кратко

Этот PR переносит универсальные символы Entropy с F21-F24 на F13-F20 с модификаторами, которые macOS распознает.

- Сохраняет те же 74 универсальных символа, но переносит символы, которые раньше использовали F21-F24, в комбинации Alt+Shift, Ctrl+Alt, Ctrl+Alt+Shift, Command/Super/Win и Command/Super/Win+Shift поверх F13-F20.
- Обновляет общий каталог символов и macOS smart input, чтобы Command-комбинации транспорта распознавались на macOS.
- Обновляет Windows smart input: добавляет Win-модификатор в транспорт и подавляет отпускание Win после срабатывания символа.
- Синхронизирует Linux-бэкенды: добавляет поддержку Super в X11, IBus и Fcitx5 и сужает допустимые транспортные клавиши до F13-F20.
- Обновляет README для IBus/Fcitx5 с новым диапазоном зарезервированных транспортных клавиш.

### Проверка
- `git diff --check`
- `mise x rust@stable -- rustfmt --edition 2021 --check src/smart_input.rs src/smart_input_symbols.rs src/smart_input_windows.rs`
- `python3 -m py_compile linux/ibus/entropy-ibus-engine`
- `mise x rust@stable -- cargo test smart_input_symbols --quiet` проходит: 4 теста.
- Проверка количества символов в таблице Fcitx5 возвращает 74 записи.
- Поиск устаревшего транспорта `F13..F24`, `F21..F24` и `KC_F13 + 8..11` возвращает 0 совпадений.
- `mise x rust@stable -- cargo test --quiet` проходит: 61 тест, с существующими warnings.
