### PR TITLE
Invalidate stale QMK settings cache

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -443,6 +443,10 @@ device_unlocked = "Device unlocked!"
 unlock_interrupted_disconnected = "Unlock interrupted — device disconnected or unavailable: {error}"
 unlock_poll_retry = "Unlock communication interrupted; retrying: {error}"
 finish_unlock_before_closing = "Finish device unlock or reconnect it before closing Entropy"
+refresh_device_data_pending_write = "Finish the pending layer write before refreshing device data"
+refresh_device_data_missing_device = "Failed to refresh device data: device not found"
+refresh_device_data_missing_info = "Failed to refresh device data: device information unavailable"
+refresh_device_data_delete_failed = "Failed to remove cached device data"
 
 [dynamic_status]
 device_not_found = "Device not found"

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -443,6 +443,10 @@ device_unlocked = "Устройство разблокировано"
 unlock_interrupted_disconnected = "Разблокировка прервана — устройство отключено или недоступно: {error}"
 unlock_poll_retry = "Связь при разблокировке прервана; повторная попытка: {error}"
 finish_unlock_before_closing = "Завершите разблокировку устройства или переподключите его перед закрытием Entropy"
+refresh_device_data_pending_write = "Завершите запись слоя перед обновлением данных устройства"
+refresh_device_data_missing_device = "Не удалось обновить данные устройства: устройство не найдено"
+refresh_device_data_missing_info = "Не удалось обновить данные устройства: информация недоступна"
+refresh_device_data_delete_failed = "Не удалось удалить сохранённые данные устройства"
 
 [dynamic_status]
 device_not_found = "Устройство не найдено"

--- a/src/ui/about_device.rs
+++ b/src/ui/about_device.rs
@@ -522,14 +522,10 @@ fn draw_about_rows(
     id_salt: &'static str,
     metrics: crate::ui_style::ResponsiveMetrics,
     rows: &[AboutRow],
+    bottom_reserve: f32,
 ) -> egui::Rect {
-    let list = allocate_adaptive_settings_list_viewport(
-        ui,
-        id_salt,
-        metrics,
-        rows.len(),
-        metrics.value(4.0),
-    );
+    let list =
+        allocate_adaptive_settings_list_viewport(ui, id_salt, metrics, rows.len(), bottom_reserve);
 
     crate::ui_style::allocate_ui_at_rect(ui, list.content_rect, |ui| {
         ui.set_clip_rect(list.viewport);
@@ -607,7 +603,8 @@ impl EntropyApp {
                         .color(app_muted_text(dark)),
                 );
                 ui.add_space(metrics.value(24.0));
-                let list_viewport = draw_about_rows(ui, "about_device", metrics, &rows);
+                let list_viewport =
+                    draw_about_rows(ui, "about_device", metrics, &rows, metrics.value(54.0));
                 let button_size = egui::vec2(metrics.value(180.0), metrics.value(32.0));
                 let actions_rect = egui::Rect::from_center_size(
                     egui::pos2(
@@ -655,7 +652,8 @@ impl EntropyApp {
                         .color(app_muted_text(dark)),
                 );
                 ui.add_space(metrics.value(24.0));
-                let list_viewport = draw_about_rows(ui, "about_entropy", metrics, &rows);
+                let list_viewport =
+                    draw_about_rows(ui, "about_entropy", metrics, &rows, metrics.value(54.0));
 
                 let checking = matches!(self.update_check, UpdateCheckState::Checking { .. });
                 let ready = match &self.update_check {

--- a/src/ui/about_device.rs
+++ b/src/ui/about_device.rs
@@ -61,6 +61,24 @@ fn device_about_description(lang: crate::i18n::Language) -> &'static str {
     }
 }
 
+fn refresh_device_data_label(lang: crate::i18n::Language) -> &'static str {
+    match lang {
+        crate::i18n::Language::Russian => "Обновить данные",
+        crate::i18n::Language::English => "Refresh device data",
+    }
+}
+
+fn refresh_device_data_tooltip(lang: crate::i18n::Language) -> &'static str {
+    match lang {
+        crate::i18n::Language::Russian => {
+            "Удалить сохраненные данные Vial и QMK, затем переподключить устройство"
+        }
+        crate::i18n::Language::English => {
+            "Discard the cached definition and QMK settings, then reconnect the device"
+        }
+    }
+}
+
 struct AboutRow {
     label: &'static str,
     tooltip: &'static str,
@@ -589,7 +607,29 @@ impl EntropyApp {
                         .color(app_muted_text(dark)),
                 );
                 ui.add_space(metrics.value(24.0));
-                draw_about_rows(ui, "about_device", metrics, &rows);
+                let list_viewport = draw_about_rows(ui, "about_device", metrics, &rows);
+                let button_size = egui::vec2(metrics.value(180.0), metrics.value(32.0));
+                let actions_rect = egui::Rect::from_center_size(
+                    egui::pos2(
+                        list_viewport.center().x,
+                        list_viewport.bottom() + metrics.value(34.0),
+                    ),
+                    button_size,
+                );
+                crate::ui_style::allocate_ui_at_rect(ui, actions_rect, |ui| {
+                    ui.set_min_size(actions_rect.size());
+                    if crate::ui_style::modern_button(
+                        ui,
+                        refresh_device_data_label(lang),
+                        button_size,
+                        true,
+                    )
+                    .on_hover_text(refresh_device_data_tooltip(lang))
+                    .clicked()
+                    {
+                        self.refresh_current_device_data();
+                    }
+                });
             });
         });
     }

