### PR TITLE
Format settings and picker helpers

### DIFF
--- a/src/entsettings.rs
+++ b/src/entsettings.rs
@@ -89,14 +89,13 @@ impl EntropyApp {
                 &[("path", &path.display().to_string())],
             )
         })?;
-        let bundle: EntSettingsFile = serde_json::from_str(&data)
-            .with_context(|| {
-                crate::i18n::tr_catalog_format(
-                    lang,
-                    "entsettings.failed_to_parse",
-                    &[("path", &path.display().to_string())],
-                )
-            })?;
+        let bundle: EntSettingsFile = serde_json::from_str(&data).with_context(|| {
+            crate::i18n::tr_catalog_format(
+                lang,
+                "entsettings.failed_to_parse",
+                &[("path", &path.display().to_string())],
+            )
+        })?;
         validate_entsettings_file(&bundle, lang)?;
         let backup_path = write_entsettings_auto_backup(&self.entsettings_snapshot(), lang)?;
         self.apply_entsettings(ctx, bundle)?;
@@ -152,8 +151,8 @@ impl EntropyApp {
         for file in &bundle.text_expander_extra_files {
             if let Some(file_name) = normalize_text_expander_rules_file_name(&file.file_name) {
                 let path = text_expander_extra_rules_path(&file_name);
-                let json = serde_json::to_string_pretty(&file.rules)
-                    .context(crate::i18n::tr_catalog(
+                let json =
+                    serde_json::to_string_pretty(&file.rules).context(crate::i18n::tr_catalog(
                         self.app_settings.language,
                         "entsettings.failed_to_serialize_rules",
                     ))?;

--- a/src/keycode_picker_special.rs
+++ b/src/keycode_picker_special.rs
@@ -41,7 +41,9 @@ impl KeycodePicker {
             let t = parts.next().unwrap_or("");
             let b = parts.next().unwrap_or(label);
             (Some(t), b)
-        } else if let Some(pos) = label.find('/').filter(|pos| *pos > 0 && *pos + 1 < label.len())
+        } else if let Some(pos) = label
+            .find('/')
+            .filter(|pos| *pos > 0 && *pos + 1 < label.len())
         {
             (Some(&label[..pos]), &label[pos + 1..])
         } else {

--- a/src/ui/alt_repeat_settings.rs
+++ b/src/ui/alt_repeat_settings.rs
@@ -90,7 +90,8 @@ impl EntropyApp {
 
     fn open_alt_repeat_picker(&mut self, target: AltRepeatPickField) {
         self.alt_repeat_pick_target = Some(target);
-        self.keycode_picker.open_regular_key_picker_with_mod_key(true);
+        self.keycode_picker
+            .open_regular_key_picker_with_mod_key(true);
     }
 
     pub(super) fn open_alt_repeat_window_compact(&mut self) {
@@ -383,12 +384,18 @@ impl EntropyApp {
                                                 name,
                                                 control_width,
                                                 metrics.settings_control_height(),
-                                                crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.name"),
+                                                crate::i18n::tr_catalog(
+                                                    self.app_settings.language,
+                                                    "alt_repeat_editor.name",
+                                                ),
                                                 12,
                                                 egui::Align::Center,
                                             );
                                             name_changed = resp.changed();
-                                            resp.clone().on_hover_text(crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.stored_locally_in_entropy"));
+                                            resp.clone().on_hover_text(crate::i18n::tr_catalog(
+                                                self.app_settings.language,
+                                                "alt_repeat_editor.stored_locally_in_entropy",
+                                            ));
                                         }
                                     },
                                 );
@@ -465,19 +472,28 @@ impl EntropyApp {
                             4..=7 => {
                                 let (row_label, left_bit, right_bit) = match row_idx {
                                     4 => (
-                                        crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.ctrl_mods")
+                                        crate::i18n::tr_catalog(
+                                            self.app_settings.language,
+                                            "alt_repeat_editor.ctrl_mods",
+                                        )
                                         .to_string(),
                                         0,
                                         4,
                                     ),
                                     5 => (
-                                        crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.shift_mods")
+                                        crate::i18n::tr_catalog(
+                                            self.app_settings.language,
+                                            "alt_repeat_editor.shift_mods",
+                                        )
                                         .to_string(),
                                         1,
                                         5,
                                     ),
                                     6 => (
-                                        crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.alt_mods")
+                                        crate::i18n::tr_catalog(
+                                            self.app_settings.language,
+                                            "alt_repeat_editor.alt_mods",
+                                        )
                                         .to_string(),
                                         2,
                                         6,
@@ -502,10 +518,22 @@ impl EntropyApp {
                                     row_label.as_str(),
                                     true,
                                     Some(match row_idx {
-                                        4 => crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.allowed_ctrl_modifiers"),
-                                        5 => crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.allowed_shift_modifiers"),
-                                        6 => crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.allowed_alt_modifiers"),
-                                        _ => crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.allowed_os_modifiers"),
+                                        4 => crate::i18n::tr_catalog(
+                                            self.app_settings.language,
+                                            "alt_repeat_editor.allowed_ctrl_modifiers",
+                                        ),
+                                        5 => crate::i18n::tr_catalog(
+                                            self.app_settings.language,
+                                            "alt_repeat_editor.allowed_shift_modifiers",
+                                        ),
+                                        6 => crate::i18n::tr_catalog(
+                                            self.app_settings.language,
+                                            "alt_repeat_editor.allowed_alt_modifiers",
+                                        ),
+                                        _ => crate::i18n::tr_catalog(
+                                            self.app_settings.language,
+                                            "alt_repeat_editor.allowed_os_modifiers",
+                                        ),
                                     }),
                                     mod_control_width,
                                     |ui| {
@@ -539,7 +567,10 @@ impl EntropyApp {
                                                         .set_cursor_icon(egui::CursorIcon::Help);
                                                 }
                                                 right_label_resp.on_hover_text(
-                                                    crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.right_side_modifier"),
+                                                    crate::i18n::tr_catalog(
+                                                        self.app_settings.language,
+                                                        "alt_repeat_editor.right_side_modifier",
+                                                    ),
                                                 );
                                                 ui.add_space(metrics.value(10.0));
                                                 let mut left_checked =
@@ -569,7 +600,10 @@ impl EntropyApp {
                                                         .set_cursor_icon(egui::CursorIcon::Help);
                                                 }
                                                 left_label_resp.on_hover_text(
-                                                    crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.left_side_modifier"),
+                                                    crate::i18n::tr_catalog(
+                                                        self.app_settings.language,
+                                                        "alt_repeat_editor.left_side_modifier",
+                                                    ),
                                                 );
                                             },
                                         );
@@ -581,9 +615,15 @@ impl EntropyApp {
                                     ui,
                                     row_content_width,
                                     row_height,
-                                    crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.default_alt_key"),
+                                    crate::i18n::tr_catalog(
+                                        self.app_settings.language,
+                                        "alt_repeat_editor.default_alt_key",
+                                    ),
                                     true,
-                                    Some(crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.use_this_alt_key_by_default")),
+                                    Some(crate::i18n::tr_catalog(
+                                        self.app_settings.language,
+                                        "alt_repeat_editor.use_this_alt_key_by_default",
+                                    )),
                                     metrics.value(46.0),
                                     |ui| {
                                         crate::ui_style::settings_switch_sized(
@@ -599,9 +639,15 @@ impl EntropyApp {
                                     ui,
                                     row_content_width,
                                     row_height,
-                                    crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.bidirectional"),
+                                    crate::i18n::tr_catalog(
+                                        self.app_settings.language,
+                                        "alt_repeat_editor.bidirectional",
+                                    ),
                                     true,
-                                    Some(crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.allow_both_keys_to_alternate_each_other")),
+                                    Some(crate::i18n::tr_catalog(
+                                        self.app_settings.language,
+                                        "alt_repeat_editor.allow_both_keys_to_alternate_each_other",
+                                    )),
                                     metrics.value(46.0),
                                     |ui| {
                                         crate::ui_style::settings_switch_sized(

--- a/src/ui/combo_settings.rs
+++ b/src/ui/combo_settings.rs
@@ -56,10 +56,12 @@ impl EntropyApp {
     }
 
     fn handle_combo_editor_input(&mut self, ctx: &egui::Context, allow_close: bool) -> bool {
-        if !self.keycode_picker.open && ctx.input(|i| i.key_pressed(egui::Key::Escape))
-            && allow_close {
-                return true;
-            }
+        if !self.keycode_picker.open
+            && ctx.input(|i| i.key_pressed(egui::Key::Escape))
+            && allow_close
+        {
+            return true;
+        }
         false
     }
 

--- a/src/ui/key_override_settings.rs
+++ b/src/ui/key_override_settings.rs
@@ -471,7 +471,7 @@ impl EntropyApp {
                     ui.set_min_size(list.content_rect.size());
                     ui.spacing_mut().item_spacing.y = 0.0;
                     for row_idx in list.first_visible_row..list.last_visible_row {
-                                    match row_idx {
+                        match row_idx {
                                         0 => {
                                             crate::ui_style::settings_list_row_with_tooltip(
                                                 ui,
@@ -722,7 +722,7 @@ impl EntropyApp {
                                         13 => crate::ui_style::settings_list_row_with_tooltip(ui, row_content_width, row_height, crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.stay_active"), true, Some(crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.stay_active_when_another_key_is_pressed")), switch_width, |ui| { crate::ui_style::settings_switch_sized_stable(ui, ("key_override_settings", "stay_active"), &mut edited.options.no_unregister_on_other_key_down, switch_size); }),
                                         _ => {}
                                     }
-                                }
+                    }
                 });
 
                 if list.has_scrollbar {


### PR DESCRIPTION
## EN
### Summary

This PR extracts settings and key picker helper formatting from the broad cargo fmt baseline into a third small, reviewable slice.

It changes only rustfmt wrapping and indentation across settings import/export, special key labels, Alt Repeat, Combos, and Key Overrides; control flow, strings, stored values, and UI behavior remain unchanged. The remaining formatter scope stays isolated to a separate `src/keycode.rs` follow-up.

### Verification

- `git diff --check`
- `/Users/igor.arkhipov/.cargo/bin/rustfmt --edition 2021 --check src/entsettings.rs src/keycode_picker_special.rs src/ui/alt_repeat_settings.rs src/ui/combo_settings.rs src/ui/key_override_settings.rs`
- `CARGO_TARGET_DIR=/private/tmp/entropy-format-slices-target /Users/igor.arkhipov/.cargo/bin/cargo test --locked` passes: 133 tests, with existing warnings.
- Repository-wide `cargo fmt -- --check` remains outside this slice until the remaining baseline PR lands.

Related: #16
Split from #27

## RU
### Кратко

Этот PR выделяет форматирование настроек и вспомогательного кода выбора клавиш из общего cargo fmt baseline в третий небольшой отдельный блок для ревью.

Он меняет только переносы строк и отступы rustfmt в импорте/экспорте настроек, специальных названиях клавиш, Alt Repeat, Combos и Key Overrides; control flow, строки, сохраненные значения и поведение UI остаются без изменений.

### Проверка

- `git diff --check`
- `/Users/igor.arkhipov/.cargo/bin/rustfmt --edition 2021 --check src/entsettings.rs src/keycode_picker_special.rs src/ui/alt_repeat_settings.rs src/ui/combo_settings.rs src/ui/key_override_settings.rs`
- `CARGO_TARGET_DIR=/private/tmp/entropy-format-slices-target /Users/igor.arkhipov/.cargo/bin/cargo test --locked` проходит: 133 теста, с существующими предупреждениями.
- Полноценный `cargo fmt -- --check` остается за пределами этого блока изменений, пока не будет добавлен оставшийся PR для baseline.

Связано с #16
Выделено из #27
