### PR TITLE
Add universal hyphen-minus symbol

### DIFF
--- a/linux/fcitx5/src/entropyuniversalsymbols.cpp
+++ b/linux/fcitx5/src/entropyuniversalsymbols.cpp
@@ -31,7 +31,7 @@ struct SmartSymbol {
     const char *symbol;
 };
 
-const std::array<SmartSymbol, 74> SMART_SYMBOLS{{
+const std::array<SmartSymbol, 75> SMART_SYMBOLS{{
     // F13..F20
     {KC_F13, "{"},
     {uint16_t(KC_F13 + 1), "}"},
@@ -112,12 +112,13 @@ const std::array<SmartSymbol, 74> SMART_SYMBOLS{{
     {uint16_t(MOD_CTRL | MOD_SHIFT | (KC_F13 + 6)), "„"},
     {uint16_t(MOD_CTRL | MOD_SHIFT | (KC_F13 + 7)), "“"},
 
-    // Super+F13..F17
+    // Super+F13..F18
     {uint16_t(MOD_GUI | KC_F13), "§"},
     {uint16_t(MOD_GUI | (KC_F13 + 1)), "”"},
     {uint16_t(MOD_GUI | (KC_F13 + 2)), "™"},
     {uint16_t(MOD_GUI | (KC_F13 + 3)), "~"},
     {uint16_t(MOD_GUI | (KC_F13 + 4)), "_"},
+    {uint16_t(MOD_GUI | (KC_F13 + 5)), "-"},
 
     // Super+Shift+F13..F17
     {uint16_t(MOD_GUI | MOD_SHIFT | KC_F13), "←"},

--- a/linux/ibus/entropy-ibus-engine
+++ b/linux/ibus/entropy-ibus-engine
@@ -152,8 +152,8 @@ def _symbol_entries():
     for idx, symbol in enumerate(["°", "‰", "′", "″", "‘", "’", "„", "“"]):
         add(idx, symbol, MOD_CTRL | MOD_SHIFT)
 
-    # Super+F13..F17
-    for idx, symbol in enumerate(["§", "”", "™", "~", "_"]):
+    # Super+F13..F18
+    for idx, symbol in enumerate(["§", "”", "™", "~", "_", "-"]):
         add(idx, symbol, MOD_GUI)
 
     # Super+Shift+F13..F17

--- a/src/keycode_picker.rs
+++ b/src/keycode_picker.rs
@@ -184,7 +184,7 @@ fn tr_picker(language: crate::i18n::Language, key: &'static str) -> &'static str
 
 const UNIVERSAL_MAIN_SYMBOL_ORDER: &[char] = &[
     '.', ',', ';', ':', '!', '?', '/', '`', '~', '\'', '"', '(', ')', '[', ']', '{', '}', '<', '>',
-    '+', '*', '=', '#', '@', '$', '%', '^', '&', '|', '\\', '_',
+    '-', '+', '*', '=', '#', '@', '$', '%', '^', '&', '|', '\\', '_',
 ];
 
 const UNIVERSAL_EXTRA_SYMBOL_ORDER: &[char] = &[
@@ -201,6 +201,12 @@ mod tests {
         for symbol in ['←', '↑', '→', '↓', '↔'] {
             assert!(UNIVERSAL_EXTRA_SYMBOL_ORDER.contains(&symbol));
         }
+    }
+
+    #[test]
+    fn universal_main_symbols_include_hyphen_minus() {
+        assert_eq!(UNIVERSAL_MAIN_SYMBOL_ORDER.len(), 32);
+        assert!(UNIVERSAL_MAIN_SYMBOL_ORDER.contains(&'-'));
     }
 
     #[test]

--- a/src/smart_input_symbols.rs
+++ b/src/smart_input_symbols.rs
@@ -341,7 +341,7 @@ const MAC_FRIENDLY_SMART_SYMBOLS: &[SmartSymbol] = &[
         symbol: '“',
         name: "Left double quotation mark",
     },
-    // Gui/Super/Win+F13..F17
+    // Gui/Super/Win+F13..F18
     SmartSymbol {
         trigger_keycode: MOD_GUI | KC_F13,
         symbol: '§',
@@ -366,6 +366,11 @@ const MAC_FRIENDLY_SMART_SYMBOLS: &[SmartSymbol] = &[
         trigger_keycode: MOD_GUI | (KC_F13 + 4),
         symbol: '_',
         name: "Underscore",
+    },
+    SmartSymbol {
+        trigger_keycode: MOD_GUI | (KC_F13 + 5),
+        symbol: '-',
+        name: "Hyphen-minus",
     },
     // Gui/Super/Win+Shift+F13..F17
     SmartSymbol {
@@ -641,7 +646,7 @@ const WINDOWS_SMART_SYMBOLS: &[SmartSymbol] = &[
         symbol: '↔',
         name: "Left right arrow",
     },
-    // Ctrl+Alt+F13..F19
+    // Ctrl+Alt+F13..F20
     SmartSymbol {
         trigger_keycode: MOD_CTRL | MOD_ALT | KC_F13,
         symbol: 'б',
@@ -676,6 +681,11 @@ const WINDOWS_SMART_SYMBOLS: &[SmartSymbol] = &[
         trigger_keycode: MOD_CTRL | MOD_ALT | (KC_F13 + 6),
         symbol: 'ё',
         name: "Cyrillic yo",
+    },
+    SmartSymbol {
+        trigger_keycode: MOD_CTRL | MOD_ALT | (KC_F13 + 7),
+        symbol: '-',
+        name: "Hyphen-minus",
     },
     // Ctrl+Alt+Shift+F13..F19
     SmartSymbol {
@@ -801,8 +811,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn universal_symbol_catalog_stays_at_74_entries() {
-        assert_eq!(SMART_SYMBOLS.len(), 74);
+    fn universal_symbol_catalog_stays_at_75_entries() {
+        assert_eq!(SMART_SYMBOLS.len(), 75);
     }
 
     #[test]
@@ -825,7 +835,7 @@ mod tests {
 
     #[test]
     fn windows_universal_symbols_avoid_gui_transport_slots() {
-        assert_eq!(WINDOWS_SMART_SYMBOLS.len(), 74);
+        assert_eq!(WINDOWS_SMART_SYMBOLS.len(), 75);
         assert!(WINDOWS_SMART_SYMBOLS
             .iter()
             .all(|symbol| symbol.trigger_keycode & MOD_GUI == 0));
@@ -882,6 +892,20 @@ mod tests {
     }
 
     #[test]
+    fn hyphen_minus_uses_platform_safe_transport_slots() {
+        assert_eq!(
+            smart_symbol_for_keycode(MOD_GUI | (KC_F13 + 5))
+                .map(|smart_symbol| smart_symbol.symbol),
+            Some('-')
+        );
+        assert_eq!(
+            windows_smart_symbol_for_keycode(MOD_CTRL | MOD_ALT | (KC_F13 + 7))
+                .map(|smart_symbol| smart_symbol.symbol),
+            Some('-')
+        );
+    }
+
+    #[test]
     fn linux_input_method_backends_include_arrow_symbols() {
         let ibus_backend = include_str!("../linux/ibus/entropy-ibus-engine");
         let fcitx5_backend = include_str!("../linux/fcitx5/src/entropyuniversalsymbols.cpp");
@@ -896,5 +920,14 @@ mod tests {
                 "Fcitx5 backend is missing {symbol}"
             );
         }
+    }
+
+    #[test]
+    fn linux_input_method_backends_include_hyphen_minus_transport() {
+        let ibus_backend = include_str!("../linux/ibus/entropy-ibus-engine");
+        let fcitx5_backend = include_str!("../linux/fcitx5/src/entropyuniversalsymbols.cpp");
+
+        assert!(ibus_backend.contains("[\"§\", \"”\", \"™\", \"~\", \"_\", \"-\"]"));
+        assert!(fcitx5_backend.contains("{uint16_t(MOD_GUI | (KC_F13 + 5)), \"-\"},"));
     }
 }


### PR DESCRIPTION
## Summary

### EN

Universal Symbols picker now includes ASCII hyphen-minus (`-`), restoring expected 32-symbol main set alongside `+`. macOS and Linux carry it through Super+F18; Windows uses Ctrl+Alt+F20 to avoid GUI-modifier conflicts. IBus and Fcitx5 mappings stay aligned with app catalog.

Hyphen-minus was omitted from picker order, platform transport catalogs, and Linux input-method tables even though neighboring operators were supported.

### RU

https://t.me/c/1464748383/37027/131133

В Universal Symbols теперь есть ASCII-дефис (`-`): основной набор снова содержит ожидаемые 32 символа вместе с `+`. macOS и Linux передают его через Super+F18; Windows использует Ctrl+Alt+F20, чтобы избежать конфликтов с GUI-модификатором. Таблицы IBus и Fcitx5 синхронизированы с каталогом приложения.

Знак минуса отсутствовал в порядке символов пикера, каталогах платформ и таблицах Linux input methods, хотя соседние операторы поддерживались.

## Verification

- `cargo test` - 136 passed
- `cargo test hyphen_minus` - 3 passed
- `cargo clippy --all-targets --all-features` - passed with existing warnings
- Targeted `rustfmt --check`, Python bytecode compilation, and `git diff --check` - passed