### PR TITLE
Persist macro names and descriptions

### DIFF
--- a/src/app_storage.rs
+++ b/src/app_storage.rs
@@ -594,6 +594,61 @@ pub(super) fn save_alt_repeat_names(names: &[String], device_name: &str) {
     }
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub(super) struct MacroMetadata {
+    #[serde(default)]
+    pub(super) names: Vec<String>,
+    #[serde(default)]
+    pub(super) descriptions: Vec<String>,
+}
+
+impl MacroMetadata {
+    pub(super) fn resize(&mut self, slot_count: usize) {
+        self.names.resize(slot_count, String::new());
+        self.descriptions.resize(slot_count, String::new());
+    }
+}
+
+pub(super) fn macro_metadata_path(device_name: &str) -> std::path::PathBuf {
+    let dir = dirs::config_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join("entropy");
+    std::fs::create_dir_all(&dir).ok();
+    let slug = device_id_slug(device_name);
+    dir.join(format!("macro_metadata_{}.json", slug))
+}
+
+fn load_macro_metadata_from_path(path: &std::path::Path) -> MacroMetadata {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|data| serde_json::from_str(&data).ok())
+        .unwrap_or_default()
+}
+
+pub(super) fn load_macro_metadata(device_name: &str) -> MacroMetadata {
+    load_macro_metadata_from_path(&macro_metadata_path(device_name))
+}
+
+fn save_macro_metadata_to_path(
+    path: &std::path::Path,
+    metadata: &MacroMetadata,
+) -> Result<(), String> {
+    let data = serde_json::to_string(metadata).map_err(|error| error.to_string())?;
+    std::fs::write(path, data).map_err(|error| error.to_string())
+}
+
+pub(super) fn save_macro_metadata(names: &[String], descriptions: &[String], device_name: &str) {
+    let path = macro_metadata_path(device_name);
+    let metadata = MacroMetadata {
+        names: names.to_vec(),
+        descriptions: descriptions.to_vec(),
+    };
+    match save_macro_metadata_to_path(&path, &metadata) {
+        Ok(()) => log::info!("save_macro_metadata ok → {:?}", path),
+        Err(error) => log::warn!("save_macro_metadata failed at {:?}: {error}", path),
+    }
+}
+
 pub(super) fn macro_custom_name(macro_names: &[String], idx: usize) -> Option<String> {
     macro_names
         .get(idx)
@@ -629,6 +684,67 @@ pub(super) fn tap_dance_display_name(tap_dance_names: &[String], idx: usize) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn temp_macro_metadata_path(test_name: &str) -> std::path::PathBuf {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "entropy_{test_name}_{}_{}.json",
+            std::process::id(),
+            nonce
+        ))
+    }
+
+    #[test]
+    fn macro_metadata_round_trip_preserves_names_and_descriptions() {
+        let path = temp_macro_metadata_path("round_trip");
+        let expected = MacroMetadata {
+            names: vec!["Copy".into(), "Paste".into()],
+            descriptions: vec!["Copy selected text".into(), "Paste clipboard".into()],
+        };
+
+        save_macro_metadata_to_path(&path, &expected).unwrap();
+        let actual = load_macro_metadata_from_path(&path);
+
+        assert_eq!(actual, expected);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn missing_or_invalid_macro_metadata_loads_empty() {
+        let path = temp_macro_metadata_path("invalid");
+
+        assert_eq!(
+            load_macro_metadata_from_path(&path),
+            MacroMetadata::default()
+        );
+
+        std::fs::write(&path, "not json").unwrap();
+        assert_eq!(
+            load_macro_metadata_from_path(&path),
+            MacroMetadata::default()
+        );
+
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn macro_metadata_resize_matches_available_slots() {
+        let mut metadata = MacroMetadata {
+            names: vec!["One".into(), "Two".into(), "Three".into()],
+            descriptions: vec!["First".into()],
+        };
+
+        metadata.resize(2);
+        assert_eq!(metadata.names, ["One", "Two"]);
+        assert_eq!(metadata.descriptions, ["First", ""]);
+
+        metadata.resize(4);
+        assert_eq!(metadata.names, ["One", "Two", "", ""]);
+        assert_eq!(metadata.descriptions, ["First", "", "", ""]);
+    }
 
     #[test]
     fn text_expander_rules_json_parses_plain_array() {

--- a/src/entlayout.rs
+++ b/src/entlayout.rs
@@ -1393,6 +1393,12 @@ impl EntropyApp {
         self.keycode_picker
             .macro_descriptions
             .truncate(self.keycode_picker.macro_count);
+        save_macro_metadata(
+            &self.keycode_picker.macro_names,
+            &self.keycode_picker.macro_descriptions,
+            &self.current_device_name,
+        );
+        self.keycode_picker.macro_metadata_dirty = false;
         self.keycode_picker.macros_dirty = false;
 
         if let Some(layout) = &self.layout {

--- a/src/keycode_picker.rs
+++ b/src/keycode_picker.rs
@@ -164,6 +164,8 @@ pub struct KeycodePicker {
     pub macro_names: Vec<String>,
     /// User-visible descriptions for macros (optional, local metadata)
     pub macro_descriptions: Vec<String>,
+    /// Local macro names or descriptions changed and need persistence
+    pub macro_metadata_dirty: bool,
     /// Macro actions for editor UI
     pub macro_actions: Vec<Vec<MacroAction>>,
     /// Flag: macro texts changed, need to write to device
@@ -356,6 +358,7 @@ impl Default for KeycodePicker {
             macro_texts: vec![Vec::new(); 16],
             macro_names: vec![String::new(); 16],
             macro_descriptions: vec![String::new(); 16],
+            macro_metadata_dirty: false,
             macro_actions: vec![vec![]; 16],
             macro_undo_stack: Vec::new(),
             macro_key_pick: None,

--- a/src/keycode_picker_macro.rs
+++ b/src/keycode_picker_macro.rs
@@ -300,6 +300,7 @@ impl KeycodePicker {
         let custom_pairs = self.custom_keycode_pairs();
         ui.add_space(4.0 * scale);
         let language = self.language;
+        let mut macro_metadata_changed = false;
         ui.horizontal(|ui| {
             ui.spacing_mut().item_spacing.x = 12.0 * scale;
             if let Some(name) = self.macro_names.get_mut(n) {
@@ -315,6 +316,7 @@ impl KeycodePicker {
                 );
                 if resp.changed() {
                     limit_chars(name, MACRO_NAME_CHAR_LIMIT);
+                    macro_metadata_changed = true;
                 }
             }
 
@@ -336,6 +338,7 @@ impl KeycodePicker {
                 ));
                 if resp.changed() {
                     limit_chars(description, MACRO_DESCRIPTION_CHAR_LIMIT);
+                    macro_metadata_changed = true;
                 }
             }
         });
@@ -738,6 +741,7 @@ impl KeycodePicker {
                     self.macro_descriptions[n].clear();
                 }
                 macro_changed = true;
+                macro_metadata_changed = true;
             }
             if picker_button(
                 ui,
@@ -785,6 +789,9 @@ impl KeycodePicker {
         if macro_changed {
             self.encode_macro(n);
             self.macros_dirty = true;
+        }
+        if macro_metadata_changed {
+            self.macro_metadata_dirty = true;
         }
 
         selected_macro

--- a/src/ui/app_lifecycle.rs
+++ b/src/ui/app_lifecycle.rs
@@ -1025,6 +1025,15 @@ impl eframe::App for EntropyApp {
             self.combo_names_dirty = false;
         }
 
+        if self.keycode_picker.macro_metadata_dirty && !self.current_device_name.is_empty() {
+            save_macro_metadata(
+                &self.keycode_picker.macro_names,
+                &self.keycode_picker.macro_descriptions,
+                &self.current_device_name,
+            );
+            self.keycode_picker.macro_metadata_dirty = false;
+        }
+
         if self.combo_colors_dirty {
             save_combo_colors(&self.combo_colors, &self.current_device_name);
             self.combo_colors_dirty = false;

--- a/src/ui/device_connect_apply.rs
+++ b/src/ui/device_connect_apply.rs
@@ -186,8 +186,11 @@ impl EntropyApp {
                     .min(self.combo_visible_count.saturating_sub(1));
                 self.keycode_picker.macro_count = r.macro_texts.len();
                 self.keycode_picker.macro_texts = r.macro_texts.clone();
-                self.keycode_picker.macro_names = vec![String::new(); r.macro_texts.len()];
-                self.keycode_picker.macro_descriptions = vec![String::new(); r.macro_texts.len()];
+                let mut macro_metadata = load_macro_metadata(&self.current_device_name);
+                macro_metadata.resize(r.macro_texts.len());
+                self.keycode_picker.macro_names = macro_metadata.names;
+                self.keycode_picker.macro_descriptions = macro_metadata.descriptions;
+                self.keycode_picker.macro_metadata_dirty = false;
                 self.keycode_picker.supports_macro_ext_keycodes = r.supports_macro_ext_keycodes;
                 self.keycode_picker.macro_ext_keycodes_disabled_reason =
                     r.macro_ext_keycodes_disabled_reason;


### PR DESCRIPTION
## EN
### Summary

Macro names and descriptions now survive app restarts and keyboard reconnects, so users no longer need to recreate macro labels each session.

- Stores names and descriptions as local per-device metadata, separate from firmware macro bytecode.
- Loads saved metadata when a keyboard connects and resizes it to the available macro slots.
- Persists editor changes, clears, and `.entlayout` imports while keeping the existing 7-character name and 120-character description limits.
- Adds regression coverage for metadata round trips, missing or invalid files, and macro-slot count changes.

### Root Cause

Entropy kept macro names and descriptions only in the in-memory key picker state. Every device connection replaced both vectors with empty strings, and unlike combo names there was no per-device load/save path. Closing the app or reconnecting a keyboard therefore discarded the labels even though the macro bytecode itself remained on the device.

### Verification

- Confirmed no open PR matched macro name/description persistence.
- `git diff --check`
- `rustfmt --edition 2021 --check --config skip_children=true src/app_storage.rs src/entlayout.rs src/keycode_picker.rs src/keycode_picker_macro.rs src/ui/device_connect_apply.rs src/ui/app_lifecycle.rs`
- `cargo test macro_metadata` passes: 3 tests, with existing warnings.
- `argo test` passes: 136 tests, with existing warnings.
- `cargo clippy --all-targets --all-features` completes with the existing warning baseline.

## RU
### Кратко

Адресует https://t.me/c/1464748383/37027/131105.

Названия и описания макросов теперь сохраняются после перезапуска приложения и переподключения клавиатуры, поэтому пользователю не нужно заново восстанавливать подписи в каждой сессии.

- Хранит названия и описания как локальные метаданные для каждого устройства отдельно от macro bytecode в прошивке.
- Загружает сохраненные метаданные при подключении клавиатуры и подгоняет их под доступное число macro slots.
- Сохраняет изменения из редактора, очистку и импорт `.entlayout`, оставляя прежние лимиты: 7 символов для названия и 120 для описания.
- Добавляет тесты для записи и чтения, отсутствующего/поврежденного файла и изменения числа macro slots.

### Причина

Entropy хранил названия и описания макросов только в памяти key picker.
При каждом подключении устройства оба массива заменялись пустыми строками, а отдельного per-device load/save пути, как у combo names, не было. Поэтому закрытие приложения или переподключение клавиатуры удаляло подписи, хотя сам macro bytecode оставался на устройстве.

### Проверка

- Подтверждено отсутствие открытого PR для сохранения названий/описаний макросов.
- `git diff --check`
- `rustfmt --edition 2021 --check --config skip_children=true src/app_storage.rs src/entlayout.rs src/keycode_picker.rs src/keycode_picker_macro.rs src/ui/device_connect_apply.rs src/ui/app_lifecycle.rs`
- `cargo test macro_metadata` проходит: 3 теста, с существующими warnings.
- `cargo test` проходит: 136 тестов, с существующими warnings.
- `cargo clippy --all-targets --all-features` завершается с существующим warning baseline.