--- a/src/ui/device_connect_task.rs
+++ b/src/ui/device_connect_task.rs
@@ -7,6 +7,37 @@ fn vial_cache_dir() -> Option<std::path::PathBuf> {
 }
 
 const VIAL_DEFINITION_CACHE_VERSION: u8 = 3;
+const QMK_SETTINGS_CACHE_VERSION: u8 = 1;
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+struct QmkSettingsCacheContext {
+    definition_size: u32,
+    definition_fingerprint: u64,
+    via_protocol: u16,
+    vial_protocol: u32,
+    firmware_version: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+struct CachedQmkSettings {
+    version: u8,
+    context: QmkSettingsCacheContext,
+    settings: Vec<u16>,
+}
+
+impl CachedQmkSettings {
+    fn new(context: &QmkSettingsCacheContext, settings: &[u16]) -> Self {
+        Self {
+            version: QMK_SETTINGS_CACHE_VERSION,
+            context: context.clone(),
+            settings: settings.to_vec(),
+        }
+    }
+
+    fn matches(&self, context: &QmkSettingsCacheContext) -> bool {
+        self.version == QMK_SETTINGS_CACHE_VERSION && &self.context == context
+    }
+}
 
 fn cache_component(value: &str) -> String {
     let mut component = String::with_capacity(value.len());
@@ -64,6 +95,35 @@ fn cached_qmk_settings_path(cache_key: &str) -> Option<std::path::PathBuf> {
     Some(vial_cache_dir()?.join(format!("qmk_settings_{cache_key}.json")))
 }
 
+fn vial_definition_fingerprint(json: &serde_json::Value) -> Result<u64, serde_json::Error> {
+    // FNV-1a is deterministic across app versions; cryptographic strength is unnecessary here.
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in serde_json::to_vec(json)? {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    Ok(hash)
+}
+
+fn qmk_settings_cache_context(
+    definition_size: u32,
+    json: &serde_json::Value,
+    via_protocol: u16,
+    vial_protocol: u32,
+    firmware_version: Option<&str>,
+) -> Result<QmkSettingsCacheContext, serde_json::Error> {
+    Ok(QmkSettingsCacheContext {
+        definition_size,
+        definition_fingerprint: vial_definition_fingerprint(json)?,
+        via_protocol,
+        vial_protocol,
+        firmware_version: firmware_version
+            .map(str::trim)
+            .filter(|version| !version.is_empty())
+            .map(str::to_owned),
+    })
+}
+
 fn load_cached_vial_definition(cache_key: &str, definition_size: u32) -> Option<serde_json::Value> {
     let path = cached_vial_definition_path(cache_key, definition_size)?;
     let text = std::fs::read_to_string(path).ok()?;
@@ -84,17 +144,25 @@ fn save_cached_vial_definition(cache_key: &str, definition_size: u32, json: &ser
     }
 }
 
-fn load_cached_qmk_settings(cache_key: &str) -> Option<Vec<u16>> {
-    let path = cached_qmk_settings_path(cache_key)?;
-    let text = std::fs::read_to_string(path).ok()?;
-    serde_json::from_str(&text).ok()
+fn parse_cached_qmk_settings(text: &str, context: &QmkSettingsCacheContext) -> Option<Vec<u16>> {
+    let cached = serde_json::from_str::<CachedQmkSettings>(text).ok()?;
+    cached.matches(context).then_some(cached.settings)
 }
 
-fn save_cached_qmk_settings(cache_key: &str, settings: &[u16]) {
+fn load_cached_qmk_settings(
+    cache_key: &str,
+    context: &QmkSettingsCacheContext,
+) -> Option<Vec<u16>> {
+    let path = cached_qmk_settings_path(cache_key)?;
+    let text = std::fs::read_to_string(path).ok()?;
+    parse_cached_qmk_settings(&text, context)
+}
+
+fn save_cached_qmk_settings(cache_key: &str, context: &QmkSettingsCacheContext, settings: &[u16]) {
     let Some(path) = cached_qmk_settings_path(cache_key) else {
         return;
     };
-    match serde_json::to_vec(settings) {
+    match serde_json::to_vec(&CachedQmkSettings::new(context, settings)) {
         Ok(bytes) => {
             if let Err(e) = std::fs::write(path, bytes) {
                 log::warn!("failed to write QMK settings cache: {e}");
@@ -102,6 +170,46 @@ fn save_cached_qmk_settings(cache_key: &str, settings: &[u16]) {
         }
         Err(e) => log::warn!("failed to serialize QMK settings cache: {e}"),
     }
+}
+
+fn is_cached_vial_definition_for_device(file_name: &str, cache_key: &str) -> bool {
+    let prefix = format!("definition_v{VIAL_DEFINITION_CACHE_VERSION}_{cache_key}_");
+    file_name.starts_with(&prefix) && file_name.ends_with(".json")
+}
+
+fn clear_cached_device_data(cache_key: &str) -> Result<(), String> {
+    let cache_dir =
+        vial_cache_dir().ok_or_else(|| "device cache directory is unavailable".to_owned())?;
+    let mut paths = Vec::new();
+    for entry in std::fs::read_dir(&cache_dir)
+        .map_err(|error| format!("failed to read {}: {error}", cache_dir.display()))?
+    {
+        let entry = entry.map_err(|error| {
+            format!(
+                "failed to inspect cached device data in {}: {error}",
+                cache_dir.display()
+            )
+        })?;
+        if entry
+            .file_name()
+            .to_str()
+            .is_some_and(|name| is_cached_vial_definition_for_device(name, cache_key))
+        {
+            paths.push(entry.path());
+        }
+    }
+    paths.push(cache_dir.join(format!("qmk_settings_{cache_key}.json")));
+
+    for path in paths {
+        match std::fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(format!("failed to remove {}: {error}", path.display()));
+            }
+        }
+    }
+    Ok(())
 }
 
 fn normalize_reported_layer_count(reported_layer_count: usize) -> usize {
@@ -268,6 +376,37 @@ fn supports_vial_macro_ext_keycodes(vial_protocol: u32, json: &serde_json::Value
 }
 
 impl EntropyApp {
+    pub(super) fn refresh_current_device_data(&mut self) {
+        if self.layer_write_task.is_some() {
+            self.status_msg =
+                "Finish the pending layer write before refreshing device data".to_owned();
+            return;
+        }
+        let Some(device_idx) = self.selected_device else {
+            self.status_msg = "Failed to refresh device data: no device selected".to_owned();
+            return;
+        };
+        let Some(device) = self.device_manager.devices().get(device_idx).cloned() else {
+            self.status_msg = "Failed to refresh device data: device not found".to_owned();
+            return;
+        };
+        let Some(info) = self.device_about_info.as_ref() else {
+            self.status_msg =
+                "Failed to refresh device data: device information unavailable".to_owned();
+            return;
+        };
+
+        let cache_key = device_cache_key(&device, info.keyboard_id);
+        if let Err(error) = clear_cached_device_data(&cache_key) {
+            self.status_msg = format!("Failed to refresh device data: {error}");
+            log::warn!("device cache refresh failed for key {cache_key}: {error}");
+            return;
+        }
+
+        log::info!("Cleared Vial definition and QMK settings cache for key {cache_key}");
+        self.start_connect(device_idx);
+    }
+
     pub(super) fn start_connect(&mut self, device_idx: usize) {
         if self.layer_write_task.is_some() {
             return;
@@ -428,10 +567,28 @@ impl EntropyApp {
 
                 let touchpad_settings_in_definition =
                     Self::layout_json_has_touchpad_settings(&json);
+                let qmk_cache_context = match qmk_settings_cache_context(
+                    definition_size,
+                    &json,
+                    via_protocol,
+                    vial_protocol,
+                    firmware_version.as_deref(),
+                ) {
+                    Ok(context) => Some(context),
+                    Err(error) => {
+                        log::warn!(
+                            "failed to fingerprint Vial definition; QMK settings cache disabled: {error}"
+                        );
+                        None
+                    }
+                };
                 let supported_qmk_settings = if vial_protocol >= 4 {
-                    if let Some(cached) = load_cached_qmk_settings(&cache_key) {
+                    if let Some(cached) = qmk_cache_context
+                        .as_ref()
+                        .and_then(|context| load_cached_qmk_settings(&cache_key, context))
+                    {
                         log::info!(
-                            "Loaded {} QMK settings from cache for keyboard id {keyboard_id:016X}, key {cache_key}",
+                            "Loaded {} QMK settings from definition-aware cache for keyboard id {keyboard_id:016X}, key {cache_key}",
                             cached.len(),
                         );
                         cached
@@ -439,11 +596,13 @@ impl EntropyApp {
                         progress("Querying QMK settings…");
                         match dev_conn.query_qmk_settings() {
                             Ok(settings) => {
-                                save_cached_qmk_settings(&cache_key, &settings);
+                                if let Some(context) = qmk_cache_context.as_ref() {
+                                    save_cached_qmk_settings(&cache_key, context, &settings);
+                                }
                                 settings
                             }
-                            Err(e) => {
-                                log::warn!("qmk settings query failed: {e}");
+                            Err(error) => {
+                                log::warn!("qmk settings query failed: {error}");
                                 Vec::new()
                             }
                         }
@@ -1202,5 +1361,91 @@ mod tests {
             cached_vial_definition_file_name("keyboard", 0x1234),
             cached_vial_definition_file_name("keyboard", 0x1235)
         );
+    }
+
+    #[test]
+    fn device_cache_refresh_matches_all_definition_sizes_for_only_one_device() {
+        assert!(is_cached_vial_definition_for_device(
+            "definition_v3_keyboard_00001234.json",
+            "keyboard"
+        ));
+        assert!(is_cached_vial_definition_for_device(
+            "definition_v3_keyboard_00005678.json",
+            "keyboard"
+        ));
+        assert!(!is_cached_vial_definition_for_device(
+            "definition_v3_other-keyboard_00001234.json",
+            "keyboard"
+        ));
+        assert!(!is_cached_vial_definition_for_device(
+            "definition_v2_keyboard_00001234.json",
+            "keyboard"
+        ));
+    }
+
+    fn cache_context(json: &serde_json::Value) -> QmkSettingsCacheContext {
+        qmk_settings_cache_context(0x1234, json, 9, 6, Some("1.2.3")).unwrap()
+    }
+
+    #[test]
+    fn qmk_settings_cache_reuses_matching_definition_and_protocol_metadata() {
+        let context = cache_context(&serde_json::json!({"settings": [120, 121]}));
+        let cached = CachedQmkSettings::new(&context, &[120, 121]);
+        let text = serde_json::to_string(&cached).unwrap();
+
+        assert_eq!(
+            parse_cached_qmk_settings(&text, &context),
+            Some(vec![120, 121])
+        );
+    }
+
+    #[test]
+    fn qmk_settings_cache_rejects_same_size_definition_changes() {
+        let first_json = serde_json::json!({"settings": [120]});
+        let second_json = serde_json::json!({"settings": [121]});
+        assert_eq!(
+            serde_json::to_vec(&first_json).unwrap().len(),
+            serde_json::to_vec(&second_json).unwrap().len()
+        );
+
+        let first_context = cache_context(&first_json);
+        let second_context = cache_context(&second_json);
+        let cached = CachedQmkSettings::new(&first_context, &[120]);
+        let text = serde_json::to_string(&cached).unwrap();
+
+        assert_eq!(parse_cached_qmk_settings(&text, &second_context), None);
+    }
+
+    #[test]
+    fn qmk_settings_cache_rejects_protocol_and_firmware_changes() {
+        let context = cache_context(&serde_json::json!({"settings": [120]}));
+        let cached = CachedQmkSettings::new(&context, &[120]);
+        let text = serde_json::to_string(&cached).unwrap();
+
+        let mut changed_size = context.clone();
+        changed_size.definition_size += 1;
+        assert_eq!(parse_cached_qmk_settings(&text, &changed_size), None);
+
+        let mut changed_via_protocol = context.clone();
+        changed_via_protocol.via_protocol += 1;
+        assert_eq!(
+            parse_cached_qmk_settings(&text, &changed_via_protocol),
+            None
+        );
+
+        let mut changed_protocol = context.clone();
+        changed_protocol.vial_protocol += 1;
+        assert_eq!(parse_cached_qmk_settings(&text, &changed_protocol), None);
+
+        let mut changed_firmware = context.clone();
+        changed_firmware.firmware_version = Some("1.2.4".to_owned());
+        assert_eq!(parse_cached_qmk_settings(&text, &changed_firmware), None);
+    }
+
+    #[test]
+    fn qmk_settings_cache_rejects_legacy_unversioned_entries() {
+        let context = cache_context(&serde_json::json!({"settings": [120]}));
+
+        assert_eq!(parse_cached_qmk_settings("[120,121]", &context), None);
     }
 }

--- a/src/ui/device_connect_task.rs
+++ b/src/ui/device_connect_task.rs
@@ -232,8 +232,17 @@ fn save_cached_qmk_settings(cache_key: &str, context: &QmkSettingsCacheContext, 
 }
 
 fn is_cached_vial_definition_for_device(file_name: &str, cache_key: &str) -> bool {
-    let prefix = format!("definition_v{VIAL_DEFINITION_CACHE_VERSION}_{cache_key}_");
-    file_name.starts_with(&prefix) && file_name.ends_with(".json")
+    let Some(stem) = file_name.strip_suffix(".json") else {
+        return false;
+    };
+    let Some((device_prefix, definition_size)) = stem.rsplit_once('_') else {
+        return false;
+    };
+    let expected_prefix = format!("definition_v{VIAL_DEFINITION_CACHE_VERSION}_{cache_key}");
+
+    device_prefix == expected_prefix
+        && definition_size.len() == 8
+        && definition_size.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 fn clear_cached_device_data(cache_key: &str) -> Result<(), String> {
@@ -436,28 +445,37 @@ fn supports_vial_macro_ext_keycodes(vial_protocol: u32, json: &serde_json::Value
 
 impl EntropyApp {
     pub(super) fn refresh_current_device_data(&mut self) {
+        let lang = self.app_settings.language;
         if self.layer_write_task.is_some() {
             self.status_msg =
-                "Finish the pending layer write before refreshing device data".to_owned();
+                crate::i18n::tr_catalog(lang, "status_messages.refresh_device_data_pending_write")
+                    .to_owned();
             return;
         }
         let Some(device_idx) = self.selected_device else {
-            self.status_msg = "Failed to refresh device data: no device selected".to_owned();
+            self.status_msg =
+                crate::i18n::tr_catalog(lang, "status_messages.refresh_device_data_missing_device")
+                    .to_owned();
             return;
         };
         let Some(device) = self.device_manager.devices().get(device_idx).cloned() else {
-            self.status_msg = "Failed to refresh device data: device not found".to_owned();
+            self.status_msg =
+                crate::i18n::tr_catalog(lang, "status_messages.refresh_device_data_missing_device")
+                    .to_owned();
             return;
         };
         let Some(info) = self.device_about_info.as_ref() else {
             self.status_msg =
-                "Failed to refresh device data: device information unavailable".to_owned();
+                crate::i18n::tr_catalog(lang, "status_messages.refresh_device_data_missing_info")
+                    .to_owned();
             return;
         };
 
         let cache_key = device_cache_key(&device, info.keyboard_id);
         if let Err(error) = clear_cached_device_data(&cache_key) {
-            self.status_msg = format!("Failed to refresh device data: {error}");
+            self.status_msg =
+                crate::i18n::tr_catalog(lang, "status_messages.refresh_device_data_delete_failed")
+                    .to_owned();
             log::warn!("device cache refresh failed for key {cache_key}: {error}");
             return;
         }
@@ -1456,6 +1474,18 @@ mod tests {
         ));
         assert!(!is_cached_vial_definition_for_device(
             "definition_v3_keyboard_00001234.json",
+            "keyboard"
+        ));
+        assert!(!is_cached_vial_definition_for_device(
+            "definition_v4_keyboard_pro_00001234.json",
+            "keyboard"
+        ));
+        assert!(!is_cached_vial_definition_for_device(
+            "definition_v4_keyboard_0000123.json",
+            "keyboard"
+        ));
+        assert!(!is_cached_vial_definition_for_device(
+            "definition_v4_keyboard_not-hex.json",
             "keyboard"
         ));
     }

--- a/src/ui/device_connect_task.rs
+++ b/src/ui/device_connect_task.rs
@@ -6,8 +6,15 @@ fn vial_cache_dir() -> Option<std::path::PathBuf> {
     Some(dir)
 }
 
-const VIAL_DEFINITION_CACHE_VERSION: u8 = 3;
-const QMK_SETTINGS_CACHE_VERSION: u8 = 1;
+const VIAL_DEFINITION_CACHE_VERSION: u8 = 4;
+const QMK_SETTINGS_CACHE_VERSION: u8 = 2;
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+struct CachedVialDefinition {
+    version: u8,
+    runtime_firmware_version: String,
+    json: serde_json::Value,
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 struct QmkSettingsCacheContext {
@@ -15,7 +22,7 @@ struct QmkSettingsCacheContext {
     definition_fingerprint: u64,
     via_protocol: u16,
     vial_protocol: u32,
-    firmware_version: Option<String>,
+    runtime_firmware_version: String,
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
@@ -84,11 +91,23 @@ fn cached_vial_definition_file_name(cache_key: &str, definition_size: u32) -> St
     format!("definition_v{VIAL_DEFINITION_CACHE_VERSION}_{cache_key}_{definition_size:08x}.json")
 }
 
+fn cached_vial_definition_path_in(
+    cache_dir: &std::path::Path,
+    cache_key: &str,
+    definition_size: u32,
+) -> std::path::PathBuf {
+    cache_dir.join(cached_vial_definition_file_name(cache_key, definition_size))
+}
+
 fn cached_vial_definition_path(
     cache_key: &str,
     definition_size: u32,
 ) -> Option<std::path::PathBuf> {
-    Some(vial_cache_dir()?.join(cached_vial_definition_file_name(cache_key, definition_size)))
+    Some(cached_vial_definition_path_in(
+        &vial_cache_dir()?,
+        cache_key,
+        definition_size,
+    ))
 }
 
 fn cached_qmk_settings_path(cache_key: &str) -> Option<std::path::PathBuf> {
@@ -110,31 +129,71 @@ fn qmk_settings_cache_context(
     json: &serde_json::Value,
     via_protocol: u16,
     vial_protocol: u32,
-    firmware_version: Option<&str>,
+    runtime_firmware_version: &str,
 ) -> Result<QmkSettingsCacheContext, serde_json::Error> {
     Ok(QmkSettingsCacheContext {
         definition_size,
         definition_fingerprint: vial_definition_fingerprint(json)?,
         via_protocol,
         vial_protocol,
-        firmware_version: firmware_version
-            .map(str::trim)
-            .filter(|version| !version.is_empty())
-            .map(str::to_owned),
+        runtime_firmware_version: runtime_firmware_version.trim().to_owned(),
     })
 }
 
-fn load_cached_vial_definition(cache_key: &str, definition_size: u32) -> Option<serde_json::Value> {
-    let path = cached_vial_definition_path(cache_key, definition_size)?;
-    let text = std::fs::read_to_string(path).ok()?;
-    serde_json::from_str(&text).ok()
+fn runtime_firmware_version_cache_token(version: Option<&str>) -> Option<&str> {
+    version.map(str::trim).filter(|version| !version.is_empty())
 }
 
-fn save_cached_vial_definition(cache_key: &str, definition_size: u32, json: &serde_json::Value) {
+fn parse_cached_vial_definition(
+    text: &str,
+    runtime_firmware_version: Option<&str>,
+) -> Option<serde_json::Value> {
+    let runtime_firmware_version = runtime_firmware_version_cache_token(runtime_firmware_version)?;
+    let cached = serde_json::from_str::<CachedVialDefinition>(text).ok()?;
+    (cached.version == VIAL_DEFINITION_CACHE_VERSION
+        && cached.runtime_firmware_version == runtime_firmware_version)
+        .then_some(cached.json)
+}
+
+fn load_cached_vial_definition_from_dir(
+    cache_dir: &std::path::Path,
+    cache_key: &str,
+    definition_size: u32,
+    runtime_firmware_version: Option<&str>,
+) -> Option<serde_json::Value> {
+    let path = cached_vial_definition_path_in(cache_dir, cache_key, definition_size);
+    let text = std::fs::read_to_string(path).ok()?;
+    parse_cached_vial_definition(&text, runtime_firmware_version)
+}
+
+fn load_cached_vial_definition(
+    cache_key: &str,
+    definition_size: u32,
+    runtime_firmware_version: Option<&str>,
+) -> Option<serde_json::Value> {
+    load_cached_vial_definition_from_dir(
+        &vial_cache_dir()?,
+        cache_key,
+        definition_size,
+        runtime_firmware_version,
+    )
+}
+
+fn save_cached_vial_definition(
+    cache_key: &str,
+    definition_size: u32,
+    runtime_firmware_version: &str,
+    json: &serde_json::Value,
+) {
     let Some(path) = cached_vial_definition_path(cache_key, definition_size) else {
         return;
     };
-    match serde_json::to_vec(json) {
+    let cached = CachedVialDefinition {
+        version: VIAL_DEFINITION_CACHE_VERSION,
+        runtime_firmware_version: runtime_firmware_version.trim().to_owned(),
+        json: json.clone(),
+    };
+    match serde_json::to_vec(&cached) {
         Ok(bytes) => {
             if let Err(e) = std::fs::write(path, bytes) {
                 log::warn!("failed to write Vial definition cache: {e}");
@@ -516,26 +575,6 @@ impl EntropyApp {
                     ));
                 }
 
-                progress("Reading Vial layout definition…");
-                log::info!("Getting layout JSON…");
-                let definition_size = dev_conn
-                    .get_definition_size()
-                    .map_err(|e| format!("Layout size read failed: {e}"))?;
-                let json = if let Some(cached) =
-                    load_cached_vial_definition(&cache_key, definition_size)
-                {
-                    log::info!(
-                        "Loaded Vial definition from cache for keyboard id {keyboard_id:016X}, key {cache_key}, size {definition_size}"
-                    );
-                    cached
-                } else {
-                    let json = dev_conn
-                        .get_layout_json_with_size(definition_size)
-                        .map_err(|e| format!("Layout read failed: {e}"))?;
-                    save_cached_vial_definition(&cache_key, definition_size, &json);
-                    json
-                };
-
                 progress("Reading firmware version…");
                 let runtime_firmware_version = match dev_conn.get_firmware_version() {
                     Ok(Some(version)) => Some(version),
@@ -550,8 +589,44 @@ impl EntropyApp {
                         None
                     }
                 };
-                let firmware_version =
-                    runtime_firmware_version.or_else(|| firmware_version_from_vial_json(&json));
+
+                progress("Reading Vial layout definition…");
+                log::info!("Getting layout JSON…");
+                let definition_size = dev_conn
+                    .get_definition_size()
+                    .map_err(|e| format!("Layout size read failed: {e}"))?;
+                let runtime_firmware_cache_token =
+                    runtime_firmware_version_cache_token(runtime_firmware_version.as_deref());
+                let json = if let Some(cached) = load_cached_vial_definition(
+                    &cache_key,
+                    definition_size,
+                    runtime_firmware_cache_token,
+                ) {
+                    log::info!(
+                        "Loaded Vial definition from cache for keyboard id {keyboard_id:016X}, key {cache_key}, size {definition_size}"
+                    );
+                    cached
+                } else {
+                    let json = dev_conn
+                        .get_layout_json_with_size(definition_size)
+                        .map_err(|e| format!("Layout read failed: {e}"))?;
+                    if let Some(runtime_firmware_version) = runtime_firmware_cache_token {
+                        save_cached_vial_definition(
+                            &cache_key,
+                            definition_size,
+                            runtime_firmware_version,
+                            &json,
+                        );
+                    } else {
+                        log::info!(
+                            "Runtime firmware version unavailable; Vial definition and QMK settings caches disabled"
+                        );
+                    }
+                    json
+                };
+                let firmware_version = runtime_firmware_version
+                    .clone()
+                    .or_else(|| firmware_version_from_vial_json(&json));
                 let battery_halves = if supports_battery_halves_from_vial_json(&json) {
                     progress("Reading split battery levels…");
                     match dev_conn.get_battery_halves() {
@@ -567,21 +642,23 @@ impl EntropyApp {
 
                 let touchpad_settings_in_definition =
                     Self::layout_json_has_touchpad_settings(&json);
-                let qmk_cache_context = match qmk_settings_cache_context(
-                    definition_size,
-                    &json,
-                    via_protocol,
-                    vial_protocol,
-                    firmware_version.as_deref(),
-                ) {
-                    Ok(context) => Some(context),
-                    Err(error) => {
-                        log::warn!(
-                            "failed to fingerprint Vial definition; QMK settings cache disabled: {error}"
-                        );
-                        None
-                    }
-                };
+                let qmk_cache_context = runtime_firmware_cache_token.and_then(
+                    |runtime_firmware_version| match qmk_settings_cache_context(
+                        definition_size,
+                        &json,
+                        via_protocol,
+                        vial_protocol,
+                        runtime_firmware_version,
+                    ) {
+                        Ok(context) => Some(context),
+                        Err(error) => {
+                            log::warn!(
+                                "failed to fingerprint Vial definition; QMK settings cache disabled: {error}"
+                            );
+                            None
+                        }
+                    },
+                );
                 let supported_qmk_settings = if vial_protocol >= 4 {
                     if let Some(cached) = qmk_cache_context
                         .as_ref()
@@ -1355,7 +1432,7 @@ mod tests {
     fn vial_definition_cache_filename_includes_schema_version_and_size() {
         assert_eq!(
             cached_vial_definition_file_name("keyboard", 0x1234),
-            "definition_v3_keyboard_00001234.json"
+            "definition_v4_keyboard_00001234.json"
         );
         assert_ne!(
             cached_vial_definition_file_name("keyboard", 0x1234),
@@ -1366,25 +1443,78 @@ mod tests {
     #[test]
     fn device_cache_refresh_matches_all_definition_sizes_for_only_one_device() {
         assert!(is_cached_vial_definition_for_device(
-            "definition_v3_keyboard_00001234.json",
+            "definition_v4_keyboard_00001234.json",
             "keyboard"
         ));
         assert!(is_cached_vial_definition_for_device(
-            "definition_v3_keyboard_00005678.json",
+            "definition_v4_keyboard_00005678.json",
             "keyboard"
         ));
         assert!(!is_cached_vial_definition_for_device(
-            "definition_v3_other-keyboard_00001234.json",
+            "definition_v4_other-keyboard_00001234.json",
             "keyboard"
         ));
         assert!(!is_cached_vial_definition_for_device(
-            "definition_v2_keyboard_00001234.json",
+            "definition_v3_keyboard_00001234.json",
             "keyboard"
         ));
     }
 
     fn cache_context(json: &serde_json::Value) -> QmkSettingsCacheContext {
-        qmk_settings_cache_context(0x1234, json, 9, 6, Some("1.2.3")).unwrap()
+        qmk_settings_cache_context(0x1234, json, 9, 6, "1.2.3").unwrap()
+    }
+
+    fn test_cache_dir(name: &str) -> std::path::PathBuf {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "entropy-device-connect-{name}-{}-{nonce}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn cached_vial_definition_same_size_requires_direct_runtime_firmware_version() {
+        let cache_dir = test_cache_dir("same-size-definition");
+        let cache_key = "keyboard";
+        let definition_size = 0x1234;
+        let cached_json = serde_json::json!({"settings": [120]});
+        let cached = CachedVialDefinition {
+            version: VIAL_DEFINITION_CACHE_VERSION,
+            runtime_firmware_version: "1.2.3".to_owned(),
+            json: cached_json.clone(),
+        };
+        let path = cached_vial_definition_path_in(&cache_dir, cache_key, definition_size);
+        std::fs::write(path, serde_json::to_vec(&cached).unwrap()).unwrap();
+
+        assert_eq!(
+            load_cached_vial_definition_from_dir(
+                &cache_dir,
+                cache_key,
+                definition_size,
+                Some("1.2.3")
+            ),
+            Some(cached_json)
+        );
+        assert_eq!(
+            load_cached_vial_definition_from_dir(
+                &cache_dir,
+                cache_key,
+                definition_size,
+                Some("1.2.4")
+            ),
+            None
+        );
+        assert_eq!(
+            load_cached_vial_definition_from_dir(&cache_dir, cache_key, definition_size, None),
+            None
+        );
+
+        std::fs::remove_dir_all(cache_dir).unwrap();
     }
 
     #[test]
@@ -1438,8 +1568,18 @@ mod tests {
         assert_eq!(parse_cached_qmk_settings(&text, &changed_protocol), None);
 
         let mut changed_firmware = context.clone();
-        changed_firmware.firmware_version = Some("1.2.4".to_owned());
+        changed_firmware.runtime_firmware_version = "1.2.4".to_owned();
         assert_eq!(parse_cached_qmk_settings(&text, &changed_firmware), None);
+    }
+
+    #[test]
+    fn runtime_firmware_version_cache_token_requires_a_direct_value() {
+        assert_eq!(runtime_firmware_version_cache_token(None), None);
+        assert_eq!(runtime_firmware_version_cache_token(Some("   ")), None);
+        assert_eq!(
+            runtime_firmware_version_cache_token(Some(" 1.2.3 ")),
+            Some("1.2.3")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## EN

### Problem

Entropy reused the cached supported-QSID list after firmware or Vial definition changes. Controller fields could stay hidden or appear unsupported until users manually removed application cache files.

### Fix

- Version QMK settings cache entries with Vial definition size and fingerprint, VIA/Vial protocol versions, and firmware version.
- Re-query supported QMK settings whenever that metadata changes; legacy unversioned cache entries are rejected and replaced.
- Add **Refresh device data** under About Device. It removes every cached definition size plus QMK settings for only the selected device, then reconnects.

Matching cache metadata still keeps normal reconnects fast.

### Verification

- `cargo test --locked`: 196 passed.
- `cargo clippy --locked --all-targets`: passed with existing repository warnings.
- `python3 scripts/check_i18n.py`: passed.
- Scoped `rustfmt --check` and `git diff --check`: passed.
- `TARGET=aarch64-apple-darwin scripts/build_macos_app.sh`: arm64 app, DMG, and ZIP built; plist validation passed.

Repository-wide `cargo fmt -- --check` still reports pre-existing formatting baseline outside this change.

## RU

### Проблема

Entropy продолжала использовать сохраненный список поддерживаемых QSID после изменения прошивки или Vial definition. Настройки контроллеров могли оставаться скрытыми или выглядеть неподдерживаемыми, пока пользователь вручную не удалял cache-файлы приложения.

### Исправление

- Записи cache для QMK settings теперь версионируются вместе с размером и fingerprint Vial definition, версиями протоколов VIA/Vial и версией прошивки.
- При изменении этих метаданных список поддерживаемых QMK settings запрашивается заново; старые записи без метаданных отклоняются и заменяются.
- На странице About Device добавлена кнопка **Обновить данные**. Она удаляет все сохраненные размеры definition и QMK settings только для выбранного устройства, затем переподключается.

При совпадении метаданных обычное переподключение по-прежнему использует быстрый cache path.

### Проверка

- `cargo test --locked`: прошли 196 тестов.
- `cargo clippy --locked --all-targets`: прошел с существующими предупреждениями репозитория.
- `python3 scripts/check_i18n.py`: прошел.
- Scoped `rustfmt --check` и `git diff --check`: прошли.
- `TARGET=aarch64-apple-darwin scripts/build_macos_app.sh`: собраны arm64-приложение, DMG и ZIP; plist прошел проверку.

Общий `cargo fmt -- --check` по репозиторию по-прежнему сообщает о ранее существовавшем formatting baseline вне этого изменения.
