### PR TITLE
Throttle tray background updates

### DIFF
--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -70,6 +70,8 @@ impl EntropyApp {
             tray_icon: None,
             #[cfg(target_os = "windows")]
             windows_hwnd: None,
+            #[cfg(target_os = "windows")]
+            windows_window_hidden_to_tray: false,
             #[cfg(target_os = "macos")]
             macos_ns_window: None,
             #[cfg(target_os = "macos")]

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1527,6 +1527,8 @@ pub struct EntropyApp {
     pub(crate) tray_icon: Option<tray_icon::TrayIcon>,
     #[cfg(target_os = "windows")]
     pub(crate) windows_hwnd: Option<isize>,
+    #[cfg(target_os = "windows")]
+    pub(crate) windows_window_hidden_to_tray: bool,
     #[cfg(target_os = "macos")]
     pub(crate) macos_ns_window: Option<usize>,
     #[cfg(target_os = "macos")]

--- a/src/ui/app_lifecycle.rs
+++ b/src/ui/app_lifecycle.rs
@@ -1,6 +1,57 @@
 use super::*;
 
+const HIDDEN_TO_TRAY_REPAINT_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
+const BLUETOOTH_VISIBLE_REPAINT_INTERVAL: std::time::Duration =
+    std::time::Duration::from_millis(16);
+const DEFAULT_VISIBLE_REPAINT_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
+
+fn hidden_to_tray_repaint_interval() -> std::time::Duration {
+    HIDDEN_TO_TRAY_REPAINT_INTERVAL
+}
+
+fn visible_repaint_interval(selected_device_is_bluetooth: bool) -> std::time::Duration {
+    if selected_device_is_bluetooth {
+        BLUETOOTH_VISIBLE_REPAINT_INTERVAL
+    } else {
+        DEFAULT_VISIBLE_REPAINT_INTERVAL
+    }
+}
+
+fn app_repaint_interval(
+    selected_device_is_bluetooth: bool,
+    main_window_hidden_to_tray: bool,
+) -> std::time::Duration {
+    if main_window_hidden_to_tray {
+        hidden_to_tray_repaint_interval()
+    } else {
+        visible_repaint_interval(selected_device_is_bluetooth)
+    }
+}
+
 impl EntropyApp {
+    fn main_window_hidden_to_tray(&self) -> bool {
+        #[cfg(target_os = "windows")]
+        {
+            self.windows_window_hidden_to_tray
+        }
+        #[cfg(target_os = "macos")]
+        {
+            self.macos_window_hidden_to_menu_bar
+        }
+        #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+        {
+            false
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn update_hidden_to_tray_background(&mut self, ctx: &egui::Context, now: f64) {
+        self.poll_connect(ctx);
+        self.poll_single_instance_signal(ctx);
+        self.poll_text_expander_deferred_save(now);
+        self.auto_reload_text_expander_rules_file(now);
+    }
+
     #[cfg(not(target_arch = "wasm32"))]
     fn import_pending(&self) -> bool {
         self.pending_entlayout_import_path.is_some()
@@ -291,16 +342,14 @@ impl eframe::App for EntropyApp {
             .and_then(|idx| self.device_manager.devices().get(idx))
             .map(|device| device.is_bluetooth_transport())
             .unwrap_or(false);
+        let main_window_hidden_to_tray = self.main_window_hidden_to_tray();
 
         // Keep lightweight device detection alive when idle. On Windows BLE, keep
         // UI repaint smooth but avoid frequent HID enumeration against the BLE stack.
         #[cfg(not(target_arch = "wasm32"))]
-        ctx.request_repaint_after(std::time::Duration::from_millis(
-            if selected_device_is_bluetooth {
-                16
-            } else {
-                250
-            },
+        ctx.request_repaint_after(app_repaint_interval(
+            selected_device_is_bluetooth,
+            main_window_hidden_to_tray,
         ));
 
         #[cfg(not(target_arch = "wasm32"))]
@@ -308,6 +357,13 @@ impl eframe::App for EntropyApp {
 
         // Auto-scan for device connect/disconnect changes.
         self.secondary_click_handled = false;
+        let now = ctx.input(|i| i.time);
+        #[cfg(not(target_arch = "wasm32"))]
+        if main_window_hidden_to_tray {
+            self.update_hidden_to_tray_background(ctx, now);
+            return;
+        }
+
         if let Some((layer, ki, kc)) = self.pending_handed_swap {
             if !ctx.input(|i| i.modifiers.ctrl) {
                 #[cfg(not(target_arch = "wasm32"))]
@@ -319,7 +375,6 @@ impl eframe::App for EntropyApp {
                 self.pending_handed_swap = None;
             }
         }
-        let now = ctx.input(|i| i.time);
         #[cfg(not(target_arch = "wasm32"))]
         self.handle_pending_imports(ctx, now);
         self.poll_text_expander_deferred_save(now);
@@ -969,5 +1024,34 @@ impl eframe::App for EntropyApp {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hidden_to_tray_repaint_interval_is_throttled() {
+        assert_eq!(
+            app_repaint_interval(true, true),
+            std::time::Duration::from_millis(500)
+        );
+        assert_eq!(
+            app_repaint_interval(false, true),
+            std::time::Duration::from_millis(500)
+        );
+    }
+
+    #[test]
+    fn visible_repaint_interval_keeps_bluetooth_responsive() {
+        assert_eq!(
+            visible_repaint_interval(true),
+            std::time::Duration::from_millis(16)
+        );
+        assert_eq!(
+            visible_repaint_interval(false),
+            std::time::Duration::from_millis(250)
+        );
     }
 }

--- a/src/ui/window_lifecycle.rs
+++ b/src/ui/window_lifecycle.rs
@@ -50,6 +50,7 @@ impl EntropyApp {
     pub(super) fn restore_from_tray(&mut self, ctx: &egui::Context) {
         #[cfg(target_os = "windows")]
         if let Some(hwnd) = self.windows_hwnd {
+            self.windows_window_hidden_to_tray = false;
             unsafe {
                 use windows_sys::Win32::UI::WindowsAndMessaging::{
                     SetForegroundWindow, ShowWindow, SW_RESTORE, SW_SHOW,
@@ -156,6 +157,7 @@ impl EntropyApp {
                     use windows_sys::Win32::UI::WindowsAndMessaging::{ShowWindow, SW_HIDE};
                     ShowWindow(hwnd as windows_sys::Win32::Foundation::HWND, SW_HIDE);
                 }
+                self.windows_window_hidden_to_tray = true;
                 self.status_msg = background_status.into();
                 return;
             }


### PR DESCRIPTION
## EN
### Summary

Fixes #59.

This PR reduces background CPU usage after closing Entropy to the tray/menu bar.

- Tracks when the Windows main window has been hidden with `SW_HIDE` for close-to-tray.
- Reuses the existing macOS menu-bar hidden state for the same throttled background path.
- Switches hidden tray/menu-bar updates to a 500 ms background tick instead of the foreground 16 ms Bluetooth / 250 ms default cadence.
- Skips the full UI render and automatic foreground device-scan path while hidden, while still polling tray restore, repeated-launch restore, in-flight scan/connect completion, and text-expander maintenance.
- Adds regression coverage for the repaint cadence decision.

### Root Cause

On Windows, close-to-tray hides the native HWND, but the main `eframe::App::update` loop kept scheduling normal foreground work. With a selected Bluetooth device this meant a 16 ms repaint cadence even though the window was invisible, and the update loop still reached the regular canvas/render and idle device-scan logic.

### Verification
- `git diff --check`
- `mise x rust@stable -- rustfmt --edition 2021 --check src/app_init.rs src/app_state.rs src/ui/app_lifecycle.rs src/ui/window_lifecycle.rs`
- `mise x rust@stable -- cargo test hidden_to_tray_repaint_interval_is_throttled --quiet` passes: 1 test.
- `mise x rust@stable -- cargo test visible_repaint_interval_keeps_bluetooth_responsive --quiet` passes: 1 test.
- `mise x rust@stable -- cargo test --quiet` passes: 61 tests, with existing warnings.
- `mise x rust@stable -- cargo check --target x86_64-pc-windows-msvc --quiet` was attempted, but this macOS environment lacks the Windows C toolchain/headers needed by `ring` (`assert.h`), so it stops before checking the app crate.

## RU
### Кратко

Этот PR снижает фоновую нагрузку CPU после закрытия Entropy в трей/менюбар.

- Отслеживает момент, когда главное окно Windows скрыто через `SW_HIDE` при close-to-tray.
- Использует уже существующее состояние скрытия в менюбар на macOS для того же throttled background path.
- Переключает скрытое окно в трее/менюбаре на фоновый тик 500 ms вместо foreground-частоты 16 ms для Bluetooth и 250 ms по умолчанию.
- Не выполняет полный UI render и обычный foreground auto-scan устройств, пока окно скрыто, но продолжает обрабатывать восстановление из трея, повторный запуск приложения, завершение уже начатого scan/connect и обслуживание Text Expander.
- Добавляет регрессионное покрытие для выбора repaint cadence.

### Причина

На Windows close-to-tray скрывал native HWND, но основной цикл `eframe::App::update` продолжал планировать обычную foreground-работу. При выбранном Bluetooth-устройстве это давало repaint каждые 16 ms, хотя окно уже невидимо, и цикл всё ещё доходил до обычного canvas/render и idle device-scan логики.

### Проверка
- `git diff --check`
- `mise x rust@stable -- rustfmt --edition 2021 --check src/app_init.rs src/app_state.rs src/ui/app_lifecycle.rs src/ui/window_lifecycle.rs`
- `mise x rust@stable -- cargo test hidden_to_tray_repaint_interval_is_throttled --quiet` проходит: 1 тест.
- `mise x rust@stable -- cargo test visible_repaint_interval_keeps_bluetooth_responsive --quiet` проходит: 1 тест.
- `mise x rust@stable -- cargo test --quiet` проходит: 61 тест, с существующими warnings.
- `mise x rust@stable -- cargo check --target x86_64-pc-windows-msvc --quiet` был запущен, но в этой macOS-среде нет Windows C toolchain/headers, необходимых `ring` (`assert.h`), поэтому проверка останавливается до app crate.
