### PR TITLE
Fix rapid Windows universal punctuation pairs

### DIFF
--- a/src/smart_input.rs
+++ b/src/smart_input.rs
@@ -390,6 +390,22 @@ fn smart_symbol_for_transport(
 }
 
 #[cfg(any(target_os = "windows", test))]
+fn windows_smart_symbol_for_transport(
+    base_keycode: u16,
+    ctrl: bool,
+    shift: bool,
+    alt: bool,
+    observed_modifiers: u16,
+) -> Option<(char, u16)> {
+    smart_symbol_for_transport(
+        base_keycode,
+        ctrl || observed_modifiers & MOD_CTRL != 0,
+        shift || observed_modifiers & MOD_SHIFT != 0,
+        alt || observed_modifiers & MOD_ALT != 0,
+    )
+}
+
+#[cfg(any(target_os = "windows", test))]
 fn app_prefers_clipboard_unicode_input(exe: &str) -> bool {
     matches!(
         exe.strip_suffix(".exe").unwrap_or(exe),
@@ -1200,5 +1216,15 @@ mod tests {
     #[test]
     fn editplus_uses_clipboard_fallback_for_universal_symbols() {
         assert!(app_prefers_clipboard_unicode_input("editplus.exe"));
+    }
+
+    #[test]
+    fn windows_transport_uses_observed_alt_state_for_rapid_punctuation_pairs() {
+        let comma =
+            windows_smart_symbol_for_transport(KC_F13 + 1, false, false, false, MOD_ALT).unwrap();
+        assert_eq!(comma.0, ',');
+
+        let dot = windows_smart_symbol_for_transport(KC_F13, false, false, false, MOD_ALT).unwrap();
+        assert_eq!(dot.0, '.');
     }
 }

--- a/src/smart_input_windows.rs
+++ b/src/smart_input_windows.rs
@@ -194,7 +194,7 @@ fn suppress_transport_modifier_keyups(trigger_keycode: u16) {
 
 #[cfg(target_os = "windows")]
 fn should_suppress_transport_modifier_keyup(vk: u32) -> bool {
-    let group = modifier_group_for_vk(vk);
+    let group = modifier_group_for_vk(vk) as u32;
     if group == 0 {
         return false;
     }

--- a/src/smart_input_windows.rs
+++ b/src/smart_input_windows.rs
@@ -141,11 +141,12 @@ fn symbol_for_vk(vk: u32) -> Option<(char, u16)> {
         0x7C..=0x87 => KC_F13 + (vk - 0x7C) as u16,
         _ => return None,
     };
-    smart_symbol_for_transport(
+    windows_smart_symbol_for_transport(
         base_keycode,
         modifier_down(VK_CONTROL),
         modifier_down(VK_SHIFT),
         modifier_down(VK_MENU),
+        active_transport_modifiers(),
     )
 }
 
@@ -155,13 +156,32 @@ fn modifier_down(vk: i32) -> bool {
 }
 
 #[cfg(target_os = "windows")]
-fn modifier_group_for_vk(vk: u32) -> u32 {
+fn modifier_group_for_vk(vk: u32) -> u16 {
     match vk as i32 {
-        VK_SHIFT | VK_LSHIFT | VK_RSHIFT => MOD_SHIFT as u32,
-        VK_CONTROL | VK_LCONTROL | VK_RCONTROL => MOD_CTRL as u32,
-        VK_MENU | VK_LMENU | VK_RMENU => MOD_ALT as u32,
+        VK_SHIFT | VK_LSHIFT | VK_RSHIFT => MOD_SHIFT,
+        VK_CONTROL | VK_LCONTROL | VK_RCONTROL => MOD_CTRL,
+        VK_MENU | VK_LMENU | VK_RMENU => MOD_ALT,
         _ => 0,
     }
+}
+
+#[cfg(target_os = "windows")]
+fn update_active_transport_modifier_state(vk: u32, is_key_down: bool, is_key_up: bool) {
+    let group = modifier_group_for_vk(vk);
+    if group == 0 {
+        return;
+    }
+    if is_key_down {
+        ACTIVE_TRANSPORT_MODIFIERS.fetch_or(group as u32, std::sync::atomic::Ordering::Relaxed);
+    } else if is_key_up {
+        ACTIVE_TRANSPORT_MODIFIERS.fetch_and(!(group as u32), std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn active_transport_modifiers() -> u16 {
+    (ACTIVE_TRANSPORT_MODIFIERS.load(std::sync::atomic::Ordering::Relaxed)
+        & (MOD_CTRL | MOD_SHIFT | MOD_ALT) as u32) as u16
 }
 
 #[cfg(target_os = "windows")]
@@ -258,6 +278,7 @@ unsafe extern "system" fn keyboard_proc(n_code: i32, w_param: usize, l_param: is
         let is_key_up = w_param == WM_KEYUP || w_param == WM_SYSKEYUP;
         let injected = info.flags & LLKHF_INJECTED != 0;
         if !injected {
+            update_active_transport_modifier_state(info.vkCode, is_key_down, is_key_up);
             if is_key_down {
                 remember_current_foreground_app();
             }
@@ -716,6 +737,10 @@ const WINEVENT_OUTOFCONTEXT: u32 = 0x0000;
 
 #[cfg(target_os = "windows")]
 static TRANSPORT_MODIFIER_KEYUPS_TO_SUPPRESS: std::sync::atomic::AtomicU32 =
+    std::sync::atomic::AtomicU32::new(0);
+
+#[cfg(target_os = "windows")]
+static ACTIVE_TRANSPORT_MODIFIERS: std::sync::atomic::AtomicU32 =
     std::sync::atomic::AtomicU32::new(0);
 
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
## EN
### Summary

This PR fixes rapid Windows Universal Symbols pairs such as `,.` and `.,` producing braces on the second symbol.

- Tracks physical Ctrl/Shift/Alt transport modifier state from the low-level Windows keyboard hook.
- Resolves universal-symbol transport using both `GetAsyncKeyState` and the observed physical modifier snapshot.
- Preserves Alt for rapid follow-up F-key transport events after Entropy sends a synthetic Alt key-up to prevent Windows menu activation.
- Adds a regression test for the punctuation case where the async Alt state is already clear but the physical Alt transport state is still active.

### Root Cause

For Alt-based universal symbols, Entropy sends a synthetic Alt key-up while typing the first symbol so Windows does not activate the foreground app menu. During very rapid punctuation pairs, the second F-key can arrive while the user is still physically holding Alt, but after the async Windows Alt state has been cleared by that synthetic key-up. The old resolver then treated the second key as plain F13/F14, which map to `{` and `}`.

### Verification
- `git diff --check`
- `mise x rust@stable -- rustfmt --edition 2021 --check src/smart_input.rs src/smart_input_windows.rs`
- `mise x rust@stable -- cargo test windows_transport_uses_observed_alt_state_for_rapid_punctuation_pairs --quiet` passes: 1 test.
- `mise x rust@stable -- cargo test smart_input --quiet` passes: 7 tests.
- `mise x rust@stable -- cargo test --quiet` passes: 60 tests, with existing warnings.
- `mise x rust@stable -- cargo check --target x86_64-pc-windows-msvc --quiet` was attempted after installing the target, but this macOS environment lacks the Windows C toolchain/headers needed by `ring` (`assert.h`), so it stops before checking the app crate.

## RU
### Кратко

Этот PR исправляет ситуацию на Windows, когда быстрый ввод пар универсальных символов вроде `,.` и `.,` вставляет фигурную скобку на месте второго символа.

- Отслеживает физическое состояние транспортных модификаторов Ctrl/Shift/Alt через low-level Windows keyboard hook.
- Определяет универсальный символ по сумме `GetAsyncKeyState` и снимка физически удерживаемых транспортных модификаторов.
- Сохраняет Alt для быстрого следующего F-key события после того, как Entropy отправляет синтетическое отпускание Alt, чтобы Windows не активировал меню приложения.
- Добавляет тест для случая, когда async-состояние Alt уже сброшено, но физический Alt транспорта всё ещё удерживается.

### Причина

Для Alt-универсальных символов Entropy отправляет синтетическое отпускание Alt при вводе первого символа, чтобы Windows не активировал меню приложения на первом плане. При очень быстром вводе пары второй F-key может прийти, когда пользователь физически ещё держит Alt, но async-состояние Alt в Windows уже очищено этим синтетическим key-up.
Старый resolver считал второй key обычным F13/F14, которые соответствуют `{` и `}`.

### Проверка
- `git diff --check`
- `mise x rust@stable -- rustfmt --edition 2021 --check src/smart_input.rs src/smart_input_windows.rs`
- `mise x rust@stable -- cargo test windows_transport_uses_observed_alt_state_for_rapid_punctuation_pairs --quiet` проходит: 1 тест.
- `mise x rust@stable -- cargo test smart_input --quiet` проходит: 7 тестов.
- `mise x rust@stable -- cargo test --quiet` проходит: 60 тестов, с существующими warnings.
