### PR TITLE
Retry stale module setting readbacks

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -840,6 +840,8 @@ pub(crate) enum ModuleSettingWritebackError {
     ReadbackMismatch { expected: u16, actual: u16 },
 }
 
+pub(crate) const MODULE_SETTING_READBACK_ATTEMPTS: usize = 3;
+
 impl std::fmt::Display for ModuleSettingWritebackError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -895,15 +897,28 @@ impl ModuleSettingsState {
         qsid: u16,
         expected: u16,
         write: impl FnOnce() -> Result<(), String>,
-        read_back: impl FnOnce() -> Result<u16, String>,
+        mut read_back: impl FnMut() -> Result<u16, String>,
     ) -> Result<u16, ModuleSettingWritebackError> {
         write().map_err(ModuleSettingWritebackError::SetFailed)?;
-        let actual = read_back().map_err(ModuleSettingWritebackError::ReadbackFailed)?;
-        if actual != expected {
-            return Err(ModuleSettingWritebackError::ReadbackMismatch { expected, actual });
+
+        let mut last_error = None;
+        for _ in 0..MODULE_SETTING_READBACK_ATTEMPTS {
+            match read_back() {
+                Ok(actual) if actual == expected => {
+                    self.set_value(qsid, actual);
+                    return Ok(actual);
+                }
+                Ok(actual) => {
+                    last_error =
+                        Some(ModuleSettingWritebackError::ReadbackMismatch { expected, actual });
+                }
+                Err(error) => {
+                    return Err(ModuleSettingWritebackError::ReadbackFailed(error));
+                }
+            }
         }
-        self.set_value(qsid, actual);
-        Ok(actual)
+
+        Err(last_error.expect("module setting readback attempts must be non-zero"))
     }
 }
 
@@ -2830,6 +2845,27 @@ mod module_settings_state_tests {
     }
 
     #[test]
+    fn verified_module_setting_write_retries_stale_readback() {
+        let mut settings = ModuleSettingsState::default();
+        settings.set_value(42, 7);
+        let mut attempts = 0;
+
+        let result = settings.write_verified_value(
+            42,
+            9,
+            || Ok(()),
+            || {
+                attempts += 1;
+                Ok(if attempts == 1 { 7 } else { 9 })
+            },
+        );
+
+        assert_eq!(result, Ok(9));
+        assert_eq!(attempts, 2);
+        assert_eq!(settings.value(42), 9);
+    }
+
+    #[test]
     fn verified_module_setting_write_keeps_old_value_when_set_fails() {
         let mut settings = ModuleSettingsState::default();
         settings.set_value(42, 7);
@@ -2850,9 +2886,17 @@ mod module_settings_state_tests {
     fn verified_module_setting_write_keeps_old_value_when_readback_fails() {
         let mut settings = ModuleSettingsState::default();
         settings.set_value(42, 7);
+        let mut attempts = 0;
 
-        let result =
-            settings.write_verified_value(42, 9, || Ok(()), || Err("read failed".to_owned()));
+        let result = settings.write_verified_value(
+            42,
+            9,
+            || Ok(()),
+            || {
+                attempts += 1;
+                Err("read failed".to_owned())
+            },
+        );
 
         assert_eq!(
             result,
@@ -2860,6 +2904,7 @@ mod module_settings_state_tests {
                 "read failed".to_owned()
             ))
         );
+        assert_eq!(attempts, 1);
         assert_eq!(settings.value(42), 7);
     }
 
@@ -2867,8 +2912,17 @@ mod module_settings_state_tests {
     fn verified_module_setting_write_keeps_old_value_when_readback_mismatches() {
         let mut settings = ModuleSettingsState::default();
         settings.set_value(42, 7);
+        let mut attempts = 0;
 
-        let result = settings.write_verified_value(42, 9, || Ok(()), || Ok(8));
+        let result = settings.write_verified_value(
+            42,
+            9,
+            || Ok(()),
+            || {
+                attempts += 1;
+                Ok(8)
+            },
+        );
 
         assert_eq!(
             result,
@@ -2877,6 +2931,7 @@ mod module_settings_state_tests {
                 actual: 8
             })
         );
+        assert_eq!(attempts, MODULE_SETTING_READBACK_ATTEMPTS);
         assert_eq!(settings.value(42), 7);
     }
 }

