### PR TITLE
Recover Vial unlock sessions after reconnect

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -269,6 +269,9 @@ return_to_layout_hint = "Right-click or Esc to return to layout"
 
 [unlock]
 highlighted_keys_hint = "Press and hold the highlighted keys"
+start_hint = "Start unlocking, then hold the highlighted keys"
+start = "Start unlocking"
+cancel = "Cancel"
 
 [universal_symbols_setup]
 open_privacy_settings = "Open Privacy Settings"
@@ -415,6 +418,7 @@ refresh_device_data_pending_write = "Finish the pending layer write before refre
 refresh_device_data_missing_device = "Failed to refresh device data: device not found"
 refresh_device_data_missing_info = "Failed to refresh device data: device information unavailable"
 refresh_device_data_delete_failed = "Failed to remove cached device data"
+unlock_recovery_detected = "Active device unlock recovered — hold the highlighted keys"
 
 [dynamic_status]
 device_not_found = "Device not found"

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -269,6 +269,9 @@ return_to_layout_hint = "ПКМ или Esc — вернуться к раскл�
 
 [unlock]
 highlighted_keys_hint = "Нажмите и удерживайте подсвеченные клавиши"
+start_hint = "Начните разблокировку, затем удерживайте подсвеченные клавиши"
+start = "Начать разблокировку"
+cancel = "Отмена"
 
 [universal_symbols_setup]
 open_privacy_settings = "Открыть настройки приватности"
@@ -415,6 +418,7 @@ refresh_device_data_pending_write = "Завершите запись слоя п
 refresh_device_data_missing_device = "Не удалось обновить данные устройства: устройство не найдено"
 refresh_device_data_missing_info = "Не удалось обновить данные устройства: информация недоступна"
 refresh_device_data_delete_failed = "Не удалось удалить сохранённые данные устройства"
