### PR TITLE
Fix high CPU load on Windows 11

### DIFF
--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -63,6 +63,7 @@ impl EntropyApp {
             import_progress_title: String::new(),
             import_progress_body: String::new(),
             dark_mode,
+            last_applied_dark_mode: None,
             app_settings,
             text_expander_rules_signature,
             text_expander_rules_last_check_at: 0.0,

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -2704,6 +2704,7 @@ pub struct EntropyApp {
     /// Stack of layers to return to on right-click (last = most recent)
     pub(crate) jump_back_stack: Vec<usize>,
     pub(crate) dark_mode: bool,
+    pub(crate) last_applied_dark_mode: Option<bool>,
     pub(crate) app_settings: AppSettings,
     pub(crate) text_expander_rules_signature: Vec<(String, Option<std::time::SystemTime>)>,
     pub(crate) text_expander_rules_last_check_at: f64,

--- a/src/app_update.rs
+++ b/src/app_update.rs
@@ -87,7 +87,13 @@ pub(crate) fn poll_update_check(state: &mut UpdateCheckState) {
     #[cfg(not(target_arch = "wasm32"))]
     {
         let outcome = match state {
-            UpdateCheckState::Checking { receiver } => receiver.try_recv().ok(),
+            UpdateCheckState::Checking { receiver } => match receiver.try_recv() {
+                Ok(outcome) => Some(outcome),
+                Err(std::sync::mpsc::TryRecvError::Empty) => None,
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => Some(
+                    UpdateCheckOutcome::Failed("Update check thread terminated unexpectedly".to_owned()),
+                ),
+            },
             _ => None,
         };
 

--- a/src/hid.rs
+++ b/src/hid.rs
@@ -803,7 +803,7 @@ pub fn run_hid_proxy_if_requested() -> bool {
 
 #[cfg(target_os = "windows")]
 fn run_hid_proxy(device: crate::device::Device) -> Result<()> {
-    let hid = HidDevice::open_fresh_for_local(&device)?;
+    let _hid = HidDevice::open_fresh_for_local(&device)?;
     writeln!(
         std::io::stdout(),
         "{}",
@@ -818,7 +818,7 @@ fn run_hid_proxy(device: crate::device::Device) -> Result<()> {
     for line in BufReader::new(std::io::stdin()).lines() {
         let line = line?;
         let line = line.trim();
-        let response = match hex_to_bytes(line).and_then(|data| hid.usb_send(&data)) {
+        let response = match hex_to_bytes(line).and_then(|data| _hid.usb_send(&data)) {
             Ok(data) => ProxyResponse {
                 ok: true,
                 data: Some(bytes_to_hex(&data)),

--- a/src/ui/app_lifecycle.rs
+++ b/src/ui/app_lifecycle.rs
@@ -374,6 +374,40 @@ impl eframe::App for EntropyApp {
         #[cfg(target_os = "macos")]
         self.handle_macos_dock_reopen(ctx);
 
+        let main_window_hidden_to_tray = self.main_window_hidden_to_tray();
+        if main_window_hidden_to_tray {
+            // The winit event loop on Windows 11 does not idle when the window is hidden.
+            // Block here and pump Windows messages so the tray icon stays responsive.
+            // On restore, break out and render the UI in the same frame.
+            while self.main_window_hidden_to_tray() {
+                #[cfg(target_os = "windows")]
+                unsafe {
+                    use windows_sys::Win32::UI::WindowsAndMessaging::{
+                        DispatchMessageW, PeekMessageW, TranslateMessage, PM_REMOVE,
+                    };
+                    let mut msg = std::mem::zeroed();
+                    while PeekMessageW(&mut msg, std::ptr::null_mut(), 0, 0, PM_REMOVE) != 0 {
+                        TranslateMessage(&msg);
+                        DispatchMessageW(&msg);
+                    }
+                }
+                if TRAY_RESTORE_REQUESTED.load(std::sync::atomic::Ordering::Relaxed) {
+                    self.handle_tray_restore_request(ctx);
+                }
+                if TRAY_QUIT_REQUESTED.load(std::sync::atomic::Ordering::Relaxed) {
+                    self.handle_tray_quit_request(ctx);
+                    std::process::exit(0);
+                }
+                if !self.main_window_hidden_to_tray() {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+            if self.main_window_hidden_to_tray() {
+                return;
+            }
+        }
+
         self.tour_target_rects.clear();
 
         let keyboard_input_wanted_at_frame_start = ctx.wants_keyboard_input();
@@ -397,20 +431,14 @@ impl eframe::App for EntropyApp {
             .and_then(|idx| self.device_manager.devices().get(idx))
             .map(|device| device.is_bluetooth_transport())
             .unwrap_or(false);
-        let main_window_hidden_to_tray = self.main_window_hidden_to_tray();
         let now = ctx.input(|i| i.time);
-
-        #[cfg(not(target_arch = "wasm32"))]
-        if main_window_hidden_to_tray {
-            self.update_hidden_to_tray_background(ctx, now);
-            ctx.request_repaint_after(hidden_to_tray_repaint_interval());
-            return;
-        }
 
         // Keep lightweight device detection alive when visible. On Windows BLE,
         // keep UI repaint smooth but avoid frequent HID enumeration against the BLE stack.
         #[cfg(not(target_arch = "wasm32"))]
-        ctx.request_repaint_after(visible_repaint_interval(selected_device_is_bluetooth));
+        // No periodic repaint timer - render purely event-driven.
+        // Continuous timers keep the event loop from idling on this system, burning
+        // 100% CPU and flooding any HID proxy child process with requests on every frame.
 
         #[cfg(not(target_arch = "wasm32"))]
         if should_poll_device_scan(main_window_hidden_to_tray) {
@@ -455,7 +483,12 @@ impl eframe::App for EntropyApp {
         #[cfg(not(target_arch = "wasm32"))]
         self.poll_single_instance_signal(ctx);
 
-        // Apply theme
+        // Apply theme - only when dark_mode actually changes.
+        // Calling set_visuals() on every frame triggers request_discard which invalidates
+        // the font atlas, forcing an expensive rebuild every frame and preventing the
+        // render loop from ever idling.
+        if self.last_applied_dark_mode != Some(self.dark_mode) {
+            self.last_applied_dark_mode = Some(self.dark_mode);
         if self.dark_mode {
             let mut v = egui::Visuals::dark();
             v.panel_fill = app_panel_fill(true);
@@ -501,6 +534,7 @@ impl eframe::App for EntropyApp {
             v.interact_cursor = Some(egui::CursorIcon::PointingHand);
             ctx.set_visuals(v);
         }
+        } // end if last_applied_dark_mode != Some(self.dark_mode)
 
         // Poll background connect thread
         #[cfg(not(target_arch = "wasm32"))]

--- a/src/ui/device_connect_apply.rs
+++ b/src/ui/device_connect_apply.rs
@@ -84,7 +84,10 @@ impl EntropyApp {
                         self.connect_state = ConnectState::Idle;
                         return;
                     }
-                    ctx.request_repaint(); // keep polling
+                    // Throttled poll: request_repaint() without a delay overrides any
+                    // baseline throttle and makes the event loop spin at 100% CPU.
+                    // Use a 250 ms interval instead.
+                    ctx.request_repaint_after(std::time::Duration::from_millis(250));
                     return;
                 }
                 Err(mpsc::TryRecvError::Disconnected) => {

--- a/src/ui/window_lifecycle.rs
+++ b/src/ui/window_lifecycle.rs
@@ -592,22 +592,6 @@ impl EntropyApp {
                     ..
                 } => {
                     TRAY_RESTORE_REQUESTED.store(true, std::sync::atomic::Ordering::Relaxed);
-                    #[cfg(target_os = "windows")]
-                    if let Some(hwnd) = hwnd_for_handler {
-                        unsafe {
-                            use windows_sys::Win32::UI::WindowsAndMessaging::{
-                                SetForegroundWindow, ShowWindow, SW_RESTORE, SW_SHOW,
-                            };
-                            let hwnd = hwnd as windows_sys::Win32::Foundation::HWND;
-                            ShowWindow(hwnd, SW_SHOW);
-                            ShowWindow(hwnd, SW_RESTORE);
-                            SetForegroundWindow(hwnd);
-                        }
-                    }
-                    ctx_for_handler.send_viewport_cmd(egui::ViewportCommand::Visible(true));
-                    ctx_for_handler.send_viewport_cmd(egui::ViewportCommand::Minimized(false));
-                    ctx_for_handler.send_viewport_cmd(egui::ViewportCommand::Focus);
-                    ctx_for_handler.request_repaint();
                 }
                 _ => {}
             }
@@ -619,11 +603,6 @@ impl EntropyApp {
             move |event: tray_icon::menu::MenuEvent| {
                 if event.id == "entropy_tray_quit" {
                     TRAY_QUIT_REQUESTED.store(true, std::sync::atomic::Ordering::Relaxed);
-                    #[cfg(target_os = "windows")]
-                    if let Some(hwnd) = hwnd_for_menu {
-                        request_windows_window_close_from_tray(hwnd);
-                    }
-                    ctx_for_menu.request_repaint();
                 }
             },
         ));


### PR DESCRIPTION
I tried to investigate #59 on my system and was able to tame it. Since I'm not familiar with Rust and egui, I had to use AI, so take everything with a big grain of salt. It looks like an ugly hack to me, but it does resolve the high CPU load issue in both Bluetooth and USB connection modes, whether the app is in the foreground or hidden in the system tray. I don't expect this to be merged as-is - I mainly needed a working fix for myself, but I hope it can give you some ideas how to implement a proper fix.