--- a/src/ui/module_settings.rs
+++ b/src/ui/module_settings.rs
@@ -7,7 +7,11 @@ enum ModuleSettingsRow {
     Field { group_idx: usize, field_idx: usize },
 }
 
-const MODULE_SETTING_WRITEBACK_DELAY: std::time::Duration = std::time::Duration::from_millis(20);
+const MODULE_SETTING_WRITEBACK_DELAYS: [std::time::Duration; MODULE_SETTING_READBACK_ATTEMPTS] = [
+    std::time::Duration::from_millis(20),
+    std::time::Duration::from_millis(80),
+    std::time::Duration::from_millis(200),
+];
 
 impl EntropyApp {
     fn module_setting_display_title<'a>(
@@ -133,6 +137,7 @@ impl EntropyApp {
             return;
         };
 
+        let mut readback_attempt = 0;
         let result = self.module_settings.write_verified_value(
             field.qsid,
             requested,
@@ -145,7 +150,10 @@ impl EntropyApp {
                 .map_err(|error| error.to_string())
             },
             || {
-                std::thread::sleep(MODULE_SETTING_WRITEBACK_DELAY);
+                let delay = MODULE_SETTING_WRITEBACK_DELAYS
+                    [readback_attempt.min(MODULE_SETTING_WRITEBACK_DELAYS.len() - 1)];
+                readback_attempt += 1;
+                std::thread::sleep(delay);
                 if field.width > 1 {
                     hid.get_qmk_setting_u16(field.qsid)
                 } else {


### PR DESCRIPTION
## EN

### Summary

K04 RMK module controls no longer snap back just because firmware still reports the previous value on the first readback.

Entropy retries stale successful readbacks with short bounded delays before reverting UI state; transport errors still surface immediately instead of multiplying the HID layer's retry budget.

Restarting Entropy after every module change should no longer be necessary.

### Root Cause

Entropy 0.2.0 verifies each module write with one readback after 20 ms.
When that readback returns the previous value, local state remains unchanged and the next UI frame resets the field or checkbox even if the requested value becomes visible later.

### Verification

- Regression test simulates a stale first readback followed by the requested value.
- `cargo test`: 134 passed.
- `cargo clippy --all-targets --all-features`: passes with existing project warnings.
- `rustfmt --edition 2021 --check src/app_state.rs src/ui/module_settings.rs` and `git diff --check`: pass.
- Physical K04 hardware was unavailable; delayed firmware visibility is covered deterministically in unit tests.

## RU

### Кратко

https://t.me/c/1464748383/37027/131606

Настройки модулей K04 на RMK больше не должны сразу возвращаться к прежнему значению, если firmware при первом readback ещё отдает старое значение.
Entropy несколько раз проверяет успешно прочитанное, но устаревшее значение с короткими ограниченными задержками; transport errors по-прежнему возвращаются сразу и не добавляют внутренние HID retries. Перезапускать Entropy после каждого изменения модуля должно быть больше не нужно.

### Причина

Entropy 0.2.0 проверяет каждую запись настройки одним чтением через 20 мс.
Если этот запрос возвращает прежнее значение, локальное состояние не меняется, поэтому на следующем UI кадре поле или чекбокс сбрасывается, даже если новое значение становится доступно позже.

### Проверка

- Регрессионный тест имитирует старое значение при первом readback и запрошенное значение при следующем.
- `cargo test`: 134 теста прошли.
- `cargo clippy --all-targets --all-features`: проходит с существующими project warnings.
- `rustfmt --edition 2021 --check src/app_state.rs src/ui/module_settings.rs` и `git diff --check`: проходят.
- Физической K04 для проверки не было; задержка firmware детерминированно покрыта unit test.