### PR TITLE
Verify module setting writebacks

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -782,6 +782,25 @@ pub(crate) struct ModuleSettingsState {
     pub(crate) supported: bool,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ModuleSettingWritebackError {
+    SetFailed(String),
+    ReadbackFailed(String),
+    ReadbackMismatch { expected: u16, actual: u16 },
+}
+
+impl std::fmt::Display for ModuleSettingWritebackError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SetFailed(error) => write!(f, "set failed: {error}"),
+            Self::ReadbackFailed(error) => write!(f, "read-back failed: {error}"),
+            Self::ReadbackMismatch { expected, actual } => {
+                write!(f, "read back {actual}, expected {expected}")
+            }
+        }
+    }
+}
+
 impl ModuleSettingsState {
     pub(crate) fn selected_module_group(&self) -> Option<usize> {
         let selected = self.groups.get(self.selected_module_group)?;
@@ -818,6 +837,22 @@ impl ModuleSettingsState {
 
     pub(crate) fn set_value(&mut self, qsid: u16, value: u16) {
         self.values.insert(qsid, value);
+    }
+
+    pub(crate) fn write_verified_value(
+        &mut self,
+        qsid: u16,
+        expected: u16,
+        write: impl FnOnce() -> Result<(), String>,
+        read_back: impl FnOnce() -> Result<u16, String>,
+    ) -> Result<u16, ModuleSettingWritebackError> {
+        write().map_err(ModuleSettingWritebackError::SetFailed)?;
+        let actual = read_back().map_err(ModuleSettingWritebackError::ReadbackFailed)?;
+        if actual != expected {
+            return Err(ModuleSettingWritebackError::ReadbackMismatch { expected, actual });
+        }
+        self.set_value(qsid, actual);
+        Ok(actual)
     }
 }
 
@@ -1622,4 +1657,71 @@ pub struct EntropyApp {
     pub(crate) vial_unlock_total: u8,
     pub(crate) vial_unlock_last_poll: Option<std::time::Instant>,
     pub(crate) vial_unlock_animation_nonce: u64,
+}
+
+#[cfg(test)]
+mod module_settings_state_tests {
+    use super::*;
+
+    #[test]
+    fn verified_module_setting_write_commits_read_back_value() {
+        let mut settings = ModuleSettingsState::default();
+        settings.set_value(42, 7);
+
+        let result = settings.write_verified_value(42, 9, || Ok(()), || Ok(9));
+
+        assert_eq!(result, Ok(9));
+        assert_eq!(settings.value(42), 9);
+    }
+
+    #[test]
+    fn verified_module_setting_write_keeps_old_value_when_set_fails() {
+        let mut settings = ModuleSettingsState::default();
+        settings.set_value(42, 7);
+
+        let result =
+            settings.write_verified_value(42, 9, || Err("device offline".to_owned()), || Ok(9));
+
+        assert_eq!(
+            result,
+            Err(ModuleSettingWritebackError::SetFailed(
+                "device offline".to_owned()
+            ))
+        );
+        assert_eq!(settings.value(42), 7);
+    }
+
+    #[test]
+    fn verified_module_setting_write_keeps_old_value_when_readback_fails() {
+        let mut settings = ModuleSettingsState::default();
+        settings.set_value(42, 7);
+
+        let result =
+            settings.write_verified_value(42, 9, || Ok(()), || Err("read failed".to_owned()));
+
+        assert_eq!(
+            result,
+            Err(ModuleSettingWritebackError::ReadbackFailed(
+                "read failed".to_owned()
+            ))
+        );
+        assert_eq!(settings.value(42), 7);
+    }
+
+    #[test]
+    fn verified_module_setting_write_keeps_old_value_when_readback_mismatches() {
+        let mut settings = ModuleSettingsState::default();
+        settings.set_value(42, 7);
+
+        let result = settings.write_verified_value(42, 9, || Ok(()), || Ok(8));
+
+        assert_eq!(
+            result,
+            Err(ModuleSettingWritebackError::ReadbackMismatch {
+                expected: 9,
+                actual: 8
+            })
+        );
+        assert_eq!(settings.value(42), 7);
+    }
 }

--- a/src/ui/module_settings.rs
+++ b/src/ui/module_settings.rs
@@ -7,6 +7,8 @@ enum ModuleSettingsRow {
     Field { group_idx: usize, field_idx: usize },
 }
 
+const MODULE_SETTING_WRITEBACK_DELAY: std::time::Duration = std::time::Duration::from_millis(20);
+
 impl EntropyApp {
     fn module_setting_display_title<'a>(
         &self,
@@ -93,19 +95,84 @@ impl EntropyApp {
         crate::i18n::tr_catalog_format(lang, key, &[("field", field_label.as_str())])
     }
 
-    fn write_module_setting_value(&mut self, field: &ModuleSettingField, value: u16) {
-        self.module_settings.set_value(field.qsid, value);
-        let Some(hid) = &self.hid_device else {
+    fn module_setting_transport_value(field: &ModuleSettingField, value: u16) -> u16 {
+        if field.width > 1 {
+            value
+        } else {
+            value.min(u8::MAX as u16)
+        }
+    }
+
+    fn write_module_setting_value(
+        &mut self,
+        group_idx: usize,
+        field: &ModuleSettingField,
+        value: u16,
+    ) {
+        let group_title = self
+            .module_settings
+            .groups
+            .get(group_idx)
+            .map(|group| group.title.clone())
+            .unwrap_or_else(|| "Modules".to_owned());
+        let field_title = field.title.clone();
+        let old_value = self.module_settings.value(field.qsid);
+        let requested = Self::module_setting_transport_value(field, value);
+
+        let Some(hid) = self.hid_device.as_ref() else {
+            self.status_msg = format!(
+                "Failed to save module setting (qsid {}): device is not connected",
+                field.qsid
+            );
+            log::warn!(
+                "module setting write skipped: group={group_title:?} field={field_title:?} qsid={} old={} requested={} readback=unavailable error=device not connected",
+                field.qsid,
+                old_value,
+                requested,
+            );
             return;
         };
-        let result = if field.width > 1 {
-            hid.set_qmk_setting_u16(field.qsid, value)
-        } else {
-            hid.set_qmk_setting_u8(field.qsid, value.min(u8::MAX as u16) as u8)
-        };
-        if let Err(e) = result {
-            self.status_msg = format!("Failed to save module setting (qsid {}): {}", field.qsid, e);
-            log::warn!("set_qmk_setting(module qsid {}) failed: {e}", field.qsid);
+
+        let result = self.module_settings.write_verified_value(
+            field.qsid,
+            requested,
+            || {
+                if field.width > 1 {
+                    hid.set_qmk_setting_u16(field.qsid, requested)
+                } else {
+                    hid.set_qmk_setting_u8(field.qsid, requested as u8)
+                }
+                .map_err(|error| error.to_string())
+            },
+            || {
+                std::thread::sleep(MODULE_SETTING_WRITEBACK_DELAY);
+                if field.width > 1 {
+                    hid.get_qmk_setting_u16(field.qsid)
+                } else {
+                    hid.get_qmk_setting_u8(field.qsid)
+                        .map(|readback| readback as u16)
+                }
+                .map_err(|error| error.to_string())
+            },
+        );
+
+        if let Err(error) = result {
+            let readback = match &error {
+                ModuleSettingWritebackError::ReadbackMismatch { actual, .. } => actual.to_string(),
+                _ => "unavailable".to_owned(),
+            };
+            self.status_msg = format!(
+                "Failed to save module setting {} (qsid {}): {}",
+                field_title, field.qsid, error
+            );
+            log::warn!(
+                "module setting writeback failed: group={group_title:?} field={field_title:?} qsid={} old={} requested={} readback={} error={}",
+                field.qsid,
+                old_value,
+                requested,
+                readback,
+                error,
+            );
         }
     }
 
@@ -161,7 +228,7 @@ impl EntropyApp {
                             } else {
                                 raw_value & !mask
                             };
-                            self.write_module_setting_value(&field, new_value);
+                            self.write_module_setting_value(group_idx, &field, new_value);
                         }
                     },
                 );
@@ -205,7 +272,7 @@ impl EntropyApp {
                                 Ok(value) => {
                                     let value = value.clamp(field.min, field.max);
                                     if value != raw_value {
-                                        self.write_module_setting_value(&field, value);
+                                        self.write_module_setting_value(group_idx, &field, value);
                                     }
                                     text = value.to_string();
                                 }
@@ -247,7 +314,7 @@ impl EntropyApp {
                             dropdown_width,
                         );
                         if let Some(picked) = picked {
-                            self.write_module_setting_value(&field, picked as u16);
+                            self.write_module_setting_value(group_idx, &field, picked as u16);
                         }
                     },
                 );


### PR DESCRIPTION
## EN
### Summary

This PR makes module setting changes observable instead of optimistic, so left/right controller modes no longer silently drift from firmware state when a write or read-back fails.

- Writes the requested QMK setting, waits briefly, and reads the same qsid back before updating local UI state.
- Keeps the previous UI value on set failures, read-back failures, or mismatched read-back values.
- Logs group, field, qsid, old value, requested value, and readback/error details to diagnose controller mode issues such as intermittent left-scroll behavior.
- Adds regression coverage for successful verified writes and each failure path.

### Root Cause

The module settings screen previously updated local state before sending the HID write, then treated `set_qmk_setting_*` success as enough. If firmware rejected, delayed, or returned a different persistent value, Entropy could show the requested left/right controller mode even though the device still held a different mode, making scroll/normal mode interactions hard to diagnose.

### Verification

- `git diff --check`
- `/Users/igor.arkhipov/.cargo/bin/rustfmt --edition 2021 --check src/app_state.rs src/ui/module_settings.rs`
- `/Users/igor.arkhipov/.cargo/bin/cargo test` passes: 63 tests, with existing warnings.
- `cargo fmt -- --check` was attempted, but current `main` reports unrelated formatting diffs outside this branch; touched files pass the explicit rustfmt check above.

## RU
### Кратко

Этот PR делает изменение настроек модулей проверяемым, а не оптимистичным: режимы левого/правого контроллера больше не могут молча разойтись с состоянием firmware, если запись или read-back не прошли.

- Записывает запрошенную QMK настройку, коротко ждёт и читает тот же qsid обратно перед обновлением локального UI state.
- Оставляет предыдущее значение в UI при ошибке записи, ошибке read-back или несовпадении прочитанного значения.
- Логирует group, field, qsid, старое значение, запрошенное значение и readback/error details для диагностики проблем с controller mode, включая нестабильный left-scroll.
- Добавляет регрессионные тесты для успешной проверенной записи настроек и всех failure paths.

### Причина

Экран module settings раньше обновлял локальное состояние до HID-записи, а затем считал успешный `set_qmk_setting_*` достаточным подтверждением.
Если firmware отклоняла запись, применяла ее с задержкой или возвращала другое persistent value, Entropy мог показывать запрошенный режим левого/правого контроллера, хотя устройство продолжало хранить другое значение, из-за чего взаимодействие scroll/normal modes было трудно диагностировать.

### Проверка

- `git diff --check`
- `/Users/igor.arkhipov/.cargo/bin/rustfmt --edition 2021 --check src/app_state.rs src/ui/module_settings.rs`
- `/Users/igor.arkhipov/.cargo/bin/cargo test` проходит: 63 теста, с существующими warnings.
- `cargo fmt -- --check` был запущен, но текущий `main` показывает unrelated formatting diffs вне этого branch; touched files проходят explicit rustfmt check выше.
