### PR TITLE
Limit embedded layouts to test-only fixtures

### DIFF
--- a/src/layouts.rs
+++ b/src/layouts.rs
@@ -1,58 +1,29 @@
-/// Offline embedded Ergohaven layout database for Vial coordinate corrections.
-///
-/// Some firmware layout JSONs use KLE rotation groups that are easier to render
-/// from trusted device-specific coordinates. `lookup_layout` matches a device
-/// name to an embedded physical layout.
+//! Validation helpers for embedded Ergohaven layout fixtures.
 use crate::keyboard::PhysicalKey;
 
 const K03_JSON: &str = include_str!("layouts/k03.json");
 const IMPERIAL44_JSON: &str = include_str!("layouts/imperial44.json");
 const OP36_JSON: &str = include_str!("layouts/op36.json");
 
-pub struct EmbeddedLayout {
-    pub id: &'static str,
-    pub name: &'static str,
-    pub json: &'static str,
+struct EmbeddedLayout {
+    name: &'static str,
+    json: &'static str,
 }
 
 static LAYOUTS: &[EmbeddedLayout] = &[
     EmbeddedLayout {
-        id: "k03",
         name: "K:03",
         json: K03_JSON,
     },
     EmbeddedLayout {
-        id: "imperial44",
         name: "Imperial44",
         json: IMPERIAL44_JSON,
     },
     EmbeddedLayout {
-        id: "op36",
         name: "Omega Point 36",
         json: OP36_JSON,
     },
 ];
-
-/// Try to find an embedded layout matching the device name (case-insensitive substring match).
-/// Returns parsed physical keys on success.
-pub fn lookup_layout(device_name: &str) -> Option<(&'static EmbeddedLayout, Vec<PhysicalKey>)> {
-    // Strip non-alphanumeric for fuzzy match (e.g. "K:03" matches id "k03")
-    let dn = device_name.to_lowercase();
-    let dn_alnum: String = dn.chars().filter(|c| c.is_alphanumeric()).collect();
-    let layout = LAYOUTS.iter().find(|l| {
-        let id = l.id.to_lowercase();
-        let name = l.name.to_lowercase();
-        let id_alnum: String = id.chars().filter(|c| c.is_alphanumeric()).collect();
-        let name_alnum: String = name.chars().filter(|c| c.is_alphanumeric()).collect();
-        dn.contains(&id)
-            || dn.contains(&name)
-            || dn_alnum.contains(&id_alnum)
-            || dn_alnum.contains(&name_alnum)
-    })?;
-
-    let keys = parse_embedded_json(layout.json)?;
-    Some((layout, keys))
-}
 
 /// Parse the embedded JSON format: `layouts.default_transform.layout` is an array of
 /// `{ row, col, x, y, r? }` with absolute coordinates in KLE units.

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod i18n;
 mod keyboard;
 mod keycode;
 mod keycode_picker;
+#[cfg(test)]
 mod layouts;
 #[cfg(target_os = "linux")]
 mod linux_setup;


### PR DESCRIPTION
## EN

### Summary

- Compile embedded Ergohaven layout fixtures only for tests because runtime code has no callers.
- Remove unused lookup metadata and API while preserving JSON parsing and visual-symmetry coverage.
- Eliminate eight dead-code warnings without changing application behavior.

### Verification

- `cargo test --locked` - 191 passed.
- `cargo clippy --locked --all-targets` - target warnings removed; existing baseline warnings remain.
- `cargo build --release --locked`.
- `scripts/build_macos_app.sh` - arm64 app, DMG, and ZIP built; plist validation passed.
- `rustfmt --edition 2021 --check src/layouts.rs` and `git diff --check`.
- Manual Build workflow: https://github.com/IgorArkhipov/entropy/actions/runs/29453685710 (Linux, macOS arm64, macOS Intel, Windows passed).

Repository-wide `cargo fmt -- --check` still reports pre-existing formatting baseline outside this change.

Related: #17

## RU

### Кратко

- Встроенные JSON-макеты Ergohaven теперь компилируются только для тестов, так как рабочий код их не использует.
- Удалены неиспользуемые метаданные и API поиска; разбор JSON и тесты визуальной симметрии сохранены.
- Устранено восемь предупреждений `dead_code` без изменения поведения приложения.

### Проверка

- `cargo test --locked` - 191 тест пройден.
- `cargo clippy --locked --all-targets` - целевые предупреждения устранены; остальные относятся к существующему baseline.
- `cargo build --release --locked`.
- `scripts/build_macos_app.sh` - собраны arm64-приложение, DMG и ZIP; plist прошел проверку.
- `rustfmt --edition 2021 --check src/layouts.rs` и `git diff --check`.
- Ручной запуск Build: https://github.com/IgorArkhipov/entropy/actions/runs/29453685710 (Linux, macOS arm64, macOS Intel и Windows прошли).

Общий `cargo fmt -- --check` по репозиторию по-прежнему сообщает о ранее существовавшем formatting baseline вне этого изменения.

Связано с #17
