### PR TITLE
Keep session alive across transient device disappearance

### DIFF
--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -34,6 +34,7 @@ impl EntropyApp {
             undo_stack: Vec::new(),
             scan_frame: 0,
             last_device_scan_at: 0.0,
+            device_absent_scans: 0,
             hover_layer: None,
             last_layout_geometry: None,
             prev_hovered_key: None,

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1501,6 +1501,10 @@ pub struct EntropyApp {
     pub(crate) scan_frame: u32,
     /// Last device scan timestamp in egui seconds
     pub(crate) last_device_scan_at: f64,
+    /// Consecutive device scans where the selected device was absent. Used to
+    /// debounce transient disappearance (e.g. USB re-enumeration after a large
+    /// import) so the session is not torn down on a single missed scan.
+    pub(crate) device_absent_scans: u32,
     /// Layer to preview on hover (None = show selected_layer)
     pub(crate) hover_layer: Option<usize>,
     /// Last main keyboard layout geometry: offset_x, offset_y, unit, padding

--- a/src/ui/device_scan.rs
+++ b/src/ui/device_scan.rs
@@ -43,11 +43,45 @@ impl EntropyApp {
 
     #[cfg(not(target_arch = "wasm32"))]
     fn apply_device_scan_result(&mut self, devices: Vec<Device>) {
+        // Number of consecutive scans the selected device must stay absent
+        // before the session is torn down. Scans run ~1s apart, so this debounces
+        // brief disappearances (e.g. USB re-enumeration after a large import)
+        // without noticeably delaying a genuine unplug.
+        const DEVICE_ABSENT_CLEAR_SCANS: u32 = 3;
+
+        let was_loading = matches!(self.connect_state, ConnectState::Loading { .. });
+
+        if devices.is_empty() {
+            let had_session =
+                self.selected_device.is_some() || self.layout.is_some() || was_loading;
+            if had_session {
+                self.device_absent_scans = self.device_absent_scans.saturating_add(1);
+                if self.device_absent_scans < DEVICE_ABSENT_CLEAR_SCANS {
+                    // Keep the device list, selection and layout so the session
+                    // (and layout-dependent actions like export) survive a
+                    // transient disappearance. Do not touch the device manager.
+                    return;
+                }
+                self.device_manager.replace_devices(devices);
+                self.device_display_names.clear();
+                self.selected_device = None;
+                self.clear_connected_keyboard_state("No device detected");
+            } else {
+                self.device_manager.replace_devices(devices);
+                self.device_display_names.clear();
+                self.qmk_hid_hosts.clear();
+            }
+            return;
+        }
+
         let previous_device_key = self
             .selected_device
             .and_then(|idx| self.device_manager.devices().get(idx))
             .map(Device::display_name_cache_key);
-        let was_loading = matches!(self.connect_state, ConnectState::Loading { .. });
+        // If the device just came back from a transient absence, the previously
+        // opened HID handle is now stale and must be reopened.
+        let recovered_from_absence = self.device_absent_scans > 0;
+        self.device_absent_scans = 0;
 
         self.device_manager.replace_devices(devices);
         let connected_display_name_keys: std::collections::HashSet<String> = self
@@ -58,16 +92,6 @@ impl EntropyApp {
             .collect();
         self.device_display_names
             .retain(|key, _| connected_display_name_keys.contains(key));
-
-        if self.device_manager.devices().is_empty() {
-            if self.selected_device.is_some() || self.layout.is_some() || was_loading {
-                self.selected_device = None;
-                self.clear_connected_keyboard_state("No device detected");
-            } else {
-                self.qmk_hid_hosts.clear();
-            }
-            return;
-        }
 
         #[cfg(target_os = "linux")]
         if self.selected_device.is_none()
@@ -87,7 +111,7 @@ impl EntropyApp {
                 .position(|dev| dev.display_name_cache_key() == device_key)
             {
                 self.selected_device = Some(idx);
-                if self.layout.is_none() && !was_loading {
+                if (self.layout.is_none() || recovered_from_absence) && !was_loading {
                     self.start_connect(idx);
                 } else {
                     self.sync_qmk_hid_host_bridges();


### PR DESCRIPTION
### Problem

After importing an `.entlayout`, the layout-image / `.entlayout` **Export** actions could go completely dead — clicking Export did nothing and no file dialog appeared.

### Root cause

The export menu items (and other layout-gated UI) are enabled only while a keyboard is connected — `self.layout.is_some()`. So a dead Export button means the layout had been cleared out from under it.

A large import writes a burst of HID transactions (keymap for every layer × key, encoders, the macro buffer, combos). Under that load the board briefly re-enumerates on USB. The **very next** device scan sees an empty list and immediately tears the whole session down (`clear_connected_keyboard_state` → `layout = None`, `selected_device = None`). On Linux the follow-up scan can then hit the udev-rules guard and refuse to auto-reconnect, leaving Export greyed out until the user manually re-selects the device.

### Fix

Debounce the disappearance in `apply_device_scan_result`:

- Require the selected device to stay absent for **3 consecutive scans (~3s)** before clearing state. Within that window the device list, selection and layout are preserved untouched, so Export and other actions keep working.
- When the device reappears after a transient absence, the previously opened HID handle is stale, so force a reconnect to reopen it even when a layout is still present.

A genuine unplug still surfaces as "No device detected" after the short debounce window.

### Testing

- `cargo build`, `cargo test` (59 passed).
- Change is confined to the device-scan reconciliation path; no behavior change when the device never disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)