### PR TITLE
Keep Vial unlock sessions recoverable

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -388,6 +388,8 @@ unlock_start_failed = "Unlock start failed: {error}"
 unlock_cancelled_disconnected = "Unlock cancelled — device disconnected"
 device_unlocked = "Device unlocked!"
 unlock_interrupted_disconnected = "Unlock interrupted — device disconnected or unavailable: {error}"
+unlock_poll_retry = "Unlock communication interrupted; retrying: {error}"
+finish_unlock_before_closing = "Finish device unlock or reconnect it before closing Entropy"
 
 [dynamic_status]
 device_not_found = "Device not found"

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -388,6 +388,8 @@ unlock_start_failed = "Не удалось начать разблокировк
 unlock_cancelled_disconnected = "Разблокировка отменена — устройство отключено"
 device_unlocked = "Устройство разблокировано"
 unlock_interrupted_disconnected = "Разблокировка прервана — устройство отключено или недоступно: {error}"
+unlock_poll_retry = "Связь при разблокировке прервана; повторная попытка: {error}"
+finish_unlock_before_closing = "Завершите разблокировку устройства или переподключите его перед закрытием Entropy"
 
 [dynamic_status]
 device_not_found = "Устройство не найдено"

--- a/src/ui/window_lifecycle.rs
+++ b/src/ui/window_lifecycle.rs
@@ -5,7 +5,21 @@ use super::*;
 #[cfg(target_os = "macos")]
 use objc::{msg_send, sel, sel_impl};
 
