### PR TITLE
Group universal-symbol setup row parameters

### DIFF
--- a/src/ui/universal_symbols_setup.rs
+++ b/src/ui/universal_symbols_setup.rs
@@ -10,6 +10,128 @@ enum MacosPermissionStatusKind {
     InputMonitoring,
 }
 
+#[derive(Clone, Copy)]
+struct UniversalSymbolsRowContext {
+    content_width: f32,
+    height: f32,
+    metrics: crate::ui_style::ResponsiveMetrics,
+    lang: crate::i18n::Language,
+    dark: bool,
+    suppress_tooltips: bool,
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy)]
+struct MacosPermissionRow {
+    label_key: &'static str,
+    tooltip_key: &'static str,
+    status_kind: MacosPermissionStatusKind,
+}
+
+#[derive(Clone, Copy)]
+struct UniversalSymbolsFinishStep {
+    label_key: &'static str,
+    tooltip_key: &'static str,
+    value_key: &'static str,
+    detail_key: Option<&'static str>,
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[derive(Clone, Copy)]
+struct UniversalSymbolsAction {
+    label_key: &'static str,
+    tooltip_key: &'static str,
+    button_key: &'static str,
+}
+
+#[cfg(target_os = "macos")]
+const MACOS_ACCESSIBILITY_STATUS_ROW: MacosPermissionRow = MacosPermissionRow {
+    label_key: "universal_symbols_setup.accessibility_status",
+    tooltip_key: "universal_symbols_setup.accessibility_status_tooltip",
+    status_kind: MacosPermissionStatusKind::Accessibility,
+};
+
+#[cfg(target_os = "macos")]
+const MACOS_INPUT_MONITORING_STATUS_ROW: MacosPermissionRow = MacosPermissionRow {
+    label_key: "universal_symbols_setup.input_monitoring_status",
+    tooltip_key: "universal_symbols_setup.input_monitoring_status_tooltip",
+    status_kind: MacosPermissionStatusKind::InputMonitoring,
+};
+
+#[cfg(target_os = "macos")]
+const OPEN_MACOS_ACCESSIBILITY_ACTION: UniversalSymbolsAction = UniversalSymbolsAction {
+    label_key: "universal_symbols_setup.open_accessibility_settings",
+    tooltip_key: "universal_symbols_setup.open_accessibility_settings_tooltip",
+    button_key: "universal_symbols_setup.open_privacy_settings",
+};
+
+#[cfg(target_os = "macos")]
+const OPEN_MACOS_INPUT_MONITORING_ACTION: UniversalSymbolsAction = UniversalSymbolsAction {
+    label_key: "universal_symbols_setup.open_input_monitoring_settings",
+    tooltip_key: "universal_symbols_setup.open_input_monitoring_settings_tooltip",
+    button_key: "universal_symbols_setup.open_privacy_settings",
+};
+
+#[cfg(target_os = "macos")]
+const RESTART_MACOS_EVENT_TAP_ACTION: UniversalSymbolsAction = UniversalSymbolsAction {
+    label_key: "universal_symbols_setup.restart_event_tap",
+    tooltip_key: "universal_symbols_setup.restart_event_tap_tooltip",
+    button_key: "universal_symbols_setup.restart_event_tap_button",
+};
+
+#[cfg(target_os = "linux")]
+const SETUP_IBUS_ACTION: UniversalSymbolsAction = UniversalSymbolsAction {
+    label_key: "universal_symbols_setup.wayland_ibus",
+    tooltip_key: "universal_symbols_setup.wayland_ibus_tooltip",
+    button_key: "universal_symbols_setup.setup_ibus",
+};
+
+#[cfg(target_os = "linux")]
+const SETUP_FCITX5_ACTION: UniversalSymbolsAction = UniversalSymbolsAction {
+    label_key: "universal_symbols_setup.wayland_fcitx5",
+    tooltip_key: "universal_symbols_setup.wayland_fcitx5_tooltip",
+    button_key: "universal_symbols_setup.setup_fcitx5",
+};
+
+#[cfg(target_os = "linux")]
+const SETUP_ALTERNATIVE_FCITX5_ACTION: UniversalSymbolsAction = UniversalSymbolsAction {
+    label_key: "universal_symbols_setup.alternative_backend",
+    tooltip_key: "universal_symbols_setup.alternative_backend_tooltip",
+    button_key: "universal_symbols_setup.setup_fcitx5",
+};
+
+#[cfg(target_os = "linux")]
+const SETUP_TEXT_EXPANSION_IBUS_ACTION: UniversalSymbolsAction = UniversalSymbolsAction {
+    label_key: "universal_symbols_setup.text_expansion_backend",
+    tooltip_key: "universal_symbols_setup.text_expansion_backend_tooltip",
+    button_key: "universal_symbols_setup.setup_ibus",
+};
+
+#[cfg(target_os = "linux")]
+const REMOVE_IBUS_ACTION: UniversalSymbolsAction = UniversalSymbolsAction {
+    label_key: "universal_symbols_setup.remove_ibus_source",
+    tooltip_key: "universal_symbols_setup.remove_ibus_source_tooltip",
+    button_key: "universal_symbols_setup.remove_ibus",
+};
+
+fn universal_symbols_finish_step_2() -> UniversalSymbolsFinishStep {
+    UniversalSymbolsFinishStep {
+        label_key: "universal_symbols_setup.finish_step_2",
+        tooltip_key: "universal_symbols_setup.finish_step_2_tooltip",
+        value_key: universal_symbols_finish_step_2_key(),
+        detail_key: universal_symbols_finish_step_2_detail_key(),
+    }
+}
+
+fn universal_symbols_finish_step_3() -> UniversalSymbolsFinishStep {
+    UniversalSymbolsFinishStep {
+        label_key: "universal_symbols_setup.finish_step_3",
+        tooltip_key: "universal_symbols_setup.finish_step_3_tooltip",
+        value_key: universal_symbols_finish_step_3_key(),
+        detail_key: universal_symbols_finish_step_3_detail_key(),
+    }
+}
+
 impl EntropyApp {
     pub(super) fn draw_universal_symbols_setup_page(
         &mut self,
@@ -147,17 +269,16 @@ impl EntropyApp {
                     ui.set_clip_rect(list.viewport);
                     ui.set_min_size(list.content_rect.size());
                     ui.spacing_mut().item_spacing.y = 0.0;
+                    let row = UniversalSymbolsRowContext {
+                        content_width: list.row_content_width,
+                        height: list.row_height,
+                        metrics,
+                        lang,
+                        dark,
+                        suppress_tooltips: list.suppress_tooltips,
+                    };
                     for row_idx in list.first_visible_row..list.last_visible_row {
-                        self.draw_macos_universal_symbols_setup_row(
-                            ui,
-                            row_idx,
-                            list.row_content_width,
-                            list.row_height,
-                            metrics,
-                            lang,
-                            dark,
-                            list.suppress_tooltips,
-                        );
+                        self.draw_macos_universal_symbols_setup_row(ui, row_idx, row);
                     }
                 });
 
@@ -193,162 +314,88 @@ impl EntropyApp {
         &mut self,
         ui: &mut egui::Ui,
         row_idx: usize,
-        row_content_width: f32,
-        row_height: f32,
-        metrics: crate::ui_style::ResponsiveMetrics,
-        lang: crate::i18n::Language,
-        dark: bool,
-        suppress_tooltips: bool,
+        row: UniversalSymbolsRowContext,
     ) {
-        let tooltip =
-            |key: &'static str| (!suppress_tooltips).then_some(crate::i18n::tr_catalog(lang, key));
+        let tooltip = |key: &'static str| {
+            (!row.suppress_tooltips).then_some(crate::i18n::tr_catalog(row.lang, key))
+        };
         match row_idx {
             0 => crate::ui_style::settings_list_row_with_tooltip(
                 ui,
-                row_content_width,
-                row_height,
-                crate::i18n::tr_catalog(lang, "universal_symbols_setup.current_backend"),
+                row.content_width,
+                row.height,
+                crate::i18n::tr_catalog(row.lang, "universal_symbols_setup.current_backend"),
                 true,
                 tooltip("universal_symbols_setup.current_backend_tooltip"),
-                metrics.settings_control_width(),
+                row.metrics.settings_control_width(),
                 |ui| {
                     draw_universal_symbols_value(
                         ui,
-                        metrics,
+                        row.metrics,
                         168.0,
-                        crate::i18n::tr_catalog(lang, universal_symbols_backend_value_key()),
+                        crate::i18n::tr_catalog(row.lang, universal_symbols_backend_value_key()),
                         ui.visuals().text_color(),
                     );
                 },
             ),
-            1 => self.draw_macos_permission_status_row(
-                ui,
-                row_content_width,
-                row_height,
-                metrics,
-                lang,
-                dark,
-                "universal_symbols_setup.accessibility_status",
-                "universal_symbols_setup.accessibility_status_tooltip",
-                MacosPermissionStatusKind::Accessibility,
-                suppress_tooltips,
-            ),
-            2 => self.draw_macos_permission_status_row(
-                ui,
-                row_content_width,
-                row_height,
-                metrics,
-                lang,
-                dark,
-                "universal_symbols_setup.input_monitoring_status",
-                "universal_symbols_setup.input_monitoring_status_tooltip",
-                MacosPermissionStatusKind::InputMonitoring,
-                suppress_tooltips,
-            ),
-            3 => self.draw_macos_event_capture_status_row(
-                ui,
-                row_content_width,
-                row_height,
-                metrics,
-                lang,
-                dark,
-                suppress_tooltips,
-            ),
+            1 => self.draw_macos_permission_status_row(ui, row, MACOS_ACCESSIBILITY_STATUS_ROW),
+            2 => self.draw_macos_permission_status_row(ui, row, MACOS_INPUT_MONITORING_STATUS_ROW),
+            3 => self.draw_macos_event_capture_status_row(ui, row),
             4 => crate::ui_style::settings_list_row_with_tooltip(
                 ui,
-                row_content_width,
-                row_height,
-                crate::i18n::tr_catalog(lang, "universal_symbols_setup.recommended_setup"),
+                row.content_width,
+                row.height,
+                crate::i18n::tr_catalog(row.lang, "universal_symbols_setup.recommended_setup"),
                 true,
                 tooltip("universal_symbols_setup.recommended_setup_tooltip"),
-                metrics.settings_control_width(),
-                |ui| self.draw_universal_symbols_recommended_control(ui, metrics, lang),
+                row.metrics.settings_control_width(),
+                |ui| self.draw_universal_symbols_recommended_control(ui, row.metrics, row.lang),
             ),
-            5 => draw_universal_symbols_finish_step_row(
-                ui,
-                metrics,
-                row_content_width,
-                row_height,
-                lang,
-                dark,
-                "universal_symbols_setup.finish_step_2",
-                "universal_symbols_setup.finish_step_2_tooltip",
-                universal_symbols_finish_step_2_key(),
-                universal_symbols_finish_step_2_detail_key(),
-            ),
-            6 => draw_universal_symbols_finish_step_row(
-                ui,
-                metrics,
-                row_content_width,
-                row_height,
-                lang,
-                dark,
-                "universal_symbols_setup.finish_step_3",
-                "universal_symbols_setup.finish_step_3_tooltip",
-                universal_symbols_finish_step_3_key(),
-                universal_symbols_finish_step_3_detail_key(),
-            ),
+            5 => draw_universal_symbols_finish_step_row(ui, row, universal_symbols_finish_step_2()),
+            6 => draw_universal_symbols_finish_step_row(ui, row, universal_symbols_finish_step_3()),
             7 => crate::ui_style::settings_list_row_with_tooltip(
                 ui,
-                row_content_width,
-                row_height,
-                crate::i18n::tr_catalog(lang, "universal_symbols_setup.text_expander"),
+                row.content_width,
+                row.height,
+                crate::i18n::tr_catalog(row.lang, "universal_symbols_setup.text_expander"),
                 true,
                 tooltip("universal_symbols_setup.text_expander_tooltip"),
-                metrics.value(220.0),
+                row.metrics.value(220.0),
                 |ui| {
                     draw_universal_symbols_value(
                         ui,
-                        metrics,
+                        row.metrics,
                         220.0,
-                        crate::i18n::tr_catalog(lang, universal_symbols_text_expander_key()),
-                        app_muted_text(dark),
+                        crate::i18n::tr_catalog(row.lang, universal_symbols_text_expander_key()),
+                        app_muted_text(row.dark),
                     );
                 },
             ),
             8 => {
                 if draw_universal_symbols_action_row_with_tooltip_state(
                     ui,
-                    metrics,
-                    row_content_width,
-                    row_height,
-                    lang,
-                    "universal_symbols_setup.open_accessibility_settings",
-                    "universal_symbols_setup.open_accessibility_settings_tooltip",
-                    "universal_symbols_setup.open_privacy_settings",
-                    suppress_tooltips,
+                    row,
+                    OPEN_MACOS_ACCESSIBILITY_ACTION,
                 ) {
-                    self.open_macos_accessibility_settings(lang);
+                    self.open_macos_accessibility_settings(row.lang);
                 }
             }
             9 => {
                 if draw_universal_symbols_action_row_with_tooltip_state(
                     ui,
-                    metrics,
-                    row_content_width,
-                    row_height,
-                    lang,
-                    "universal_symbols_setup.open_input_monitoring_settings",
-                    "universal_symbols_setup.open_input_monitoring_settings_tooltip",
-                    "universal_symbols_setup.open_privacy_settings",
-                    suppress_tooltips,
+                    row,
+                    OPEN_MACOS_INPUT_MONITORING_ACTION,
                 ) {
-                    self.open_macos_input_monitoring_settings(lang);
+                    self.open_macos_input_monitoring_settings(row.lang);
                 }
             }
             10 if draw_universal_symbols_action_row_with_tooltip_state(
                 ui,
-                metrics,
-                row_content_width,
-                row_height,
-                lang,
-                "universal_symbols_setup.restart_event_tap",
-                "universal_symbols_setup.restart_event_tap_tooltip",
-                "universal_symbols_setup.restart_event_tap_button",
-                suppress_tooltips,
+                row,
+                RESTART_MACOS_EVENT_TAP_ACTION,
             ) =>
             {
-                self.restart_macos_event_tap(lang);
+                self.restart_macos_event_tap(row.lang);
             }
             _ => {}
         }
@@ -364,6 +411,14 @@ impl EntropyApp {
         let row_height = metrics.settings_row_height();
         let row_content_width = metrics.settings_row_content_width();
         let tooltip = |key: &'static str| Some(crate::i18n::tr_catalog(lang, key));
+        let row = UniversalSymbolsRowContext {
+            content_width: row_content_width,
+            height: row_height,
+            metrics,
+            lang,
+            dark,
+            suppress_tooltips: false,
+        };
 
         crate::ui_style::settings_list_row_with_tooltip(
             ui,
@@ -401,31 +456,9 @@ impl EntropyApp {
             crate::i18n::tr_catalog(lang, "universal_symbols_setup.next_step"),
         );
 
-        draw_universal_symbols_finish_step_row(
-            ui,
-            metrics,
-            row_content_width,
-            row_height,
-            lang,
-            dark,
-            "universal_symbols_setup.finish_step_2",
-            "universal_symbols_setup.finish_step_2_tooltip",
-            universal_symbols_finish_step_2_key(),
-            universal_symbols_finish_step_2_detail_key(),
-        );
+        draw_universal_symbols_finish_step_row(ui, row, universal_symbols_finish_step_2());
 
-        draw_universal_symbols_finish_step_row(
-            ui,
-            metrics,
-            row_content_width,
-            row_height,
-            lang,
-            dark,
-            "universal_symbols_setup.finish_step_3",
-            "universal_symbols_setup.finish_step_3_tooltip",
-            universal_symbols_finish_step_3_key(),
-            universal_symbols_finish_step_3_detail_key(),
-        );
+        draw_universal_symbols_finish_step_row(ui, row, universal_symbols_finish_step_3());
 
         crate::ui_style::settings_list_row_with_tooltip(
             ui,
@@ -548,47 +581,29 @@ impl EntropyApp {
         #[cfg(target_os = "macos")]
         {
             let lang = self.app_settings.language;
-            let row_height = metrics.settings_row_height();
-            let row_content_width = metrics.settings_row_content_width();
-
-            let accessibility_clicked = draw_universal_symbols_action_row(
-                ui,
+            let row = UniversalSymbolsRowContext {
+                content_width: metrics.settings_row_content_width(),
+                height: metrics.settings_row_height(),
                 metrics,
-                row_content_width,
-                row_height,
                 lang,
-                "universal_symbols_setup.open_accessibility_settings",
-                "universal_symbols_setup.open_accessibility_settings_tooltip",
-                "universal_symbols_setup.open_privacy_settings",
-            );
+                dark: ui.visuals().dark_mode,
+                suppress_tooltips: false,
+            };
+
+            let accessibility_clicked =
+                draw_universal_symbols_action_row(ui, row, OPEN_MACOS_ACCESSIBILITY_ACTION);
             if accessibility_clicked {
                 self.open_macos_accessibility_settings(lang);
             }
 
-            let monitoring_clicked = draw_universal_symbols_action_row(
-                ui,
-                metrics,
-                row_content_width,
-                row_height,
-                lang,
-                "universal_symbols_setup.open_input_monitoring_settings",
-                "universal_symbols_setup.open_input_monitoring_settings_tooltip",
-                "universal_symbols_setup.open_privacy_settings",
-            );
+            let monitoring_clicked =
+                draw_universal_symbols_action_row(ui, row, OPEN_MACOS_INPUT_MONITORING_ACTION);
             if monitoring_clicked {
                 self.open_macos_input_monitoring_settings(lang);
             }
 
-            let restart_clicked = draw_universal_symbols_action_row(
-                ui,
-                metrics,
-                row_content_width,
-                row_height,
-                lang,
-                "universal_symbols_setup.restart_event_tap",
-                "universal_symbols_setup.restart_event_tap_tooltip",
-                "universal_symbols_setup.restart_event_tap_button",
-            );
+            let restart_clicked =
+                draw_universal_symbols_action_row(ui, row, RESTART_MACOS_EVENT_TAP_ACTION);
             if restart_clicked {
                 self.restart_macos_event_tap(lang);
             }
@@ -597,8 +612,14 @@ impl EntropyApp {
         #[cfg(target_os = "linux")]
         {
             let lang = self.app_settings.language;
-            let row_height = metrics.settings_row_height();
-            let row_content_width = metrics.settings_row_content_width();
+            let row = UniversalSymbolsRowContext {
+                content_width: metrics.settings_row_content_width(),
+                height: metrics.settings_row_height(),
+                metrics,
+                lang,
+                dark: ui.visuals().dark_mode,
+                suppress_tooltips: false,
+            };
 
             ui.vertical_centered(|ui| {
                 ui.label(
@@ -614,16 +635,8 @@ impl EntropyApp {
 
             match crate::smart_input::linux_recommended_input_backend() {
                 crate::smart_input::LinuxRecommendedInputBackend::X11Native => {
-                    let ibus_clicked = draw_universal_symbols_action_row(
-                        ui,
-                        metrics,
-                        row_content_width,
-                        row_height,
-                        lang,
-                        "universal_symbols_setup.wayland_ibus",
-                        "universal_symbols_setup.wayland_ibus_tooltip",
-                        "universal_symbols_setup.setup_ibus",
-                    );
+                    let ibus_clicked =
+                        draw_universal_symbols_action_row(ui, row, SETUP_IBUS_ACTION);
                     if ibus_clicked {
                         self.run_linux_universal_symbols_setup(
                             "linux/ibus/install-user.sh",
@@ -631,16 +644,8 @@ impl EntropyApp {
                         );
                     }
 
-                    let fcitx5_clicked = draw_universal_symbols_action_row(
-                        ui,
-                        metrics,
-                        row_content_width,
-                        row_height,
-                        lang,
-                        "universal_symbols_setup.wayland_fcitx5",
-                        "universal_symbols_setup.wayland_fcitx5_tooltip",
-                        "universal_symbols_setup.setup_fcitx5",
-                    );
+                    let fcitx5_clicked =
+                        draw_universal_symbols_action_row(ui, row, SETUP_FCITX5_ACTION);
                     if fcitx5_clicked {
                         self.run_linux_universal_symbols_setup(
                             "linux/fcitx5/install-user.sh",
@@ -649,16 +654,8 @@ impl EntropyApp {
                     }
                 }
                 crate::smart_input::LinuxRecommendedInputBackend::IBus => {
-                    let alternative_clicked = draw_universal_symbols_action_row(
-                        ui,
-                        metrics,
-                        row_content_width,
-                        row_height,
-                        lang,
-                        "universal_symbols_setup.alternative_backend",
-                        "universal_symbols_setup.alternative_backend_tooltip",
-                        "universal_symbols_setup.setup_fcitx5",
-                    );
+                    let alternative_clicked =
+                        draw_universal_symbols_action_row(ui, row, SETUP_ALTERNATIVE_FCITX5_ACTION);
                     if alternative_clicked {
                         self.run_linux_universal_symbols_setup(
                             "linux/fcitx5/install-user.sh",
@@ -666,16 +663,8 @@ impl EntropyApp {
                         );
                     }
 
-                    let remove_clicked = draw_universal_symbols_action_row(
-                        ui,
-                        metrics,
-                        row_content_width,
-                        row_height,
-                        lang,
-                        "universal_symbols_setup.remove_ibus_source",
-                        "universal_symbols_setup.remove_ibus_source_tooltip",
-                        "universal_symbols_setup.remove_ibus",
-                    );
+                    let remove_clicked =
+                        draw_universal_symbols_action_row(ui, row, REMOVE_IBUS_ACTION);
                     if remove_clicked {
                         self.run_linux_universal_symbols_setup(
                             "linux/ibus/uninstall-user.sh",
@@ -686,13 +675,8 @@ impl EntropyApp {
                 crate::smart_input::LinuxRecommendedInputBackend::Fcitx5 => {
                     let text_expansion_clicked = draw_universal_symbols_action_row(
                         ui,
-                        metrics,
-                        row_content_width,
-                        row_height,
-                        lang,
-                        "universal_symbols_setup.text_expansion_backend",
-                        "universal_symbols_setup.text_expansion_backend_tooltip",
-                        "universal_symbols_setup.setup_ibus",
+                        row,
+                        SETUP_TEXT_EXPANSION_IBUS_ACTION,
                     );
                     if text_expansion_clicked {
                         self.run_linux_universal_symbols_setup(
@@ -701,16 +685,8 @@ impl EntropyApp {
                         );
                     }
 
-                    let remove_clicked = draw_universal_symbols_action_row(
-                        ui,
-                        metrics,
-                        row_content_width,
-                        row_height,
-                        lang,
-                        "universal_symbols_setup.remove_ibus_source",
-                        "universal_symbols_setup.remove_ibus_source_tooltip",
-                        "universal_symbols_setup.remove_ibus",
-                    );
+                    let remove_clicked =
+                        draw_universal_symbols_action_row(ui, row, REMOVE_IBUS_ACTION);
                     if remove_clicked {
                         self.run_linux_universal_symbols_setup(
                             "linux/ibus/uninstall-user.sh",
@@ -766,39 +742,34 @@ impl EntropyApp {
     fn draw_macos_permission_status_row(
         &mut self,
         ui: &mut egui::Ui,
-        row_content_width: f32,
-        row_height: f32,
-        metrics: crate::ui_style::ResponsiveMetrics,
-        lang: crate::i18n::Language,
-        dark: bool,
-        label_key: &'static str,
-        tooltip_key: &'static str,
-        status_kind: MacosPermissionStatusKind,
-        suppress_tooltips: bool,
+        row: UniversalSymbolsRowContext,
+        permission: MacosPermissionRow,
     ) {
         let status = crate::smart_input::macos_universal_symbols_status();
-        let granted = crate::i18n::tr_catalog(lang, "universal_symbols_setup.permission_granted");
-        let denied = crate::i18n::tr_catalog(lang, "universal_symbols_setup.permission_denied");
-        let is_granted = match status_kind {
+        let granted =
+            crate::i18n::tr_catalog(row.lang, "universal_symbols_setup.permission_granted");
+        let denied = crate::i18n::tr_catalog(row.lang, "universal_symbols_setup.permission_denied");
+        let is_granted = match permission.status_kind {
             MacosPermissionStatusKind::Accessibility => status.accessibility_granted,
             MacosPermissionStatusKind::InputMonitoring => status.input_monitoring_granted,
         };
 
         crate::ui_style::settings_list_row_with_tooltip(
             ui,
-            row_content_width,
-            row_height,
-            crate::i18n::tr_catalog(lang, label_key),
+            row.content_width,
+            row.height,
+            crate::i18n::tr_catalog(row.lang, permission.label_key),
             true,
-            (!suppress_tooltips).then_some(crate::i18n::tr_catalog(lang, tooltip_key)),
-            metrics.value(250.0),
+            (!row.suppress_tooltips)
+                .then_some(crate::i18n::tr_catalog(row.lang, permission.tooltip_key)),
+            row.metrics.value(250.0),
             |ui| {
                 draw_universal_symbols_value(
                     ui,
-                    metrics,
+                    row.metrics,
                     250.0,
                     if is_granted { granted } else { denied },
-                    macos_permission_color(is_granted, dark),
+                    macos_permission_color(is_granted, row.dark),
                 );
             },
         );
@@ -808,29 +779,25 @@ impl EntropyApp {
     fn draw_macos_event_capture_status_row(
         &mut self,
         ui: &mut egui::Ui,
-        row_content_width: f32,
-        row_height: f32,
-        metrics: crate::ui_style::ResponsiveMetrics,
-        lang: crate::i18n::Language,
-        dark: bool,
-        suppress_tooltips: bool,
+        row: UniversalSymbolsRowContext,
     ) {
         let status = crate::smart_input::macos_universal_symbols_status();
-        let active = crate::i18n::tr_catalog(lang, "universal_symbols_setup.event_tap_active");
-        let inactive = crate::i18n::tr_catalog(lang, "universal_symbols_setup.event_tap_inactive");
-        let capture_detail = macos_event_capture_detail(lang, &status);
+        let active = crate::i18n::tr_catalog(row.lang, "universal_symbols_setup.event_tap_active");
+        let inactive =
+            crate::i18n::tr_catalog(row.lang, "universal_symbols_setup.event_tap_inactive");
+        let capture_detail = macos_event_capture_detail(row.lang, &status);
 
         crate::ui_style::settings_list_row_with_tooltip(
             ui,
-            row_content_width,
-            row_height,
-            crate::i18n::tr_catalog(lang, "universal_symbols_setup.event_capture_status"),
+            row.content_width,
+            row.height,
+            crate::i18n::tr_catalog(row.lang, "universal_symbols_setup.event_capture_status"),
             true,
-            (!suppress_tooltips).then_some(crate::i18n::tr_catalog(
-                lang,
+            (!row.suppress_tooltips).then_some(crate::i18n::tr_catalog(
+                row.lang,
                 "universal_symbols_setup.event_capture_status_tooltip",
             )),
-            metrics.value(250.0),
+            row.metrics.value(250.0),
             |ui| {
                 let status_label = if status.event_tap_active {
                     active
@@ -840,19 +807,19 @@ impl EntropyApp {
                 if capture_detail.is_empty() {
                     draw_universal_symbols_value(
                         ui,
-                        metrics,
+                        row.metrics,
                         250.0,
                         status_label,
-                        macos_permission_color(status.event_tap_active, dark),
+                        macos_permission_color(status.event_tap_active, row.dark),
                     );
                 } else {
                     draw_universal_symbols_two_line_value(
                         ui,
-                        metrics,
+                        row.metrics,
                         250.0,
                         status_label,
                         &capture_detail,
-                        dark,
+                        row.dark,
                     );
                 }
             },
@@ -1011,41 +978,34 @@ fn draw_universal_symbols_section_label(
 
 fn draw_universal_symbols_finish_step_row(
     ui: &mut egui::Ui,
-    metrics: crate::ui_style::ResponsiveMetrics,
-    row_content_width: f32,
-    row_height: f32,
-    lang: crate::i18n::Language,
-    dark: bool,
-    label_key: &'static str,
-    tooltip_key: &'static str,
-    value_key: &'static str,
-    detail_key: Option<&'static str>,
+    row: UniversalSymbolsRowContext,
+    step: UniversalSymbolsFinishStep,
 ) {
     crate::ui_style::settings_list_row_with_tooltip(
         ui,
-        row_content_width,
-        row_height,
-        crate::i18n::tr_catalog(lang, label_key),
+        row.content_width,
+        row.height,
+        crate::i18n::tr_catalog(row.lang, step.label_key),
         true,
-        Some(crate::i18n::tr_catalog(lang, tooltip_key)),
-        metrics.value(250.0),
+        Some(crate::i18n::tr_catalog(row.lang, step.tooltip_key)),
+        row.metrics.value(250.0),
         |ui| {
-            if let Some(detail_key) = detail_key {
+            if let Some(detail_key) = step.detail_key {
                 draw_universal_symbols_two_line_value(
                     ui,
-                    metrics,
+                    row.metrics,
                     250.0,
-                    crate::i18n::tr_catalog(lang, value_key),
-                    crate::i18n::tr_catalog(lang, detail_key),
-                    dark,
+                    crate::i18n::tr_catalog(row.lang, step.value_key),
+                    crate::i18n::tr_catalog(row.lang, detail_key),
+                    row.dark,
                 );
             } else {
                 draw_universal_symbols_value(
                     ui,
-                    metrics,
+                    row.metrics,
                     250.0,
-                    crate::i18n::tr_catalog(lang, value_key),
-                    app_muted_text(dark),
+                    crate::i18n::tr_catalog(row.lang, step.value_key),
+                    app_muted_text(row.dark),
                 );
             }
         },
@@ -1055,53 +1015,32 @@ fn draw_universal_symbols_finish_step_row(
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 fn draw_universal_symbols_action_row(
     ui: &mut egui::Ui,
-    metrics: crate::ui_style::ResponsiveMetrics,
-    row_content_width: f32,
-    row_height: f32,
-    lang: crate::i18n::Language,
-    label_key: &'static str,
-    tooltip_key: &'static str,
-    button_key: &'static str,
+    row: UniversalSymbolsRowContext,
+    action: UniversalSymbolsAction,
 ) -> bool {
-    draw_universal_symbols_action_row_with_tooltip_state(
-        ui,
-        metrics,
-        row_content_width,
-        row_height,
-        lang,
-        label_key,
-        tooltip_key,
-        button_key,
-        false,
-    )
+    draw_universal_symbols_action_row_with_tooltip_state(ui, row, action)
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 fn draw_universal_symbols_action_row_with_tooltip_state(
     ui: &mut egui::Ui,
-    metrics: crate::ui_style::ResponsiveMetrics,
-    row_content_width: f32,
-    row_height: f32,
-    lang: crate::i18n::Language,
-    label_key: &'static str,
-    tooltip_key: &'static str,
-    button_key: &'static str,
-    suppress_tooltips: bool,
+    row: UniversalSymbolsRowContext,
+    action: UniversalSymbolsAction,
 ) -> bool {
     let mut clicked = false;
     crate::ui_style::settings_list_row_with_tooltip(
         ui,
-        row_content_width,
-        row_height,
-        crate::i18n::tr_catalog(lang, label_key),
+        row.content_width,
+        row.height,
+        crate::i18n::tr_catalog(row.lang, action.label_key),
         true,
-        (!suppress_tooltips).then_some(crate::i18n::tr_catalog(lang, tooltip_key)),
-        metrics.settings_control_width(),
+        (!row.suppress_tooltips).then_some(crate::i18n::tr_catalog(row.lang, action.tooltip_key)),
+        row.metrics.settings_control_width(),
         |ui| {
             clicked = crate::ui_style::modern_button(
                 ui,
-                crate::i18n::tr_catalog(lang, button_key),
-                metrics.size(168.0, 34.0),
+                crate::i18n::tr_catalog(row.lang, action.button_key),
+                row.metrics.size(168.0, 34.0),
                 true,
             )
             .clicked();


### PR DESCRIPTION
## EN

### Summary

- Group universal-symbol setup row geometry, theme, language, and tooltip state into a typed context.
- Represent permission, finish-step, and platform action rows with typed descriptors.
- Remove six `clippy::too_many_arguments` warnings while preserving existing labels, tooltips, colors, sizing, and platform actions.

### Verification

- `cargo test --locked` - 191 passed.
- `cargo check --locked --all-targets`.
- `cargo clippy --locked --all-targets` - all six target warnings removed; existing baseline warnings remain.
- `cargo build --release --locked`.
- `scripts/build_macos_app.sh` - arm64 app, DMG, and ZIP built; plist validation passed.
- `rustfmt --edition 2021 --check src/ui/universal_symbols_setup.rs` and `git diff --check`.
- Manual Build workflow: https://github.com/IgorArkhipov/entropy/actions/runs/29454409859

Repository-wide `cargo fmt -- --check` still reports pre-existing formatting baseline outside this change.

Related: #17

## RU

### Кратко

- Геометрия строки, тема, язык и состояние подсказок страницы настройки универсальных символов объединены в типизированный контекст.
- Строки разрешений, финальных шагов и платформенных действий представлены типизированными описателями.
- Устранено шесть предупреждений `clippy::too_many_arguments`; существующие подписи, подсказки, цвета, размеры и платформенные действия сохранены.

### Проверка

- `cargo test --locked` - 191 тест пройден.
- `cargo check --locked --all-targets`.
- `cargo clippy --locked --all-targets` - все шесть целевых предупреждений устранены; остальные относятся к существующему baseline.
- `cargo build --release --locked`.
- `scripts/build_macos_app.sh` - собраны arm64-приложение, DMG и ZIP; plist прошел проверку.
- `rustfmt --edition 2021 --check src/ui/universal_symbols_setup.rs` и `git diff --check`.
- Ручной запуск Build: https://github.com/IgorArkhipov/entropy/actions/runs/29454409859

Общий `cargo fmt -- --check` по репозиторию по-прежнему сообщает о ранее существовавшем formatting baseline вне этого изменения.

Связано с #17
