### PR TITLE
Try macOS event tap despite stale preflight

### DIFF
--- a/src/smart_input.rs
+++ b/src/smart_input.rs
@@ -422,6 +422,35 @@ pub struct MacosUniversalSymbolsStatus {
     pub failure_reason: Option<String>,
 }
 
+#[cfg(any(target_os = "macos", test))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MacosEventTapStartupDecision {
+    TryCreateTap,
+    WaitForPermission(&'static str),
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn macos_event_tap_startup_decision(
+    _input_monitoring_preflight_granted: bool,
+    accessibility_granted: bool,
+) -> MacosEventTapStartupDecision {
+    if !accessibility_granted {
+        return MacosEventTapStartupDecision::WaitForPermission(
+            "Accessibility permission is required for Universal Symbols",
+        );
+    }
+
+    MacosEventTapStartupDecision::TryCreateTap
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn macos_effective_input_monitoring_granted(
+    input_monitoring_preflight_granted: bool,
+    event_tap_active: bool,
+) -> bool {
+    input_monitoring_preflight_granted || event_tap_active
+}
+
 #[cfg(target_os = "macos")]
 pub fn macos_universal_symbols_status() -> MacosUniversalSymbolsStatus {
     macos::status_snapshot()
@@ -517,10 +546,14 @@ mod macos {
             .lock()
             .ok()
             .and_then(|guard| guard.as_ref().map(|at| at.elapsed().as_millis()));
+        let event_tap_active = EVENT_TAP_ACTIVE.load(Ordering::SeqCst);
         MacosUniversalSymbolsStatus {
             accessibility_granted: accessibility_granted(),
-            input_monitoring_granted: input_monitoring_granted(),
-            event_tap_active: EVENT_TAP_ACTIVE.load(Ordering::SeqCst),
+            input_monitoring_granted: macos_effective_input_monitoring_granted(
+                input_monitoring_granted(),
+                event_tap_active,
+            ),
+            event_tap_active,
             last_event_ms_ago,
             failure_reason: FAILURE_REASON.lock().ok().and_then(|guard| guard.clone()),
         }
@@ -597,22 +630,19 @@ mod macos {
         loop {
             clear_failure_reason();
 
-            if !input_monitoring_granted() {
-                set_failure_reason("Input Monitoring permission is required for Universal Symbols");
-                std::thread::sleep(Duration::from_secs(2));
-                if !RESTART_REQUESTED.swap(false, Ordering::SeqCst) {
-                    return;
+            match macos_event_tap_startup_decision(
+                input_monitoring_granted(),
+                accessibility_granted(),
+            ) {
+                MacosEventTapStartupDecision::TryCreateTap => {}
+                MacosEventTapStartupDecision::WaitForPermission(reason) => {
+                    set_failure_reason(reason);
+                    std::thread::sleep(Duration::from_secs(2));
+                    if !RESTART_REQUESTED.swap(false, Ordering::SeqCst) {
+                        return;
+                    }
+                    continue;
                 }
-                continue;
-            }
-
-            if !accessibility_granted() {
-                set_failure_reason("Accessibility permission is required for Universal Symbols");
-                std::thread::sleep(Duration::from_secs(2));
-                if !RESTART_REQUESTED.swap(false, Ordering::SeqCst) {
-                    return;
-                }
-                continue;
             }
 
             let mask = (1u64 << K_CG_EVENT_KEY_DOWN) | (1u64 << K_CG_EVENT_KEY_UP);
@@ -1200,5 +1230,18 @@ mod tests {
     #[test]
     fn editplus_uses_clipboard_fallback_for_universal_symbols() {
         assert!(app_prefers_clipboard_unicode_input("editplus.exe"));
+    }
+
+    #[test]
+    fn macos_input_monitoring_preflight_denied_still_attempts_event_tap() {
+        assert_eq!(
+            macos_event_tap_startup_decision(false, true),
+            MacosEventTapStartupDecision::TryCreateTap
+        );
+    }
+
+    #[test]
+    fn macos_active_event_tap_counts_as_input_monitoring_granted() {
+        assert!(macos_effective_input_monitoring_granted(false, true));
     }
 }


### PR DESCRIPTION
## EN
### Summary

Fixes #58.

This PR makes the macOS Universal Symbols backend try to create the keyboard event tap even when `CGPreflightListenEventAccess()` reports that Input Monitoring is not granted.

- Keeps Accessibility as a startup prerequisite.
- Stops treating a false Input Monitoring preflight as a hard block before event tap creation.
- Reports Input Monitoring as effectively granted when the event tap is already active, even if the preflight API remains stale.
- Adds regression tests for the stale-preflight startup policy and active-event-tap status.

### Root Cause

Entropy used `CGPreflightListenEventAccess()` as a strict gate before attempting `CGEventTapCreate`. On macOS, that preflight can remain false even when System Settings shows Entropy as allowed in Input Monitoring. In that state Entropy never tried the event tap, so it kept showing “Input Monitoring permission is required” forever.

The event tap creation itself is the more useful runtime check: if the permission is truly missing, creation still fails and the existing failure path remains; if the permission is granted but preflight is stale, the backend can now start successfully.

### Verification

- Confirmed no open PR matched issue #58 / Input Monitoring stale preflight.
- `git diff --check`
- `python3 scripts/check_i18n.py`
- `mise x rust@stable -- cargo test macos_ --quiet` passes: 2 tests.
- `mise x rust@stable -- cargo test --quiet` passes: 61 tests, with existing warnings.

## RU
### Кратко

Адресует #58.

Этот PR меняет macOS backend Universal Symbols: Entropy теперь пробует создать keyboard event tap даже если `CGPreflightListenEventAccess()` сообщает, что Input Monitoring не выдан.

- Accessibility остается обязательным предварительным условием.
- Ложный/устаревший Input Monitoring preflight больше не блокирует создание event tap.
- Если event tap уже активен, Input Monitoring считается фактически выданным даже при stale preflight.
- Добавлены тесты на stale-preflight startup policy и статус активного event tap.

### Причина

Entropy использовал `CGPreflightListenEventAccess()` как строгий gate перед `CGEventTapCreate`.
На macOS этот preflight может оставаться false, хотя System Settings показывает, что Entropy разрешен в Input Monitoring.
В таком состоянии Entropy вообще не пытался создать event tap и продолжал показывать “Input Monitoring permission is required”.

Создание event tap оптимистичнее как runtime-проверка: если разрешения действительно нет, создание все равно упадет, и сработает существующий failure path; если разрешение есть, но preflight устарел, backend теперь сможет запуститься.

### Проверка

- `git diff --check`
- `python3 scripts/check_i18n.py`
- `mise x rust@stable -- cargo test macos_ --quiet` проходит: 2 теста.
- `mise x rust@stable -- cargo test --quiet` проходит: 61 тест, с существующими warnings.