+fn should_keep_vial_unlock_visible(unlock_open: bool, unlock_polling: bool) -> bool {
+    unlock_open || unlock_polling
+}
+
 impl EntropyApp {
+    fn keep_vial_unlock_visible(&mut self, ctx: &egui::Context) {
+        self.restore_from_tray(ctx);
+        self.status_msg = crate::i18n::tr_catalog(
+            self.app_settings.language,
+            "status_messages.finish_unlock_before_closing",
+        )
+        .into();
+        ctx.request_repaint();
+    }
+
     pub(super) fn remember_main_window_size(&mut self, ctx: &egui::Context) {
         let viewport = ctx.input(|i| i.viewport().clone());
         if viewport.minimized == Some(true)
@@ -108,6 +122,12 @@ impl EntropyApp {
             return;
         }
 
+        if should_keep_vial_unlock_visible(self.unlock_open, self.vial_unlock_polling) {
+            ctx.send_viewport_cmd(egui::ViewportCommand::CancelClose);
+            self.keep_vial_unlock_visible(ctx);
+            return;
+        }
+
         #[cfg(any(target_os = "windows", target_os = "macos"))]
         if self.consume_tray_quit_request() {
             return;
@@ -140,6 +160,11 @@ impl EntropyApp {
     }
 
     pub(super) fn minimize_window_to_tray(&mut self, ctx: &egui::Context) {
+        if should_keep_vial_unlock_visible(self.unlock_open, self.vial_unlock_polling) {
+            self.keep_vial_unlock_visible(ctx);
+            return;
+        }
+
         #[cfg(target_os = "linux")]
         let background_status = "Entropy is running in background";
         #[cfg(target_os = "macos")]
@@ -658,6 +683,13 @@ impl EntropyApp {
 
     #[cfg(any(target_os = "windows", target_os = "macos"))]
     pub(super) fn handle_tray_quit_request(&mut self, ctx: &egui::Context) {
+        if should_keep_vial_unlock_visible(self.unlock_open, self.vial_unlock_polling)
+            && TRAY_QUIT_REQUESTED.swap(false, std::sync::atomic::Ordering::Relaxed)
+        {
+            self.keep_vial_unlock_visible(ctx);
+            return;
+        }
+
         if self.consume_tray_quit_request() {
             #[cfg(target_os = "windows")]
             {
@@ -912,5 +944,18 @@ fn linux_close_to_tray_prompt_copy(
             "Keep running",
             "Cancel",
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn active_vial_unlock_blocks_close_and_tray_actions() {
+        assert!(should_keep_vial_unlock_visible(true, false));
+        assert!(should_keep_vial_unlock_visible(false, true));
+        assert!(should_keep_vial_unlock_visible(true, true));
+        assert!(!should_keep_vial_unlock_visible(false, false));
     }
 }

--- a/src/vial/unlock.rs
+++ b/src/vial/unlock.rs
@@ -3,6 +3,20 @@ use super::*;
 const VIAL_UNLOCK_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(200);
 const VIAL_UNLOCK_PROGRESS_ANIMATION_TIME: f32 = 0.16;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum UnlockPollFailureAction {
+    Retry,
+    Stop,
+}
+
+fn unlock_poll_failure_action(disconnected: bool) -> UnlockPollFailureAction {
+    if disconnected {
+        UnlockPollFailureAction::Stop
+    } else {
+        UnlockPollFailureAction::Retry
+    }
+}
+
 impl EntropyApp {
     fn stop_vial_unlock_with_status(&mut self, status: impl Into<String>) {
         self.status_msg = status.into();
@@ -91,14 +105,28 @@ impl EntropyApp {
                                     }
                                 }
                             }
-                            Err(e) => {
-                                self.stop_vial_unlock_with_status(crate::i18n::tr_catalog_format(
-                                    self.app_settings.language,
-                                    "status_messages.unlock_interrupted_disconnected",
-                                    &[("error", &e.to_string())],
-                                ));
-                                return;
-                            }
+                            Err(e) => match unlock_poll_failure_action(
+                                crate::hid::is_disconnect_error(&e),
+                            ) {
+                                UnlockPollFailureAction::Stop => {
+                                    self.stop_vial_unlock_with_status(
+                                        crate::i18n::tr_catalog_format(
+                                            self.app_settings.language,
+                                            "status_messages.unlock_interrupted_disconnected",
+                                            &[("error", &e.to_string())],
+                                        ),
+                                    );
+                                    return;
+                                }
+                                UnlockPollFailureAction::Retry => {
+                                    log::warn!("Vial unlock poll failed; retrying: {e}");
+                                    self.status_msg = crate::i18n::tr_catalog_format(
+                                        self.app_settings.language,
+                                        "status_messages.unlock_poll_retry",
+                                        &[("error", &e.to_string())],
+                                    );
+                                }
+                            },
                         }
                     } else {
                         self.stop_vial_unlock_with_status(crate::i18n::tr_catalog(
@@ -273,5 +301,26 @@ impl EntropyApp {
                     }
                 });
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transient_unlock_poll_failure_keeps_session_active() {
+        assert_eq!(
+            unlock_poll_failure_action(false),
+            UnlockPollFailureAction::Retry
+        );
+    }
+
+    #[test]
+    fn disconnected_unlock_poll_failure_stops_session() {
+        assert_eq!(
+            unlock_poll_failure_action(true),
+            UnlockPollFailureAction::Stop
+        );
     }
 }


### PR DESCRIPTION
## EN
### Summary

This PR prevents Entropy-controlled close, tray, and quit actions from abandoning a Vial unlock session while firmware is suppressing keyboard input.

Transient HID polling errors now keep retrying; confirmed disconnects still end the local session. While unlock is active, Entropy stays visible and asks the user to finish unlocking or reconnect the device before closing.

Force-killing Entropy or losing the host process remains firmware-owned; this change covers Entropy-controlled lifecycle paths.

### Verification

- `git diff --check`
- `/Users/igor.arkhipov/.cargo/bin/rustfmt --edition 2021 --check src/vial/unlock.rs src/ui/window_lifecycle.rs`
- `python3 scripts/check_i18n.py`
- `/Users/igor.arkhipov/.cargo/bin/cargo test --locked` passes: 136 tests, with existing warnings.

## RU
### Кратко

Этот PR не позволяет действиям закрытия, сворачивания в трей и выхода из Entropy прервать разблокировку Vial, пока прошивка блокирует ввод с клавиатуры.

Адресует жалобу https://t.me/c/1464748383/7588/130869

После временных ошибок HID Entropy продолжает опрос; подтвержденное отключение устройства по-прежнему завершает локальный процесс.
Пока разблокировка активна, Entropy остается видимой и просит завершить разблокировку или переподключить устройство перед закрытием.

Принудительное завершение Entropy или потеря процесса хоста остаются задачей прошивки; это изменение относится только к циклу, контролируемому Entropy.

### Проверка

- `git diff --check`
- `/Users/igor.arkhipov/.cargo/bin/rustfmt --edition 2021 --check src/vial/unlock.rs src/ui/window_lifecycle.rs`
- `python3 scripts/check_i18n.py`
- `/Users/igor.arkhipov/.cargo/bin/cargo test --locked` проходит: 136 тестов, с существующими предупреждениями.
