### PR TITLE
Skip X11 smart input backend on Wayland

### DIFF
--- a/src/smart_input.rs
+++ b/src/smart_input.rs
@@ -175,7 +175,7 @@ pub fn universal_output_status() -> String {
     "Universal output backend: unsupported on this OS".to_owned()
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", test))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum LinuxSessionKind {
     Wayland,
@@ -192,6 +192,11 @@ fn linux_session_kind() -> LinuxSessionKind {
     } else {
         LinuxSessionKind::Unknown
     }
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn should_start_linux_x11_backend(session: LinuxSessionKind) -> bool {
+    matches!(session, LinuxSessionKind::X11)
 }
 
 #[cfg(target_os = "linux")]
@@ -504,6 +509,9 @@ pub fn start() {
 
 #[cfg(target_os = "linux")]
 pub fn start() {
+    if !should_start_linux_x11_backend(linux_session_kind()) {
+        return;
+    }
     use std::sync::Once;
     static START: Once = Once::new();
     START.call_once(|| {
@@ -1304,6 +1312,13 @@ mod tests {
         let hard_sign =
             windows_smart_symbol_for_transport(KC_F13 + 5, true, false, true, false, 0).unwrap();
         assert_eq!(hard_sign.0, 'ъ');
+    }
+
+    #[test]
+    fn linux_x11_backend_only_starts_for_x11_sessions() {
+        assert!(should_start_linux_x11_backend(LinuxSessionKind::X11));
+        assert!(!should_start_linux_x11_backend(LinuxSessionKind::Wayland));
+        assert!(!should_start_linux_x11_backend(LinuxSessionKind::Unknown));
     }
 
     #[test]


### PR DESCRIPTION
## EN

### Summary

Entropy no longer starts its X11 `XGrabKey`/`xdotool` smart-input backend in Wayland sessions. Universal symbols stay on the configured IBus/Fcitx5 path, preventing duplicate `*` output and the extra synthetic `|` input that could move the caret.

### Root cause

Wayland sessions commonly expose both `WAYLAND_DISPLAY` and an XWayland `DISPLAY`. Entropy already classified that environment as Wayland, but Linux startup ignored the classification and always spawned the X11 listener.

### Verification

- Added a regression test proving the X11 backend starts only for `LinuxSessionKind::X11`, not `Wayland` or `Unknown`
- `cargo test`: 192 passed
- `cargo clippy --all-targets --all-features`: passed with pre-existing warnings
- `rustfmt --check src/smart_input.rs`: passed
- Real Wayland/XWayland retest remains required because the local environment is macOS

## RU

### Кратко

https://t.me/c/1464748383/7597/131836

Entropy больше не запускает X11-бэкенд `XGrabKey`/`xdotool` в Wayland-сессии. Универсальные символы остаются на настроенном IBus/Fcitx5-бэкенде, поэтому `*` не печатается дважды, а дополнительный синтетический ввод `|` не сбивает каретку.

### Причина

Wayland-сессия обычно экспортирует и `WAYLAND_DISPLAY`, и XWayland `DISPLAY`. Entropy уже определял такую сессию как Wayland, но Linux startup игнорировал результат и всегда запускал X11 listener.

### Проверка

- Добавлен тест: X11 backend стартует только для `LinuxSessionKind::X11`, но не для `Wayland`/`Unknown`
- `cargo test`: 192 прошли
- `cargo clippy --all-targets --all-features`: успешно с уже имеющимися предупреждениями
- `rustfmt --check src/smart_input.rs`: успешно
- Нужен финальный retest на реальном Wayland/XWayland: локальная среда macOS
