### PR TITLE
Guard RMK macro layer actions

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -231,6 +231,11 @@ pub(crate) struct VialFeatureSupport {
     pub(crate) repeat_key: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MacroExtKeycodesDisabledReason {
+    RmkVialMacroExtUnsupported,
+}
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct DeviceAboutInfo {
     pub(crate) manufacturer: String,
@@ -246,6 +251,7 @@ pub(crate) struct DeviceAboutInfo {
     pub(crate) macro_memory_bytes: Option<u16>,
     pub(crate) supports_macro_delays: bool,
     pub(crate) supports_macro_ext_keycodes: bool,
+    pub(crate) macro_ext_keycodes_disabled_reason: Option<MacroExtKeycodesDisabledReason>,
     pub(crate) tap_dance_entries: usize,
     pub(crate) combo_entries: usize,
     pub(crate) key_override_entries: usize,
@@ -271,6 +277,7 @@ pub(crate) struct ConnectResult {
     pub(crate) macro_texts: Vec<Vec<u8>>,
     /// Vial protocol >= 5 supports 2-byte keycodes in macros.
     pub(crate) supports_macro_ext_keycodes: bool,
+    pub(crate) macro_ext_keycodes_disabled_reason: Option<MacroExtKeycodesDisabledReason>,
     /// Tap dance entries
     pub(crate) tap_dance_entries: Vec<crate::keycode_picker::TapDanceEntry>,
     /// Combo entries

--- a/src/keycode_picker.rs
+++ b/src/keycode_picker.rs
@@ -1,4 +1,5 @@
 /// Keycode picker modal for Vial/QMK keycodes.
+use crate::app::MacroExtKeycodesDisabledReason;
 use crate::keycode::{
     gui_label, gui_mod_name, gui_sym, key_label_font_sizes, keycode_label_with_names_and_layout,
     keycode_tooltip, modifier_label_from_bits, KeyLegendLayout, KeycodeCategory, KEYCODES,
@@ -127,6 +128,7 @@ pub struct KeycodePicker {
     pub supports_layer_lock: bool,
     pub supports_persistent_default_layer: bool,
     pub supports_macro_ext_keycodes: bool,
+    pub macro_ext_keycodes_disabled_reason: Option<MacroExtKeycodesDisabledReason>,
     pub layer_names: Vec<String>,
     pub layer_count: usize,
     pub layer_has_content: Vec<bool>,
@@ -191,6 +193,22 @@ mod tests {
         for symbol in ['←', '↑', '→', '↓', '↔'] {
             assert!(UNIVERSAL_EXTRA_SYMBOL_ORDER.contains(&symbol));
         }
+    }
+
+    #[test]
+    fn rmk_macro_ext_guard_hides_layer_macro_choices_and_explains_why() {
+        let mut picker = KeycodePicker::default();
+        picker.supports_macro_ext_keycodes = false;
+        picker.macro_ext_keycodes_disabled_reason =
+            Some(MacroExtKeycodesDisabledReason::RmkVialMacroExtUnsupported);
+
+        assert!(picker
+            .macro_layer_key_choices(MacroKeyPickKind::Tap)
+            .is_empty());
+        assert!(picker
+            .macro_ext_keycodes_notice(crate::i18n::Language::English)
+            .expect("RMK notice should be present")
+            .contains("RMK"));
     }
 }
 
@@ -306,6 +324,7 @@ impl Default for KeycodePicker {
             supports_layer_lock: true,
             supports_persistent_default_layer: true,
             supports_macro_ext_keycodes: true,
+            macro_ext_keycodes_disabled_reason: None,
             layer_names: (0..16).map(|i| i.to_string()).collect(),
             layer_count: 4,
             layer_has_content: vec![true; 16],
@@ -388,6 +407,19 @@ impl KeycodePicker {
         }
 
         self.layer_action_key_choices(kind)
+    }
+
+    fn macro_ext_keycodes_notice(&self, language: crate::i18n::Language) -> Option<&'static str> {
+        match self.macro_ext_keycodes_disabled_reason? {
+            MacroExtKeycodesDisabledReason::RmkVialMacroExtUnsupported => match language {
+                crate::i18n::Language::Russian => Some(
+                    "RMK сейчас не выполняет Vial extended macro keycodes. Действия слоев в macro отключены, чтобы не сохранять macro, которые не сработают на клавиатуре.",
+                ),
+                crate::i18n::Language::English => Some(
+                    "RMK currently does not execute Vial extended macro keycodes. Layer actions in macros are disabled to avoid saving macros that will not work on the keyboard.",
+                ),
+            },
+        }
     }
 
     fn layer_action_key_choices(&self, kind: MacroKeyPickKind) -> Vec<(u16, String, String)> {

--- a/src/keycode_picker_macro.rs
+++ b/src/keycode_picker_macro.rs
@@ -221,6 +221,14 @@ impl KeycodePicker {
             );
             return 254;
         }
+        if let Some(notice) = self.macro_ext_keycodes_notice(self.language) {
+            ui.label(
+                RichText::new(notice)
+                    .size(11.0)
+                    .color(Color32::from_rgb(180, 120, 40)),
+            );
+            ui.add_space(4.0);
+        }
         egui::Frame::NONE.show(ui, |ui| {
             let slot_scroll_height = 86.0 * responsive_picker_element_scale(ui.ctx());
             ui.set_max_height(slot_scroll_height);

--- a/src/ui/about_device.rs
+++ b/src/ui/about_device.rs
@@ -119,6 +119,22 @@ fn bytes_label(lang: crate::i18n::Language, bytes: u16) -> String {
     }
 }
 
+fn macro_ext_keycodes_status(lang: crate::i18n::Language, info: &DeviceAboutInfo) -> String {
+    if info.supports_macro_ext_keycodes {
+        return yes_no(lang, true).to_owned();
+    }
+
+    match info.macro_ext_keycodes_disabled_reason {
+        Some(MacroExtKeycodesDisabledReason::RmkVialMacroExtUnsupported) => match lang {
+            crate::i18n::Language::Russian => {
+                "нет, отключено для RMK macro compatibility".to_owned()
+            }
+            crate::i18n::Language::English => "no, disabled for RMK macro compatibility".to_owned(),
+        },
+        None => yes_no(lang, false).to_owned(),
+    }
+}
+
 fn device_about_rows(lang: crate::i18n::Language, info: &DeviceAboutInfo) -> Vec<AboutRow> {
     let firmware_version = info
         .firmware_version
@@ -233,7 +249,7 @@ fn device_about_rows(lang: crate::i18n::Language, info: &DeviceAboutInfo) -> Vec
             "2-byte macro keycodes",
             "Поддержка complex macro keycodes",
             "Complex macro keycode support",
-            yes_no(lang, info.supports_macro_ext_keycodes),
+            macro_ext_keycodes_status(lang, info),
         ),
         localized_row(
             lang,
@@ -639,5 +655,23 @@ impl EntropyApp {
                 });
             });
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn macro_ext_status_explains_rmk_guard() {
+        let info = DeviceAboutInfo {
+            supports_macro_ext_keycodes: false,
+            macro_ext_keycodes_disabled_reason: Some(
+                MacroExtKeycodesDisabledReason::RmkVialMacroExtUnsupported,
+            ),
+            ..Default::default()
+        };
+
+        assert!(macro_ext_keycodes_status(crate::i18n::Language::English, &info).contains("RMK"));
     }
 }

--- a/src/ui/device_connect_apply.rs
+++ b/src/ui/device_connect_apply.rs
@@ -149,6 +149,8 @@ impl EntropyApp {
                 self.keycode_picker.macro_texts = r.macro_texts.clone();
                 self.keycode_picker.macro_names = vec![String::new(); r.macro_texts.len()];
                 self.keycode_picker.supports_macro_ext_keycodes = r.supports_macro_ext_keycodes;
+                self.keycode_picker.macro_ext_keycodes_disabled_reason =
+                    r.macro_ext_keycodes_disabled_reason;
                 // Parse macro texts into actions (Vial protocol v2+ bytecode).
                 self.keycode_picker.macro_actions = r
                     .macro_texts

--- a/src/ui/device_connect_task.rs
+++ b/src/ui/device_connect_task.rs
@@ -132,6 +132,68 @@ fn firmware_version_from_vial_json(json: &serde_json::Value) -> Option<String> {
     .find_map(|path| json_path_string(json, path))
 }
 
+fn json_u16_value(value: &serde_json::Value) -> Option<u16> {
+    match value {
+        serde_json::Value::Number(number) => {
+            number.as_u64().and_then(|value| u16::try_from(value).ok())
+        }
+        serde_json::Value::String(text) => {
+            let trimmed = text.trim();
+            let hex = trimmed
+                .strip_prefix("0x")
+                .or_else(|| trimmed.strip_prefix("0X"));
+            if let Some(hex) = hex {
+                u16::from_str_radix(hex, 16).ok()
+            } else {
+                trimmed.parse::<u16>().ok()
+            }
+        }
+        _ => None,
+    }
+}
+
+fn json_path_u16(json: &serde_json::Value, path: &[&str]) -> Option<u16> {
+    let mut value = json;
+    for key in path {
+        value = value.get(*key)?;
+    }
+    json_u16_value(value)
+}
+
+fn json_path_contains_rmk(json: &serde_json::Value, path: &[&str]) -> bool {
+    json_path_string(json, path)
+        .map(|value| value.to_ascii_lowercase().contains("rmk"))
+        .unwrap_or(false)
+}
+
+fn is_rmk_vial_definition(json: &serde_json::Value) -> bool {
+    let text_marker = [
+        &["name"][..],
+        &["manufacturer"][..],
+        &["firmware", "name"][..],
+        &["firmware", "manufacturer"][..],
+    ]
+    .into_iter()
+    .any(|path| json_path_contains_rmk(json, path));
+    if text_marker {
+        return true;
+    }
+
+    json_path_u16(json, &["vendorId"]) == Some(0x4C4B)
+        && json_path_u16(json, &["productId"]) == Some(0x4643)
+}
+
+fn macro_ext_keycodes_disabled_reason(
+    json: &serde_json::Value,
+) -> Option<MacroExtKeycodesDisabledReason> {
+    is_rmk_vial_definition(json)
+        .then_some(MacroExtKeycodesDisabledReason::RmkVialMacroExtUnsupported)
+}
+
+fn supports_vial_macro_ext_keycodes(vial_protocol: u32, json: &serde_json::Value) -> bool {
+    vial_protocol >= 5 && macro_ext_keycodes_disabled_reason(json).is_none()
+}
+
 impl EntropyApp {
     pub(super) fn start_connect(&mut self, device_idx: usize) {
         let dev = match self.device_manager.devices().get(device_idx) {
@@ -815,6 +877,10 @@ impl EntropyApp {
                     entries
                 };
 
+                let macro_ext_keycodes_disabled_reason = macro_ext_keycodes_disabled_reason(&json);
+                let supports_macro_ext_keycodes =
+                    supports_vial_macro_ext_keycodes(vial_protocol, &json);
+
                 let about_info = DeviceAboutInfo {
                     manufacturer: dev.manufacturer.clone(),
                     product: dev.name.clone(),
@@ -828,7 +894,8 @@ impl EntropyApp {
                     macro_entries: macro_texts.len(),
                     macro_memory_bytes,
                     supports_macro_delays: !macro_texts.is_empty(),
-                    supports_macro_ext_keycodes: vial_protocol >= 5,
+                    supports_macro_ext_keycodes,
+                    macro_ext_keycodes_disabled_reason,
                     tap_dance_entries: tap_dance_entries.len(),
                     combo_entries: combo_entries.len(),
                     key_override_entries: key_override_entries.len(),
@@ -845,7 +912,8 @@ impl EntropyApp {
                     hid_device: Some(dev_conn),
                     about_info,
                     macro_texts,
-                    supports_macro_ext_keycodes: vial_protocol >= 5,
+                    supports_macro_ext_keycodes,
+                    macro_ext_keycodes_disabled_reason,
                     tap_dance_entries,
                     combo_entries,
                     combo_term,
@@ -883,5 +951,27 @@ mod tests {
     fn reported_layer_count_is_never_zero() {
         assert_eq!(normalize_reported_layer_count(0), 1);
         assert_eq!(normalize_reported_layer_count(4), 4);
+    }
+
+    #[test]
+    fn rmk_default_vial_definition_disables_macro_ext_keycodes() {
+        let json = serde_json::json!({
+            "name": "RMK Keyboard",
+            "vendorId": "0x4C4B",
+            "productId": "0x4643"
+        });
+
+        assert!(!supports_vial_macro_ext_keycodes(6, &json));
+    }
+
+    #[test]
+    fn non_rmk_vial_protocol_five_keeps_macro_ext_keycodes_enabled() {
+        let json = serde_json::json!({
+            "name": "Entropy Keyboard",
+            "vendorId": "0xFEED",
+            "productId": "0x0001"
+        });
+
+        assert!(supports_vial_macro_ext_keycodes(5, &json));
     }
 }


### PR DESCRIPTION
## EN
### Summary

This PR prevents RMK devices from offering Vial extended macro keycodes that RMK currently does not execute.

- Detects RMK-style Vial definitions and disables 2-byte macro keycodes for those devices.
- Hides macro layer/custom key choices that would serialize into unsupported extended macro opcodes.
- Shows a macro editor notice and About Device status so the limitation is visible instead of silently producing macros that will not work.

### Root Cause

RMK can report a Vial protocol version high enough for Entropy to treat 2-byte macro keycodes as available. Those extended macro opcodes are not executed by RMK today, so macros that combine actions such as layer switching with other steps could be saved by the UI but fail on the keyboard.

### Verification

- `git diff --check`
- `rtk env PATH="/Users/igor.arkhipov/.cargo/bin:$PATH" cargo test macro_ext -- --nocapture` passes: 4 tests, with existing warnings.
- `rtk env PATH="/Users/igor.arkhipov/.cargo/bin:$PATH" cargo test` passes: 63 tests, with existing warnings.
- Hardware validation was not run; the guard is covered with Vial-definition and picker/about-device regression tests.

## RU
### Кратко

Этот PR не дает RMK-устройствам предлагать Vial extended macro keycodes, которые RMK сейчас не выполняет.

- Определяет RMK-style Vial definitions и отключает 2-byte macro keycodes для таких устройств.
- Скрывает macro layer/custom key choices, которые сериализуются в неподдерживаемые extended macro opcodes.
- Показывает уведомление в macro editor и статус в About Device, чтобы ограничение было явным, а не приводило к сохранению macro, которые не сработают на клавиатуре.

### Причина

RMK может сообщать Vial версию протокола, достаточную для того, чтобы Entropy считал 2-byte macro keycodes доступными. Сейчас RMK не выполняет эти extended macro opcodes, поэтому macro со сменой слоя и другими шагами могли сохраняться в UI, но не работать на клавиатуре.

### Проверка

- `git diff --check`
- `rtk env PATH="/Users/igor.arkhipov/.cargo/bin:$PATH" cargo test macro_ext -- --nocapture` проходит: 4 теста, с существующими warnings.
- `rtk env PATH="/Users/igor.arkhipov/.cargo/bin:$PATH" cargo test` проходит: 63 теста, с существующими warnings.
- Hardware validation не запускался; guard покрыт regression tests для Vial definition, picker и About Device.
