### PR TITLE
Verify keycode writebacks

### DIFF
--- a/src/hid.rs
+++ b/src/hid.rs
@@ -119,6 +119,7 @@ mod hid_macros;
 
 #[path = "hid_keymap.rs"]
 mod hid_keymap;
+pub(crate) use hid_keymap::is_keycode_writeback_mismatch;
 
 #[path = "hid_settings.rs"]
 mod hid_settings;
@@ -623,6 +624,7 @@ fn response_matches_command(command: &[u8], resp: &[u8; MSG_LEN]) -> bool {
         CMD_VIA_GET_KEYBOARD_VALUE | CMD_VIA_LIGHTING_GET_VALUE => {
             command.len() >= 2 && resp[0] == cmd && resp[1] == command[1]
         }
+        CMD_VIA_GET_KEYCODE => command.len() >= 4 && resp[0] == cmd && resp[1..4] == command[1..4],
         CMD_VIA_SET_KEYBOARD_VALUE
         | CMD_VIA_SET_KEYCODE
         | CMD_VIA_LIGHTING_SET_VALUE

--- a/src/hid_keymap.rs
+++ b/src/hid_keymap.rs
@@ -3,6 +3,52 @@ use super::hid_protocol::*;
 use super::HidDevice;
 use anyhow::{bail, Context, Result};
 
+#[derive(Debug)]
+struct KeycodeWritebackMismatch {
+    layer: u8,
+    row: u8,
+    col: u8,
+    requested: u16,
+    readback: u16,
+}
+
+impl std::fmt::Display for KeycodeWritebackMismatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "keycode writeback mismatch at layer {}, row {}, col {}: wrote {:#06X}, read back {:#06X}",
+            self.layer, self.row, self.col, self.requested, self.readback
+        )
+    }
+}
+
+impl std::error::Error for KeycodeWritebackMismatch {}
+
+pub(crate) fn is_keycode_writeback_mismatch(error: &anyhow::Error) -> bool {
+    error.downcast_ref::<KeycodeWritebackMismatch>().is_some()
+}
+
+fn verify_keycode_writeback(
+    layer: u8,
+    row: u8,
+    col: u8,
+    requested: u16,
+    readback: u16,
+) -> Result<()> {
+    if readback == requested {
+        return Ok(());
+    }
+
+    Err(KeycodeWritebackMismatch {
+        layer,
+        row,
+        col,
+        requested,
+        readback,
+    }
+    .into())
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 impl HidDevice {
     pub fn get_layer_count(&self) -> Result<u8> {
@@ -54,12 +100,23 @@ impl HidDevice {
         Ok(parse_keymap_u16_be(&keymap))
     }
 
+    pub fn get_keycode(&self, layer: u8, row: u8, col: u8) -> Result<u16> {
+        let resp = self
+            .usb_send(&[CMD_VIA_GET_KEYCODE, layer, row, col])
+            .with_context(|| {
+                format!("failed to read keycode at layer {layer}, row {row}, col {col}")
+            })?;
+        Ok(u16::from_be_bytes([resp[4], resp[5]]))
+    }
+
     pub fn set_keycode(&self, layer: u8, row: u8, col: u8, keycode: u16) -> Result<()> {
         let [hi, lo] = keycode.to_be_bytes();
         self.usb_send(&[CMD_VIA_SET_KEYCODE, layer, row, col, hi, lo])
             .with_context(|| {
                 format!("failed to set keycode at layer {layer}, row {row}, col {col}")
             })?;
+        let readback = self.get_keycode(layer, row, col)?;
+        verify_keycode_writeback(layer, row, col, keycode, readback)?;
         Ok(())
     }
 
@@ -92,5 +149,25 @@ impl HidDevice {
                 format!("failed to set encoder {idx} direction {direction} on layer {layer}")
             })?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keycode_writeback_accepts_matching_kc_no() {
+        assert!(verify_keycode_writeback(5, 3, 7, 0x0000, 0x0000).is_ok());
+    }
+
+    #[test]
+    fn keycode_writeback_rejects_stale_transparent_after_kc_no_write() {
+        let err = verify_keycode_writeback(5, 3, 7, 0x0000, 0x0001).unwrap_err();
+
+        assert!(
+            err.to_string().contains("read back 0x0001"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/src/ui/key_assignment.rs
+++ b/src/ui/key_assignment.rs
@@ -242,32 +242,34 @@ impl EntropyApp {
     }
 
     pub(super) fn assign_keycode(&mut self, layer: usize, ki: usize, kc_value: u16) {
-        // Save old value for undo
         let old_kc = self
             .layout
             .as_ref()
             .map(|l| l.get_keycode(layer, ki))
             .unwrap_or(0);
-        self.undo_stack.push(UndoAction::Key {
-            layer,
-            key_idx: ki,
-            old_kc,
-        });
-        // Update in-memory layout
-        if let Some(layout) = &mut self.layout {
-            layout.set_keycode(layer, ki, kc_value);
-        }
-        self.refresh_layer_picker_content_flags();
 
         let key = match self.layout.as_ref().and_then(|l| l.keys.get(ki)) {
             Some(k) => k.clone(),
             None => return,
         };
 
+        let commit_local_assignment = |this: &mut Self| {
+            this.undo_stack.push(UndoAction::Key {
+                layer,
+                key_idx: ki,
+                old_kc,
+            });
+            if let Some(layout) = &mut this.layout {
+                layout.set_keycode(layer, ki, kc_value);
+            }
+            this.refresh_layer_picker_content_flags();
+        };
+
         // Never open a fresh HID handle synchronously from the UI thread.
         // Connect keeps the active Vial handle alive; if it is unavailable,
         // keep the edit local/read-only instead of freezing the whole app.
         let Some(conn) = &self.hid_device else {
+            commit_local_assignment(self);
             self.status_msg =
                 "Read-only: key changed locally, firmware write disabled for this device".into();
             return;
@@ -275,11 +277,16 @@ impl EntropyApp {
         let result = conn.set_keycode(layer as u8, key.row, key.col, kc_value);
 
         match result {
-            Ok(()) => self.status_msg = "✓ Saved".into(),
+            Ok(()) => {
+                commit_local_assignment(self);
+                self.status_msg = "✓ Saved".into();
+            }
             Err(e) => {
                 self.status_msg = format!("Write error: {e}");
-                // Connection lost — reopen
-                self.hid_device = None;
+                if !crate::hid::is_keycode_writeback_mismatch(&e) {
+                    // Connection lost — reopen
+                    self.hid_device = None;
+                }
             }
         }
     }


### PR DESCRIPTION
## EN
### Summary

This PR verifies keycode writes by reading the affected key back from firmware before Entropy treats the assignment as saved.

- Adds `CMD_VIA_GET_KEYCODE` support for single-key readback.
- Verifies `SET_KEYCODE` by comparing the device readback with the requested keycode, including `KC_NO` / `0x0000`.
- Delays the local layout update until the device write is verified, so the UI no longer shows an optimistic value when firmware keeps an old/transparent keycode.
- Keeps the HID session alive for writeback mismatches, while preserving reconnect behavior for communication errors.

### Root Cause

The key picker preserved `KC_NO` and `KC_TRNS` correctly, but key assignment updated the in-memory layout before verifying the firmware write. If a device accepted the HID command shape but failed to store `0x0000`, Entropy could show `None` while the device still behaved as if the key were transparent or unchanged.

### Verification

- Confirmed no open PR matched keymap/keycode writeback verification.
- `git diff --check`
- `python3 scripts/check_i18n.py`
- `mise x rust@stable -- cargo test keycode_writeback --quiet` passes: 2 tests.
- `mise x rust@stable -- cargo test --quiet` passes: 61 tests, with existing warnings.

## RU
### Кратко

Этот PR проверяет запись keycode: после записи Entropy перечитывает эту же клавишу из прошивки и только потом считает назначение сохраненным.

- Добавляет поддержку `CMD_VIA_GET_KEYCODE` для точечного readback одной клавиши.
- Проверяет `SET_KEYCODE`, сравнивая значение из устройства с запрошенным keycode, включая `KC_NO` / `0x0000`.
- Откладывает локальное обновление раскладки до подтверждения записи устройством, чтобы UI больше не показывал оптимистичный `None`, когда прошивка оставила старое/transparent значение.
- Для writeback mismatch HID-сессия остается живой; reconnect сохраняется для ошибок связи.

### Причина

Picker корректно различал `KC_NO` и `KC_TRNS`, но назначение клавиши обновляло локальную раскладку до проверки записи в прошивке. Если устройство отвечало на HID-команду, но фактически не сохраняло `0x0000`, Entropy мог показывать `None`, хотя клавиатура продолжала вести себя как transparent или как старое назначение.

### Проверка

- `git diff --check`
- `python3 scripts/check_i18n.py`
- `mise x rust@stable -- cargo test keycode_writeback --quiet` проходит: 2 теста.
- `mise x rust@stable -- cargo test --quiet` проходит: 61 тест, с существующими warnings.