+unlock_recovery_detected = "Активная разблокировка восстановлена — удерживайте подсвеченные клавиши"
 
 [dynamic_status]
 device_not_found = "Устройство не найдено"

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -209,6 +209,7 @@ impl EntropyApp {
             vial_unlock_total: 50,
             vial_unlock_last_poll: None,
             vial_unlock_animation_nonce: 0,
+            vial_unlock_reconnect_after_completion: false,
             #[cfg(not(target_arch = "wasm32"))]
             connect_state: ConnectState::Idle,
             #[cfg(not(target_arch = "wasm32"))]
@@ -275,28 +276,26 @@ impl EntropyApp {
 
     #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn cancel_vial_unlock(&mut self, suppress_macro_auto_unlock: bool) {
-        if let Some(hid) = &self.hid_device {
-            match hid.lock() {
-                Ok(()) => {
-                    self.vial_unlocked = Some(false);
-                    self.status_msg = crate::i18n::tr_catalog(
-                        self.app_settings.language,
-                        "status_messages.device_unlock_cancelled",
-                    )
-                    .into();
-                }
-                Err(e) => {
-                    self.status_msg = crate::i18n::tr_catalog_format(
-                        self.app_settings.language,
-                        "status_messages.cancel_unlock_failed",
-                        &[("error", &e.to_string())],
-                    );
-                }
-            }
+        if self.vial_unlock_polling {
+            log::warn!("Ignored Vial unlock cancellation after UNLOCK_START");
+            self.status_msg = crate::i18n::tr_catalog(
+                self.app_settings.language,
+                "status_messages.finish_unlock_before_closing",
+            )
+            .into();
+            return;
         }
+        log::info!("Vial unlock prompt dismissed before UNLOCK_START");
+        self.vial_unlocked = Some(false);
+        self.status_msg = crate::i18n::tr_catalog(
+            self.app_settings.language,
+            "status_messages.device_unlock_cancelled",
+        )
+        .into();
         self.unlock_open = false;
         self.vial_unlock_polling = false;
         self.vial_unlock_last_poll = None;
+        self.vial_unlock_reconnect_after_completion = false;
         self.pending_layout_indicator_open_after_unlock = false;
         self.vial_unlock_counter = 0;
         self.vial_unlock_best = 50;

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1000,10 +1000,26 @@ pub(crate) struct ConnectResult {
     pub(crate) deferred_load: DeferredDeviceLoadState,
 }
 
+/// Minimal device state available while Vial firmware blocks normal VIA commands.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) struct UnlockRecoveryResult {
+    pub(crate) device_name: String,
+    pub(crate) keyboard_id: u64,
+    pub(crate) hid_device: Option<crate::hid::HidDevice>,
+    pub(crate) layout: KeyboardLayout,
+    pub(crate) unlock_keys: Vec<(u8, u8)>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) enum ConnectOutcome {
+    Connected(ConnectResult),
+    UnlockRecovery(UnlockRecoveryResult),
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) enum ConnectTaskMessage {
     Progress(String),
-    Done(Box<Result<ConnectResult, String>>),
+    Done(Box<Result<ConnectOutcome, String>>),
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -3974,6 +3990,8 @@ pub struct EntropyApp {
     pub(crate) vial_unlock_total: u8,
     pub(crate) vial_unlock_last_poll: Option<std::time::Instant>,
     pub(crate) vial_unlock_animation_nonce: u64,
+    /// Reload full device state after finishing an unlock recovered during connect.
+    pub(crate) vial_unlock_reconnect_after_completion: bool,
 }
 
 #[cfg(test)]

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1012,8 +1012,8 @@ pub(crate) struct UnlockRecoveryResult {
 
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) enum ConnectOutcome {
-    Connected(ConnectResult),
-    UnlockRecovery(UnlockRecoveryResult),
+    Connected(Box<ConnectResult>),
+    UnlockRecovery(Box<UnlockRecoveryResult>),
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/src/hid.rs
+++ b/src/hid.rs
@@ -1446,10 +1446,7 @@ fn response_matches_command(command: &[u8], resp: &[u8; MSG_LEN]) -> bool {
     };
 
     match cmd {
-        CMD_VIA_GET_PROTOCOL_VERSION => {
-            resp[0] == CMD_VIA_GET_PROTOCOL_VERSION
-                && matches!(u16::from_be_bytes([resp[1], resp[2]]), 9 | 0xFFFF)
-        }
+        CMD_VIA_GET_PROTOCOL_VERSION => response_matches_via_protocol_version(command, resp),
         CMD_VIA_GET_LAYER_COUNT => {
             resp[0] == CMD_VIA_GET_LAYER_COUNT && (1..=32).contains(&resp[1])
         }
@@ -1472,6 +1469,16 @@ fn response_matches_command(command: &[u8], resp: &[u8; MSG_LEN]) -> bool {
         CMD_VIA_VIAL_PREFIX => response_matches_vial_command(command, resp),
         _ => true,
     }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn response_matches_via_protocol_version(command: &[u8], resp: &[u8]) -> bool {
+    command.first() == Some(&CMD_VIA_GET_PROTOCOL_VERSION)
+        && resp.first() == Some(&CMD_VIA_GET_PROTOCOL_VERSION)
+        && resp
+            .get(1..3)
+            .map(|version| matches!(u16::from_be_bytes([version[0], version[1]]), 0 | 9 | 0xFFFF))
+            .unwrap_or(false)
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -2063,6 +2070,22 @@ mod tests {
 
         assert!(response_matches_command(&command, &success));
         assert!(response_matches_command(&command, &error));
+    }
+
+    #[test]
+    fn protocol_version_matcher_accepts_active_unlock_zero_and_rejects_unrelated_reports() {
+        let command = [CMD_VIA_GET_PROTOCOL_VERSION];
+        let active_unlock_response = [CMD_VIA_GET_PROTOCOL_VERSION, 0, 0];
+        let unrelated_response = [CMD_VIA_GET_LAYER_COUNT, 0, 0];
+
+        assert!(response_matches_via_protocol_version(
+            &command,
+            &active_unlock_response
+        ));
+        assert!(!response_matches_via_protocol_version(
+            &command,
+            &unrelated_response
+        ));
     }
 
     #[test]

--- a/src/hid_parse.rs
+++ b/src/hid_parse.rs
@@ -154,8 +154,16 @@ pub(crate) fn parse_vialrgb_supported_effects_payload(
     batch_max
 }
 
-pub(crate) fn parse_unlock_status_response(resp: &[u8]) -> (bool, Vec<(u8, u8)>) {
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct VialUnlockStatus {
+    pub(crate) unlocked: bool,
+    pub(crate) in_progress: bool,
+    pub(crate) keys: Vec<(u8, u8)>,
+}
+
+pub(crate) fn parse_unlock_status_response(resp: &[u8]) -> VialUnlockStatus {
     let unlocked = resp.first().copied() == Some(1);
+    let in_progress = resp.get(1).copied() == Some(1);
     let mut keys = Vec::new();
     let mut i = 2;
     while i + 1 < resp.len() {
@@ -167,12 +175,33 @@ pub(crate) fn parse_unlock_status_response(resp: &[u8]) -> (bool, Vec<(u8, u8)>)
         keys.push((row, col));
         i += 2;
     }
-    (unlocked, keys)
+    VialUnlockStatus {
+        unlocked,
+        in_progress,
+        keys,
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parses_active_unlock_status_and_keys() {
+        let mut resp = [0xFFu8; 32];
+        resp[0] = 0;
+        resp[1] = 1;
+        resp[2..6].copy_from_slice(&[1, 2, 3, 4]);
+
+        assert_eq!(
+            parse_unlock_status_response(&resp),
+            VialUnlockStatus {
+                unlocked: false,
+                in_progress: true,
+                keys: vec![(1, 2), (3, 4)],
+            }
+        );
+    }
 
     #[test]
     fn parses_and_pads_macro_buffer() {
@@ -300,7 +329,11 @@ mod tests {
         let resp = [1, 0, 3, 4, 5, 6, 0xff, 0xff, 7, 8];
         assert_eq!(
             parse_unlock_status_response(&resp),
-            (true, vec![(3, 4), (5, 6)])
+            VialUnlockStatus {
+                unlocked: true,
+                in_progress: false,
+                keys: vec![(3, 4), (5, 6)],
+            }
         );
     }
 }

--- a/src/hid_vial.rs
+++ b/src/hid_vial.rs
@@ -1,4 +1,4 @@
-use super::hid_parse::parse_unlock_status_response;
+use super::hid_parse::{parse_unlock_status_response, VialUnlockStatus};
 use super::hid_protocol::*;
 use super::HidDevice;
 use anyhow::{bail, Context, Result};
@@ -81,8 +81,7 @@ impl HidDevice {
     }
 
     /// Check if keyboard is unlocked
-    /// Returns (unlocked, unlock_keys: Vec<(row,col)>)
-    pub fn get_unlock_status(&self) -> Result<(bool, Vec<(u8, u8)>)> {
+    pub fn get_unlock_status(&self) -> Result<VialUnlockStatus> {
         let resp = self
             .usb_send(&[CMD_VIA_VIAL_PREFIX, CMD_VIAL_GET_UNLOCK_STATUS])
             .context("failed to read Vial unlock status")?;

--- a/src/ui/device_connect_apply.rs
+++ b/src/ui/device_connect_apply.rs
@@ -59,7 +59,7 @@ fn is_hid_open_failure(error: &str) -> bool {
 enum ConnectTaskChannelState {
     Empty,
     Progress(String),
-    Done(Box<Result<ConnectResult, String>>),
+    Done(Box<Result<ConnectOutcome, String>>),
     Disconnected,
 }
 
@@ -365,7 +365,7 @@ impl EntropyApp {
 
         enum ConnectPollEvent {
             Done {
-                result: Result<ConnectResult, String>,
+                result: Result<ConnectOutcome, String>,
                 reconnect: Option<BluetoothReconnectState>,
             },
             Failed {

--- a/src/ui/device_connect_apply.rs
+++ b/src/ui/device_connect_apply.rs
@@ -439,7 +439,55 @@ impl EntropyApp {
         };
 
         match result {
-            Ok(mut r) => {
+            Ok(ConnectOutcome::UnlockRecovery(r)) => {
+                let layer_count = r.layout.layers.len().max(1);
+                log::warn!(
+                    "Applying Vial unlock recovery for {} (keyboard id {:016X}, {} unlock keys)",
+                    r.device_name,
+                    r.keyboard_id,
+                    r.unlock_keys.len()
+                );
+                self.pending_tap_hold_numeric_writes.clear();
+                self.tap_hold_numeric_write_due = None;
+                self.connection_generation = self.connection_generation.wrapping_add(1);
+                self.layer_count = layer_count;
+                self.firmware = r.layout.firmware;
+                self.current_device_name = r.device_name.clone();
+                self.current_keyboard_id = Some(r.keyboard_id);
+                self.current_encoder_visibility_id =
+                    encoder_visibility_id(&r.device_name, r.keyboard_id);
+                self.layout = Some(r.layout);
+                self.vial_unlocked = Some(false);
+                self.shared_hid_output = r
+                    .hid_device
+                    .as_ref()
+                    .and_then(crate::hid::HidDevice::shared_output);
+                self.hid_device = r.hid_device;
+                self.vial_unlock_keys = r.unlock_keys;
+                self.vial_unlock_polling = true;
+                self.vial_unlock_counter = 1;
+                self.vial_unlock_best = 1;
+                self.vial_unlock_total = 1;
+                self.vial_unlock_last_poll = Some(std::time::Instant::now());
+                self.vial_unlock_animation_nonce = self.vial_unlock_animation_nonce.wrapping_add(1);
+                self.vial_unlock_reconnect_after_completion = true;
+                self.unlock_open = true;
+                self.macro_auto_unlock_cancelled = false;
+                self.status_msg = crate::i18n::tr_catalog(
+                    self.app_settings.language,
+                    "status_messages.unlock_recovery_detected",
+                )
+                .into();
+                if let Some(dev) = self
+                    .selected_device
+                    .and_then(|idx| self.device_manager.devices().get(idx))
+                {
+                    self.device_display_names
+                        .insert(dev.display_name_cache_key(), r.device_name);
+                }
+                ctx.request_repaint();
+            }
+            Ok(ConnectOutcome::Connected(mut r)) => {
                 if reconnect.is_some() && self.layout.is_some() {
                     self.preserve_deferred_snapshot_on_reconnect(&mut r);
                 }

--- a/src/ui/device_connect_task.rs
+++ b/src/ui/device_connect_task.rs
@@ -1390,7 +1390,8 @@ impl EntropyApp {
                 Ok(ConnectOutcome::Connected(Box::new(ConnectResult {
                     device_name: dev.name.clone(),
                     keyboard_id,
-                    vial_unlock_status,
+                    vial_unlock_status: vial_unlock_status
+                        .map(|status| (status.unlocked, status.keys)),
                     hid_device: Some(dev_conn),
                     about_info,
                     layer_names_from_firmware,
@@ -1458,9 +1459,24 @@ mod tests {
         );
         assert_eq!(classify_via_connect(0, None), ViaConnectMode::Unsupported);
         assert_eq!(classify_via_connect(9, None), ViaConnectMode::Normal);
+        assert_eq!(classify_via_connect(u16::MAX, None), ViaConnectMode::Normal);
+    }
+
+    #[test]
+    fn active_unlock_via_zero_response_requires_unlock_in_progress() {
+        let command = [0x01]; // CMD_VIA_GET_PROTOCOL_VERSION
+        let response = [0x01, 0, 0];
+
+        assert!(crate::hid::response_matches_via_protocol_version(
+            &command, &response
+        ));
         assert_eq!(
-            classify_via_connect(u16::MAX, None),
-            ViaConnectMode::Normal
+            classify_via_connect(0, Some((false, true))),
+            ViaConnectMode::RecoverUnlock
+        );
+        assert_eq!(
+            classify_via_connect(0, Some((false, false))),
+            ViaConnectMode::Unsupported
         );
     }
 

--- a/src/ui/device_connect_task.rs
+++ b/src/ui/device_connect_task.rs
@@ -844,13 +844,15 @@ impl EntropyApp {
                         unlock_keys.len()
                     );
                     progress("Resuming active Vial unlock…");
-                    return Ok(ConnectOutcome::UnlockRecovery(UnlockRecoveryResult {
-                        device_name: dev.name.clone(),
-                        keyboard_id,
-                        hid_device: Some(dev_conn),
-                        layout,
-                        unlock_keys,
-                    }));
+                    return Ok(ConnectOutcome::UnlockRecovery(Box::new(
+                        UnlockRecoveryResult {
+                            device_name: dev.name.clone(),
+                            keyboard_id,
+                            hid_device: Some(dev_conn),
+                            layout,
+                            unlock_keys,
+                        },
+                    )));
                 }
 
                 let firmware_version = runtime_firmware_version
@@ -1385,7 +1387,7 @@ impl EntropyApp {
                 };
 
                 progress("Applying keyboard layout…");
-                Ok(ConnectOutcome::Connected(ConnectResult {
+                Ok(ConnectOutcome::Connected(Box::new(ConnectResult {
                     device_name: dev.name.clone(),
                     keyboard_id,
                     vial_unlock_status,
@@ -1419,7 +1421,7 @@ impl EntropyApp {
                     layer_count,
                     supported_qmk_settings,
                     deferred_load,
-                }))
+                })))
             })();
 
             let _ = tx.send(ConnectTaskMessage::Done(Box::new(result)));

--- a/src/ui/device_connect_task.rs
+++ b/src/ui/device_connect_task.rs
@@ -494,6 +494,23 @@ fn supports_vial_macro_ext_keycodes(vial_protocol: u32, json: &serde_json::Value
     vial_protocol >= 5 && macro_ext_keycodes_disabled_reason(json).is_none()
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ViaConnectMode {
+    Normal,
+    RecoverUnlock,
+    Unsupported,
+}
+
+fn classify_via_connect(via_protocol: u16, unlock_status: Option<(bool, bool)>) -> ViaConnectMode {
+    if matches!(via_protocol, 9 | u16::MAX) {
+        ViaConnectMode::Normal
+    } else if via_protocol == 0 && unlock_status == Some((false, true)) {
+        ViaConnectMode::RecoverUnlock
+    } else {
+        ViaConnectMode::Unsupported
+    }
+}
+
 impl EntropyApp {
     pub(super) fn refresh_current_device_data(&mut self) {
         let lang = self.app_settings.language;
@@ -675,6 +692,10 @@ impl EntropyApp {
             self.key_override_pick_target = None;
             self.vial_unlocked = None;
             self.vial_unlock_keys.clear();
+            self.unlock_open = false;
+            self.vial_unlock_polling = false;
+            self.vial_unlock_last_poll = None;
+            self.vial_unlock_reconnect_after_completion = false;
             self.reset_matrix_tester_state();
         }
 
@@ -691,7 +712,7 @@ impl EntropyApp {
             let progress = |message: &str| {
                 let _ = tx.send(ConnectTaskMessage::Progress(message.to_owned()));
             };
-            let result = (|| -> Result<ConnectResult, String> {
+            let result = (|| -> Result<ConnectOutcome, String> {
                 use crate::hid::HidDevice;
 
                 progress("Opening HID device…");
@@ -719,9 +740,6 @@ impl EntropyApp {
                 log::info!("Vial protocol: {vial_protocol}, keyboard id: {keyboard_id:016X}");
                 let cache_keys = device_cache_keys(&dev, keyboard_id);
                 let cache_key = &cache_keys[0];
-                if ![-1i32, 9].contains(&(via_protocol as i32)) {
-                    return Err(format!("Unsupported VIA protocol version: {via_protocol}"));
-                }
                 if !matches!(vial_protocol, 0..=6) {
                     return Err(format!(
                         "Unsupported Vial protocol version: {vial_protocol}"
@@ -735,7 +753,22 @@ impl EntropyApp {
                         None
                     }
                 };
-
+                if via_protocol == 0 {
+                    progress("Checking active Vial unlock…");
+                    log::warn!(
+                        "VIA protocol 0 received from {}; checking Vial unlock state",
+                        dev.name
+                    );
+                }
+                let connect_mode = classify_via_connect(
+                    via_protocol,
+                    vial_unlock_status
+                        .as_ref()
+                        .map(|status| (status.unlocked, status.in_progress)),
+                );
+                if connect_mode == ViaConnectMode::Unsupported {
+                    return Err(format!("Unsupported VIA protocol version: {via_protocol}"));
+                }
                 progress("Reading firmware version…");
                 let runtime_firmware_version = match dev_conn.get_firmware_version() {
                     Ok(Some(version)) => Some(version),
@@ -795,6 +828,31 @@ impl EntropyApp {
                     }
                     json
                 };
+
+                progress("Parsing keyboard layout…");
+                let mut layout = KeyboardLayout::from_vial_json(&json)
+                    .map_err(|e| format!("Layout parse failed: {e}"))?;
+
+                if connect_mode == ViaConnectMode::RecoverUnlock {
+                    let Some(unlock_status) = vial_unlock_status.as_ref() else {
+                        return Err("Active Vial unlock state disappeared during connect".into());
+                    };
+                    let unlock_keys = unlock_status.keys.clone();
+                    log::warn!(
+                        "Recovering active Vial unlock for {} (keyboard id {keyboard_id:016X}, {} unlock keys)",
+                        dev.name,
+                        unlock_keys.len()
+                    );
+                    progress("Resuming active Vial unlock…");
+                    return Ok(ConnectOutcome::UnlockRecovery(UnlockRecoveryResult {
+                        device_name: dev.name.clone(),
+                        keyboard_id,
+                        hid_device: Some(dev_conn),
+                        layout,
+                        unlock_keys,
+                    }));
+                }
+
                 let firmware_version = runtime_firmware_version
                     .clone()
                     .or_else(|| firmware_version_from_vial_json(&json));
@@ -867,10 +925,6 @@ impl EntropyApp {
                     Vec::new()
                 };
                 let has_qmk_setting = |qsid: u16| supported_qmk_settings.contains(&qsid);
-
-                progress("Parsing keyboard layout…");
-                let mut layout = KeyboardLayout::from_vial_json(&json)
-                    .map_err(|e| format!("Layout parse failed: {e}"))?;
 
                 progress("Reading layer count…");
                 log::info!("Getting layer count…");
@@ -1331,7 +1385,7 @@ impl EntropyApp {
                 };
 
                 progress("Applying keyboard layout…");
-                Ok(ConnectResult {
+                Ok(ConnectOutcome::Connected(ConnectResult {
                     device_name: dev.name.clone(),
                     keyboard_id,
                     vial_unlock_status,
@@ -1365,7 +1419,7 @@ impl EntropyApp {
                     layer_count,
                     supported_qmk_settings,
                     deferred_load,
-                })
+                }))
             })();
 
             let _ = tx.send(ConnectTaskMessage::Done(Box::new(result)));
@@ -1385,6 +1439,28 @@ impl EntropyApp {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn via_zero_recovers_only_active_vial_unlock() {
+        assert_eq!(
+            classify_via_connect(0, Some((false, true))),
+            ViaConnectMode::RecoverUnlock
+        );
+        assert_eq!(
+            classify_via_connect(0, Some((false, false))),
+            ViaConnectMode::Unsupported
+        );
+        assert_eq!(
+            classify_via_connect(0, Some((true, true))),
+            ViaConnectMode::Unsupported
+        );
+        assert_eq!(classify_via_connect(0, None), ViaConnectMode::Unsupported);
+        assert_eq!(classify_via_connect(9, None), ViaConnectMode::Normal);
+        assert_eq!(
+            classify_via_connect(u16::MAX, None),
+            ViaConnectMode::Normal
+        );
+    }
 
     #[test]
     fn reported_layer_count_is_never_zero() {

--- a/src/ui/device_connection.rs
+++ b/src/ui/device_connection.rs
@@ -226,6 +226,7 @@ impl EntropyApp {
         self.vial_unlock_keys.clear();
         self.vial_unlock_polling = false;
         self.vial_unlock_last_poll = None;
+        self.vial_unlock_reconnect_after_completion = false;
         self.pending_layout_indicator_open_after_unlock = false;
         self.keycode_picker.open = false;
         self.current_device_name.clear();

--- a/src/ui/vial_hid_task.rs
+++ b/src/ui/vial_hid_task.rs
@@ -91,11 +91,14 @@ fn run_vial_hid_operation(
 ) -> anyhow::Result<VialHidOutcome> {
     match operation {
         VialHidOperation::UnlockStart => {
-            let (unlocked, keys) = hid.get_unlock_status()?;
-            if !unlocked {
+            let status = hid.get_unlock_status()?;
+            if !status.unlocked && !status.in_progress {
                 hid.unlock_start()?;
             }
-            Ok(VialHidOutcome::UnlockStarted { unlocked, keys })
+            Ok(VialHidOutcome::UnlockStarted {
+                unlocked: status.unlocked,
+                keys: status.keys,
+            })
         }
         VialHidOperation::UnlockPoll => {
             let (unlocked, in_progress, counter) = hid.unlock_poll()?;

--- a/src/vial/unlock.rs
+++ b/src/vial/unlock.rs
@@ -5,6 +5,14 @@ use super::*;
 const VIAL_UNLOCK_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(200);
 const VIAL_UNLOCK_PROGRESS_ANIMATION_TIME: f32 = 0.16;
 
+fn should_start_vial_unlock(
+    unlock_open: bool,
+    unlock_polling: bool,
+    start_requested: bool,
+) -> bool {
+    unlock_open && !unlock_polling && start_requested
+}
+
 impl EntropyApp {
     pub(super) fn stop_vial_unlock_with_status(&mut self, status: impl Into<String>) {
         self.status_msg = status.into();
@@ -125,23 +133,6 @@ impl EntropyApp {
     pub(super) fn draw_vial_unlock_overlay(&mut self, ctx: &egui::Context) {
         // Vial unlock modal
         if self.unlock_open && self.firmware == FirmwareProtocol::Vial {
-            // Start unlock through the serialized HID worker so Bluetooth
-            // round-trips never block the UI thread.
-            #[cfg(not(target_arch = "wasm32"))]
-            if !self.vial_unlock_polling {
-                match self.start_vial_unlock(ctx) {
-                    VialHidTaskStart::Started | VialHidTaskStart::Busy => {}
-                    VialHidTaskStart::NoDevice => {
-                        self.stop_vial_unlock_with_status(crate::i18n::tr_catalog(
-                            self.app_settings.language,
-                            "status_messages.unlock_cancelled_disconnected",
-                        ));
-                        return;
-                    }
-                }
-                ctx.request_repaint_after(std::time::Duration::from_millis(16));
-            }
-
             // Match Vial's polling cadence. Vial QMK resets the unlock counter whenever
             // UNLOCK_POLL arrives before its internal ~100ms timer has elapsed, even if the
             // correct keys are held. Polling too fast makes progress stick near zero.
@@ -174,6 +165,9 @@ impl EntropyApp {
             let counter = self.vial_unlock_counter;
             let total = self.vial_unlock_total;
             let layout_options_value = self.layout_options_value;
+            let waiting_for_start = !self.vial_unlock_polling;
+            let mut start_requested = false;
+            let mut cancel_requested = false;
 
             egui::Area::new(egui::Id::new("unlock_overlay"))
                 .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
@@ -207,6 +201,11 @@ impl EntropyApp {
                     } else {
                         Color32::from_rgb(230, 230, 233)
                     };
+                    ui.interact(
+                        screen,
+                        egui::Id::new("unlock_overlay_blocker"),
+                        egui::Sense::click_and_drag(),
+                    );
                     ui.painter().rect_filled(screen, 0.0, screen_bg);
 
                     let center_x = screen.center().x;
@@ -224,53 +223,96 @@ impl EntropyApp {
                         title_color,
                     );
 
+                    let subtitle_key = if waiting_for_start {
+                        "unlock.start_hint"
+                    } else {
+                        "unlock.highlighted_keys_hint"
+                    };
                     ui.painter().text(
                         egui::pos2(center_x, top_y + 30.0),
                         egui::Align2::CENTER_CENTER,
-                        crate::i18n::tr_catalog(
-                            self.app_settings.language,
-                            "unlock.highlighted_keys_hint",
-                        ),
+                        crate::i18n::tr_catalog(self.app_settings.language, subtitle_key),
                         FontId::proportional(14.0),
                         subtitle_color,
                     );
 
-                    // Progress bar
-                    let target_progress = if total > 0 {
-                        1.0 - (counter as f32 / total as f32)
+                    if waiting_for_start {
+                        let controls_rect = egui::Rect::from_center_size(
+                            egui::pos2(center_x, top_y + 78.0),
+                            egui::vec2(320.0, 40.0),
+                        );
+                        crate::ui_style::allocate_ui_at_rect(ui, controls_rect, |ui| {
+                            ui.horizontal_centered(|ui| {
+                                if crate::ui_style::modern_button(
+                                    ui,
+                                    crate::i18n::tr_catalog(
+                                        self.app_settings.language,
+                                        "unlock.cancel",
+                                    ),
+                                    egui::vec2(120.0, 34.0),
+                                    true,
+                                )
+                                .clicked()
+                                {
+                                    cancel_requested = true;
+                                }
+                                ui.add_space(12.0);
+                                if crate::ui_style::modern_button(
+                                    ui,
+                                    crate::i18n::tr_catalog(
+                                        self.app_settings.language,
+                                        "unlock.start",
+                                    ),
+                                    egui::vec2(120.0, 34.0),
+                                    true,
+                                )
+                                .clicked()
+                                {
+                                    start_requested = true;
+                                }
+                            });
+                        });
                     } else {
-                        0.0
-                    };
-                    let progress = ui.ctx().animate_value_with_time(
-                        egui::Id::new(("vial_unlock_progress", self.vial_unlock_animation_nonce)),
-                        target_progress.clamp(0.0, 1.0),
-                        VIAL_UNLOCK_PROGRESS_ANIMATION_TIME,
-                    );
-                    let bar_w = 300.0f32;
-                    let bar_h = 12.0f32;
-                    let bar_y = top_y + 55.0;
-                    let bar_rect = egui::Rect::from_min_size(
-                        egui::pos2(center_x - bar_w / 2.0, bar_y),
-                        egui::Vec2::new(bar_w, bar_h),
-                    );
-                    ui.painter().rect(
-                        bar_rect,
-                        4.0,
-                        bar_bg,
-                        egui::Stroke::NONE,
-                        egui::StrokeKind::Inside,
-                    );
-                    let fill_rect = egui::Rect::from_min_size(
-                        bar_rect.min,
-                        egui::Vec2::new(bar_w * progress, bar_h),
-                    );
-                    ui.painter().rect(
-                        fill_rect,
-                        4.0,
-                        app_accent(),
-                        egui::Stroke::NONE,
-                        egui::StrokeKind::Inside,
-                    );
+                        // Progress bar
+                        let target_progress = if total > 0 {
+                            1.0 - (counter as f32 / total as f32)
+                        } else {
+                            0.0
+                        };
+                        let progress = ui.ctx().animate_value_with_time(
+                            egui::Id::new((
+                                "vial_unlock_progress",
+                                self.vial_unlock_animation_nonce,
+                            )),
+                            target_progress.clamp(0.0, 1.0),
+                            VIAL_UNLOCK_PROGRESS_ANIMATION_TIME,
+                        );
+                        let bar_w = 300.0f32;
+                        let bar_h = 12.0f32;
+                        let bar_y = top_y + 55.0;
+                        let bar_rect = egui::Rect::from_min_size(
+                            egui::pos2(center_x - bar_w / 2.0, bar_y),
+                            egui::Vec2::new(bar_w, bar_h),
+                        );
+                        ui.painter().rect(
+                            bar_rect,
+                            4.0,
+                            bar_bg,
+                            egui::Stroke::NONE,
+                            egui::StrokeKind::Inside,
+                        );
+                        let fill_rect = egui::Rect::from_min_size(
+                            bar_rect.min,
+                            egui::Vec2::new(bar_w * progress, bar_h),
+                        );
+                        ui.painter().rect(
+                            fill_rect,
+                            4.0,
+                            app_accent(),
+                            egui::Stroke::NONE,
+                            egui::StrokeKind::Inside,
+                        );
+                    }
 
                     // Draw layout keys with highlighted unlock keys. Always compute geometry
                     // against the fullscreen unlock overlay: `last_layout_geometry` belongs to
@@ -331,6 +373,38 @@ impl EntropyApp {
                         }
                     }
                 });
+
+            if cancel_requested {
+                self.cancel_vial_unlock(true);
+                ctx.request_repaint();
+                return;
+            }
+            if should_start_vial_unlock(self.unlock_open, self.vial_unlock_polling, start_requested)
+            {
+                match self.start_vial_unlock(ctx) {
+                    VialHidTaskStart::Started | VialHidTaskStart::Busy => {}
+                    VialHidTaskStart::NoDevice => {
+                        self.stop_vial_unlock_with_status(crate::i18n::tr_catalog(
+                            self.app_settings.language,
+                            "status_messages.unlock_cancelled_disconnected",
+                        ));
+                    }
+                }
+                ctx.request_repaint_after(std::time::Duration::from_millis(16));
+            }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unlock_waits_for_explicit_start_request() {
+        assert!(!should_start_vial_unlock(true, false, false));
+        assert!(should_start_vial_unlock(true, false, true));
+        assert!(!should_start_vial_unlock(false, false, true));
+        assert!(!should_start_vial_unlock(true, true, true));
     }
 }

--- a/src/vial/unlock.rs
+++ b/src/vial/unlock.rs
@@ -11,12 +11,14 @@ impl EntropyApp {
         self.unlock_open = false;
         self.vial_unlock_polling = false;
         self.vial_unlock_last_poll = None;
+        self.vial_unlock_reconnect_after_completion = false;
         self.vial_unlock_counter = self.vial_unlock_total;
         self.vial_unlock_best = self.vial_unlock_total;
         self.pending_layout_indicator_open_after_unlock = false;
     }
 
     fn complete_vial_unlock(&mut self) {
+        let reconnect_after_completion = self.vial_unlock_reconnect_after_completion;
         self.vial_unlocked = Some(true);
         self.status_msg = crate::i18n::tr_catalog(
             self.app_settings.language,
@@ -26,12 +28,24 @@ impl EntropyApp {
         self.unlock_open = false;
         self.vial_unlock_polling = false;
         self.vial_unlock_last_poll = None;
+        self.vial_unlock_reconnect_after_completion = false;
         self.macro_auto_unlock_cancelled = false;
         if self.pending_layout_indicator_open_after_unlock {
             self.pending_layout_indicator_open_after_unlock = false;
             self.app_settings.sticky_layout_window = true;
             self.sticky_layout_last_size = None;
             save_app_settings(&self.app_settings);
+        }
+        if reconnect_after_completion {
+            if let Some(device_idx) = self.selected_device {
+                log::info!("Reloading device state after Vial unlock recovery");
+                self.start_connect(device_idx);
+            } else {
+                self.stop_vial_unlock_with_status(crate::i18n::tr_catalog(
+                    self.app_settings.language,
+                    "status_messages.unlock_cancelled_disconnected",
+                ));
+            }
         }
     }
 
@@ -59,7 +73,7 @@ impl EntropyApp {
     pub(super) fn finish_vial_unlock_poll(
         &mut self,
         unlocked: bool,
-        _in_progress: bool,
+        in_progress: bool,
         counter: u8,
     ) {
         self.vial_unlock_counter = counter;
@@ -68,6 +82,21 @@ impl EntropyApp {
         }
         if unlocked {
             self.complete_vial_unlock();
+        } else if !in_progress {
+            log::warn!("Vial unlock poll reported session ended before unlock; reconnecting");
+            self.vial_unlocked = Some(false);
+            self.unlock_open = false;
+            self.vial_unlock_polling = false;
+            self.vial_unlock_last_poll = None;
+            self.vial_unlock_reconnect_after_completion = false;
+            if let Some(device_idx) = self.selected_device {
+                self.start_connect(device_idx);
+            } else {
+                self.stop_vial_unlock_with_status(crate::i18n::tr_catalog(
+                    self.app_settings.language,
+                    "status_messages.unlock_cancelled_disconnected",
+                ));
+            }
         } else {
             self.vial_unlocked = Some(false);
         }


### PR DESCRIPTION
## EN

### Problem

Diagnostic logs captured Phenom Mini freezes with VIA protocol `0` while Vial protocol `6` and keyboard ID remained valid. A hardware reset restored VIA protocol `9`. This state matches firmware remaining inside a Vial unlock session, where normal keyboard input is suppressed until unlock finishes or firmware resets.

Entropy rejected this state as unsupported during reconnect, before checking Vial unlock status. It could also start the blocking firmware session without a deliberate unlock action because opening a locked Matrix Tester or macro flow immediately sent `UNLOCK_START`.

### Fix

- Treat VIA `0` as recoverable only when Vial reports `unlocked = false` and `in_progress = true`; every other unsupported VIA response remains an error.
- Load the keyboard definition through commands allowed during active unlock, restore the highlighted-key overlay, and continue `UNLOCK_POLL` without sending another `UNLOCK_START`.
- Reload full keyboard state after recovery completes or firmware reports that the session ended.
- Require an explicit Start click before beginning a new unlock. Cancel before Start only closes the prompt; an active firmware session stays visible because Vial provides no cancel command.
- Log protocol detection, explicit start, resume, completion, and reconnect transitions for future diagnostics.

This closes Entropy-controlled triggering and reconnect recovery. A firmware timeout/watchdog for host loss remains separate firmware work.

### Verification

- `cargo test --locked`: 194 passed.
- `cargo build --locked --release`: passed on macOS.
- `cargo clippy --locked --all-targets`: passed with existing repository warnings.
- `python3 scripts/check_i18n.py`: passed.
- Scoped `rustfmt --check` and `git diff --check`: passed.
- Physical Phenom Mini validation was not available locally.

## Post-Deploy monitoring & validation

- On a locked Phenom Mini, open Matrix Tester: the prompt may open, but keyboard input must continue until Start is clicked.
- Start unlock, then suspend, reconnect, or relaunch Entropy before completing it. Entropy must restore highlighted keys, finish unlock without another `UNLOCK_START`, and reload full keyboard state.
- Inspect logs for `VIA protocol 0 received`, `Recovering active Vial unlock`, `Vial UNLOCK_START accepted`, and `Reloading device state after Vial unlock recovery`. Repeated recovery loops or VIA `0` without active Vial status are rollback signals.
- Validation window: next 0.2.x prerelease and first 24 hours after release. Owner: Entropy maintainers. Rollback: revert this commit or ship the previous Entropy build; keep firmware watchdog work separate.

Related: #68

## RU

### Проблема

https://t.me/c/1464748383/7588/130869

Диагностические логи зафиксировали зависание Phenom Mini: VIA protocol возвращал `0`, при этом Vial protocol `6` и keyboard ID читались корректно. После аппаратного сброса VIA protocol снова стал `9`. Такое состояние соответствует незавершенной Vial unlock session в прошивке, во время которой обычный ввод с клавиатуры заблокирован до завершения unlock или сброса прошивки.

При reconnect Entropy отклоняла это состояние как неподдерживаемое до проверки Vial unlock status. Кроме того, открытие заблокированного Matrix Tester или macro flow сразу отправляло `UNLOCK_START`, поэтому блокирующая firmware session могла начаться без явного действия пользователя.

### Исправление

- VIA `0` считается восстанавливаемым только если Vial сообщает `unlocked = false` и `in_progress = true`; остальные неподдерживаемые ответы VIA остаются ошибкой.
- Entropy загружает keyboard definition через команды, разрешенные во время активного unlock, восстанавливает экран с подсвеченными клавишами и продолжает `UNLOCK_POLL` без повторного `UNLOCK_START`.
- После завершения recovery или окончания firmware session Entropy заново загружает полное состояние клавиатуры.
- Новый unlock начинается только после явного нажатия Start. Cancel до Start только закрывает prompt; активная firmware session остается видимой, потому что Vial не предоставляет команду cancel.
- В логи добавлены обнаружение протокола, события start, resume, completion и reconnect transitions.

Это закрывает запуск блокирующего состояния и reconnect recovery со стороны Entropy. Firmware timeout/watchdog при потере host остаётся отдельной задачей прошивки.

### Проверка

- `cargo test --locked`: прошли 194 теста.
- `cargo build --locked --release`: прошёл на macOS.
- `cargo clippy --locked --all-targets`: прошёл с существующими предупреждениями репозитория.
- `python3 scripts/check_i18n.py`: прошёл.
- Scoped `rustfmt --check` и `git diff --check`: прошли.
- Физическая проверка на Phenom Mini локально не выполнялась.

### Проверка после билда

- На заблокированной Phenom Mini открыть Matrix Tester: prompt может открыться, но клавиатура должна продолжать работать до нажатия Start.
- Начать unlock, затем усыпить Mac, переподключить клавиатуру или перезапустить Entropy до завершения. Entropy должна восстановить подсвеченные клавиши, завершить unlock без повторного `UNLOCK_START` и заново загрузить полное состояние клавиатуры.
- В логах проверить `VIA protocol 0 received`, `Recovering active Vial unlock`, `Vial UNLOCK_START accepted` и `Reloading device state after Vial unlock recovery`. Повторяющийся recovery loop или VIA `0` без активного Vial status требуют rollback.
