### PR TITLE
Format layout and universal symbol UI

### DIFF
--- a/src/ui/layout_indicator_window.rs
+++ b/src/ui/layout_indicator_window.rs
@@ -491,47 +491,56 @@ impl EntropyApp {
                         );
                     }
 
-                    crate::ui_style::allocate_ui_at_rect(ui, title_rect.shrink2(Vec2::new(6.0, 4.0)), |ui| {
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            if sticky_layout_window_icon_button(
-                                ui,
-                                dark,
-                                StickyLayoutWindowButton::Close,
-                                false,
-                                crate::i18n::tr_catalog(
-                                    lang,
-                                    "ui.sticky_layout_window_close_tooltip",
-                                ),
-                            )
-                            .clicked()
-                            {
-                                *should_close = true;
-                            }
-                            ui.add_space(4.0);
-                            if sticky_layout_window_icon_button(
-                                ui,
-                                dark,
-                                StickyLayoutWindowButton::Pin,
-                                sticky_always_on_top,
-                                crate::i18n::tr_catalog(
-                                    lang,
-                                    "ui.sticky_layout_window_pin_tooltip",
-                                ),
-                            )
-                            .clicked()
-                            {
-                                sticky_always_on_top = !sticky_always_on_top;
-                                should_save_settings = true;
-                                viewport_ctx.send_viewport_cmd(egui::ViewportCommand::WindowLevel(
-                                    if sticky_always_on_top {
-                                        egui::WindowLevel::AlwaysOnTop
-                                    } else {
-                                        egui::WindowLevel::Normal
-                                    },
-                                ));
-                            }
-                        });
-                    });
+                    crate::ui_style::allocate_ui_at_rect(
+                        ui,
+                        title_rect.shrink2(Vec2::new(6.0, 4.0)),
+                        |ui| {
+                            ui.with_layout(
+                                egui::Layout::right_to_left(egui::Align::Center),
+                                |ui| {
+                                    if sticky_layout_window_icon_button(
+                                        ui,
+                                        dark,
+                                        StickyLayoutWindowButton::Close,
+                                        false,
+                                        crate::i18n::tr_catalog(
+                                            lang,
+                                            "ui.sticky_layout_window_close_tooltip",
+                                        ),
+                                    )
+                                    .clicked()
+                                    {
+                                        *should_close = true;
+                                    }
+                                    ui.add_space(4.0);
+                                    if sticky_layout_window_icon_button(
+                                        ui,
+                                        dark,
+                                        StickyLayoutWindowButton::Pin,
+                                        sticky_always_on_top,
+                                        crate::i18n::tr_catalog(
+                                            lang,
+                                            "ui.sticky_layout_window_pin_tooltip",
+                                        ),
+                                    )
+                                    .clicked()
+                                    {
+                                        sticky_always_on_top = !sticky_always_on_top;
+                                        should_save_settings = true;
+                                        viewport_ctx.send_viewport_cmd(
+                                            egui::ViewportCommand::WindowLevel(
+                                                if sticky_always_on_top {
+                                                    egui::WindowLevel::AlwaysOnTop
+                                                } else {
+                                                    egui::WindowLevel::Normal
+                                                },
+                                            ),
+                                        );
+                                    }
+                                },
+                            );
+                        },
+                    );
 
                     let footer_rect = egui::Rect::from_min_max(
                         egui::pos2(

--- a/src/ui/matrix_tester.rs
+++ b/src/ui/matrix_tester.rs
@@ -179,7 +179,8 @@ impl EntropyApp {
             })
             .count();
 
-        crate::ui_style::allocate_ui_at_rect(ui, 
+        crate::ui_style::allocate_ui_at_rect(
+            ui,
             egui::Rect::from_min_max(
                 egui::pos2(content_rect.left(), content_rect.top()),
                 egui::pos2(content_rect.right(), desc_y + 10.0),

--- a/src/ui/universal_symbols_setup.rs
+++ b/src/ui/universal_symbols_setup.rs
@@ -336,20 +336,20 @@ impl EntropyApp {
                     self.open_macos_input_monitoring_settings(lang);
                 }
             }
-            10
-                if draw_universal_symbols_action_row_with_tooltip_state(
-                    ui,
-                    metrics,
-                    row_content_width,
-                    row_height,
-                    lang,
-                    "universal_symbols_setup.restart_event_tap",
-                    "universal_symbols_setup.restart_event_tap_tooltip",
-                    "universal_symbols_setup.restart_event_tap_button",
-                    suppress_tooltips,
-                ) => {
-                    self.restart_macos_event_tap(lang);
-                }
+            10 if draw_universal_symbols_action_row_with_tooltip_state(
+                ui,
+                metrics,
+                row_content_width,
+                row_height,
+                lang,
+                "universal_symbols_setup.restart_event_tap",
+                "universal_symbols_setup.restart_event_tap_tooltip",
+                "universal_symbols_setup.restart_event_tap_button",
+                suppress_tooltips,
+            ) =>
+            {
+                self.restart_macos_event_tap(lang);
+            }
             _ => {}
         }
     }


### PR DESCRIPTION
## EN
### Summary

This PR extracts layout and Universal Symbols UI formatting from the broad cargo fmt baseline into a second small, reviewable slice.

It changes only rustfmt wrapping and indentation in the layout indicator window, matrix tester, and Universal Symbols setup UI; control flow, strings, layout values, and UI behavior remain unchanged. Remaining formatter drift stays in separate, non-overlapping PRs.

### Verification

- `git diff --check`
- `/Users/igor.arkhipov/.cargo/bin/rustfmt --edition 2021 --check src/ui/layout_indicator_window.rs src/ui/matrix_tester.rs src/ui/universal_symbols_setup.rs`
- `CARGO_TARGET_DIR=/private/tmp/entropy-format-slices-target /Users/igor.arkhipov/.cargo/bin/cargo test --locked` passes: 133 tests, with existing warnings.
- Repository-wide `cargo fmt -- --check` remains outside this slice until the remaining baseline PRs land.

Related: #16
Split from #27

## RU
### Кратко

Этот PR выделяет форматирование окна индикатора раскладки, тестировщика раскладки и настройки Universal Symbols из общего cargo fmt baseline во второй небольшой отдельный блок для ревью.

Он меняет только переносы строк и отступы rustfmt; control flow, строки, значения раскладки и поведение UI остаются без изменений.

### Проверка

- `git diff --check`
- `/Users/igor.arkhipov/.cargo/bin/rustfmt --edition 2021 --check src/ui/layout_indicator_window.rs src/ui/matrix_tester.rs src/ui/universal_symbols_setup.rs`
- `CARGO_TARGET_DIR=/private/tmp/entropy-format-slices-target /Users/igor.arkhipov/.cargo/bin/cargo test --locked` проходит: 133 теста, с существующими предупреждениями.
- Полноценный `cargo fmt -- --check` остается за пределами этого блока изменений, пока не будут добавлены остальные PR для baseline.

Связано с #16
Выделено из #27
