### PR TITLE
Make HID settings writes nonblocking

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1153,6 +1153,18 @@ one_shot_timeout = "One-shot timeout"
 how_long_one_shot_state_waits_before_it_is_released = "How long one-shot state waits before it is released"
 value_is_in_milliseconds = "Value is in milliseconds"
 
+[settings_write]
+pending = "Saving"
+saved = "Saved"
+failed = "Save failed: {error}"
+pending_status = "Saving {setting}..."
+saved_status = "Saved {setting}"
+failed_status = "Failed to save {setting}: {error}"
+device_not_connected = "Device is not connected"
+device_disconnected = "Device disconnected"
+worker_failed = "Settings write worker stopped unexpectedly"
+busy = "Wait for the pending setting to finish saving"
+
 [touchpad_settings]
 dpi = "DPI"
 touchpad_pointer_resolution_in_dots_per_inch = "Touchpad pointer resolution in dots per inch"

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -1153,6 +1153,18 @@ one_shot_timeout = "One-shot таймаут"
 how_long_one_shot_state_waits_before_it_is_released = "Сколько one-shot состояние ждёт перед сбросом"
 value_is_in_milliseconds = "Значение в миллисекундах"
 
+[settings_write]
+pending = "Сохранение"
+saved = "Сохранено"
+failed = "Ошибка сохранения: {error}"
+pending_status = "Сохранение {setting}..."
+saved_status = "Сохранено: {setting}"
+failed_status = "Не удалось сохранить {setting}: {error}"
+device_not_connected = "Устройство не подключено"
+device_disconnected = "Устройство отключено"
+worker_failed = "Фоновая задача сохранения настроек неожиданно остановилась"
+busy = "Дождитесь завершения сохранения настройки"
+
 [touchpad_settings]
 dpi = "DPI"
 touchpad_pointer_resolution_in_dots_per_inch = "Разрешение указателя тачпада в точках на дюйм"

--- a/src/app.rs
+++ b/src/app.rs
@@ -143,6 +143,11 @@ mod onboarding_tour;
 mod rgb_settings_ui;
 #[path = "ui/settings_shell.rs"]
 mod settings_shell;
+#[path = "ui/settings_write_queue.rs"]
+mod settings_write_queue;
+use settings_write_queue::SettingsWriteQueueState;
+#[cfg(not(target_arch = "wasm32"))]
+use settings_write_queue::SettingsWriteTask;
 #[path = "ui/tap_hold_settings.rs"]
 mod tap_hold_settings_ui;
 #[path = "ui/text_expander_editor.rs"]

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -34,6 +34,8 @@ impl EntropyApp {
             layer_write_task: None,
             #[cfg(not(target_arch = "wasm32"))]
             combo_write_task: None,
+            settings_write_task: None,
+            settings_write_queue: SettingsWriteQueueState::default(),
             #[cfg(not(target_arch = "wasm32"))]
             qmk_hid_hosts: std::collections::HashMap::new(),
             firmware: FirmwareProtocol::Vial,

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -137,6 +137,7 @@ impl EntropyApp {
             combo_pick_target: None,
             key_override_entries: Vec::new(),
             key_override_names: vec![],
+            key_override_dirty: false,
             key_override_visible_count: 1,
             key_override_undo_stack: Vec::new(),
             text_expander_deleted_rules: Vec::new(),

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -2805,6 +2805,7 @@ pub struct EntropyApp {
     pub(crate) combo_pick_target: Option<(usize, ComboPickField)>,
     pub(crate) key_override_entries: Vec<KeyOverrideEntry>,
     pub(crate) key_override_names: Vec<String>,
+    pub(crate) key_override_dirty: bool,
     pub(crate) key_override_visible_count: usize,
     pub(crate) key_override_undo_stack: Vec<(Vec<KeyOverrideEntry>, Vec<String>, usize, usize)>,
     pub(crate) text_expander_deleted_rules: Vec<(usize, crate::text_expander::TextExpansionRule)>,

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -2702,6 +2702,10 @@ pub struct EntropyApp {
     /// Background combo HID write. Owns the device handle while active.
     #[cfg(not(target_arch = "wasm32"))]
     pub(super) combo_write_task: Option<ComboWriteTask>,
+    /// Serialized background QMK settings write. Owns the HID handle while active.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(super) settings_write_task: Option<SettingsWriteTask>,
+    pub(super) settings_write_queue: SettingsWriteQueueState,
     /// Built-in qmk-hid-host bridges for displays/presets that need host data
     #[cfg(not(target_arch = "wasm32"))]
     pub(crate) qmk_hid_hosts:

--- a/src/hid.rs
+++ b/src/hid.rs
@@ -149,6 +149,13 @@ impl TestHidRecorder {
     }
 }
 
+#[cfg(test)]
+#[derive(Clone, Copy)]
+pub(crate) enum TestHidFault {
+    Disconnect,
+    WorkerPanic,
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 enum HidBackend {
     Local {
@@ -163,6 +170,7 @@ enum HidBackend {
         recorder: TestHidRecorder,
         combo: std::sync::Mutex<([u16; 4], u16)>,
         qmk_settings: std::sync::Mutex<std::collections::BTreeMap<u16, u16>>,
+        fault_after_requests: std::sync::Mutex<Option<(usize, TestHidFault)>>,
     },
 }
 
@@ -276,6 +284,13 @@ fn device_info_matches(
 impl HidDevice {
     #[cfg(test)]
     pub(crate) fn test_device() -> (Self, TestHidRecorder) {
+        Self::test_device_with_fault_after_requests(None)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_device_with_fault_after_requests(
+        fault_after_requests: Option<(usize, TestHidFault)>,
+    ) -> (Self, TestHidRecorder) {
         let recorder = TestHidRecorder {
             requests: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
         };
@@ -284,6 +299,7 @@ impl HidDevice {
                 recorder: recorder.clone(),
                 combo: std::sync::Mutex::new(([0; 4], 0)),
                 qmk_settings: std::sync::Mutex::new(std::collections::BTreeMap::new()),
+                fault_after_requests: std::sync::Mutex::new(fault_after_requests),
             },
         };
         (device, recorder)
@@ -468,6 +484,7 @@ impl HidDevice {
                 recorder,
                 combo,
                 qmk_settings,
+                fault_after_requests,
             } => {
                 let mut request = [0; MSG_LEN];
                 let len = data.len().min(MSG_LEN);
@@ -477,6 +494,26 @@ impl HidDevice {
                     .lock()
                     .unwrap_or_else(|error| error.into_inner())
                     .push(request);
+
+                let fault = {
+                    let mut pending = fault_after_requests
+                        .lock()
+                        .unwrap_or_else(|error| error.into_inner());
+                    match pending.as_mut() {
+                        Some((remaining, _)) if *remaining == 0 => pending.take(),
+                        Some((remaining, _)) => {
+                            *remaining -= 1;
+                            None
+                        }
+                        None => None,
+                    }
+                };
+                if let Some((_, fault)) = fault {
+                    match fault {
+                        TestHidFault::Disconnect => bail!("HID device disconnected"),
+                        TestHidFault::WorkerPanic => panic!("test HID worker stopped"),
+                    }
+                }
 
                 let mut response = [0; MSG_LEN];
                 match (request[0], request[1], request[2]) {

--- a/src/ui/app_lifecycle.rs
+++ b/src/ui/app_lifecycle.rs
@@ -95,6 +95,7 @@ impl EntropyApp {
         main_window_hidden_to_tray: bool,
         selected_device_is_bluetooth: bool,
     ) {
+        self.poll_settings_write(ctx);
         if should_poll_device_scan(main_window_hidden_to_tray) {
             if hid_lifecycle_writes_available(self.hid_write_task_active()) {
                 self.handle_pending_imports(ctx, now);

--- a/src/ui/app_lifecycle.rs
+++ b/src/ui/app_lifecycle.rs
@@ -428,6 +428,76 @@ mod tests {
         assert!(!should_write_dynamic_entries(true, false, false, true));
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn settings_task_defers_and_drains_hid_writes_before_exit() {
+        let ctx = egui::Context::default();
+        let creation_context = eframe::CreationContext::_new_kittest(ctx.clone());
+        let mut app = EntropyApp::new(&creation_context);
+        let (hid_device, recorder) = crate::hid::HidDevice::test_device();
+        app.hid_device = Some(hid_device);
+        app.queue_touchpad_setting_write("Sniper sensitivity".to_owned(), 121, 1, 1, 2);
+        assert!(app.settings_write_task.is_some());
+
+        app.keycode_picker.macro_texts = vec![vec![1, 2, 3]];
+        app.keycode_picker.macros_dirty = true;
+        app.combo_entries = vec![combo([0x0004, 0x0005, 0, 0], 0x0006)];
+        app.combo_synced_entries = vec![ComboEntry::default()];
+        app.combo_dirty = true;
+        app.combo_edit_revision = 1;
+        app.combo_term = Some(150);
+        app.combo_term_dirty = true;
+        app.keycode_picker.tap_dance_entries = vec![crate::keycode_picker::TapDanceEntry {
+            on_tap: 0x0004,
+            tapping_term: 175,
+            ..Default::default()
+        }];
+        app.keycode_picker.tap_dance_synced_entries = vec![Default::default()];
+        app.keycode_picker.tap_dance_dirty = true;
+        app.key_override_entries = vec![KeyOverrideEntry::default()];
+        app.key_override_pick_target = Some(KeyOverridePickField::Trigger);
+        app.keycode_picker.result = Some(0x0004);
+        app.pending_tap_hold_numeric_writes.insert(7, 175);
+        app.tap_hold_numeric_write_due = Some(std::time::Instant::now());
+        app.exit_after_hid_write = true;
+
+        let mut frame = eframe::Frame::_new_kittest();
+        let mut close_sent = false;
+        for _ in 0..200 {
+            app.update_native_background(&ctx, 0.0, true, true);
+            let output = ctx.run_ui(egui::RawInput::default(), |ui| {
+                eframe::App::ui(&mut app, ui, &mut frame);
+            });
+            close_sent |= output
+                .viewport_output
+                .get(&egui::ViewportId::ROOT)
+                .is_some_and(|viewport| viewport.commands.contains(&egui::ViewportCommand::Close));
+            if close_sent {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+
+        assert!(close_sent);
+        assert!(!app.hid_write_task_active());
+        assert!(!app.keycode_picker.macros_dirty);
+        assert!(!app.combo_dirty);
+        assert!(!app.combo_term_dirty);
+        assert!(!app.keycode_picker.tap_dance_dirty);
+        assert!(!app.key_override_dirty);
+        assert!(app.pending_tap_hold_numeric_writes.is_empty());
+        let requests = recorder.requests();
+        assert!(requests
+            .iter()
+            .any(|request| request[..3] == [0xfe, 0x0d, 0x04]));
+        assert!(requests
+            .iter()
+            .any(|request| request[..3] == [0xfe, 0x0d, 0x02]));
+        assert!(requests
+            .iter()
+            .any(|request| request[..4] == [0xfe, 0x0b, 7, 0]));
+    }
+
     fn combo(keys: [u16; 4], output: u16) -> ComboEntry {
         ComboEntry { keys, output }
     }
@@ -595,6 +665,7 @@ mod tests {
         assert!(app.keycode_picker.result.is_none());
         app.apply_picker_results();
         assert_eq!(app.key_override_entries[0].trigger, 0x0004);
+        app.flush_pending_key_override_writes();
 
         let final_close_output = ctx.run_ui(egui::RawInput::default(), |_ui| {
             app.finish_deferred_exit_after_hid_write(&ctx);

--- a/src/ui/app_lifecycle.rs
+++ b/src/ui/app_lifecycle.rs
@@ -403,8 +403,10 @@ fn tap_dance_entries_to_write(
 #[cfg(test)]
 mod tests {
     use super::super::combo_write::ComboWritePlan;
+    use super::super::layer_operations::LayerSnapshot;
+    use super::super::settings_write_queue::SettingsWriteStatus;
     use super::*;
-    use crate::keyboard::{KeyboardLayout, LayoutOption};
+    use crate::keyboard::{KeyboardLayout, LayoutOption, PhysicalKey};
 
     #[test]
     fn dirty_dynamic_entries_write_over_bluetooth() {
@@ -709,6 +711,174 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn combo_completion_starts_settings_queued_behind_it() {
+        let ctx = egui::Context::default();
+        let creation_context = eframe::CreationContext::_new_kittest(ctx.clone());
+        let mut app = EntropyApp::new(&creation_context);
+        let (hid_device, _recorder) = crate::hid::HidDevice::test_device();
+        app.hid_device = Some(hid_device);
+        app.combo_entries = vec![combo([0x0004, 0x0005, 0, 0], 0x0006)];
+        app.combo_synced_entries = vec![ComboEntry::default()];
+        app.combo_dirty = true;
+        app.combo_edit_revision = 1;
+        app.maybe_start_combo_write(&ctx);
+        app.queue_touchpad_setting_write("Sniper sensitivity".to_owned(), 121, 1, 1, 2);
+        assert!(app.settings_write_task.is_none());
+
+        for _ in 0..100 {
+            app.poll_combo_write(&ctx);
+            if app.settings_write_task.is_some() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+
+        assert!(app.settings_write_task.is_some());
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn layer_completion_starts_settings_queued_behind_it() {
+        let ctx = egui::Context::default();
+        let creation_context = eframe::CreationContext::_new_kittest(ctx.clone());
+        let mut app = EntropyApp::new(&creation_context);
+        let (hid_device, _recorder) = crate::hid::HidDevice::test_device();
+        app.hid_device = Some(hid_device);
+        app.layout = Some(KeyboardLayout {
+            name: "Test".into(),
+            rows: 1,
+            cols: 1,
+            keys: vec![PhysicalKey {
+                x: 0.0,
+                y: 0.0,
+                w: 1.0,
+                h: 1.0,
+                row: 0,
+                col: 0,
+                label: "0".into(),
+                rotation: 0.0,
+                rotation_x: 0.0,
+                rotation_y: 0.0,
+                layout_condition: None,
+            }],
+            encoders: vec![],
+            layers: vec![vec![0x0004]],
+            encoder_layers: vec![vec![]],
+            layer_names: vec![],
+            custom_keycodes: vec![],
+            layout_options: vec![],
+            live_features: Default::default(),
+            supports_rgb: false,
+            lighting_mode: None,
+            firmware: FirmwareProtocol::Vial,
+        });
+        app.apply_layer_snapshot(
+            0,
+            LayerSnapshot {
+                keycodes: vec![0x0005],
+                encoder_keycodes: vec![],
+            },
+            "layer_actions.paste",
+        );
+        assert!(app.layer_write_task.is_some());
+        app.queue_touchpad_setting_write("Sniper sensitivity".to_owned(), 121, 1, 1, 2);
+        assert!(app.settings_write_task.is_none());
+
+        for _ in 0..100 {
+            app.poll_layer_write(&ctx);
+            if app.settings_write_task.is_some() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+
+        assert!(app.settings_write_task.is_some());
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn settings_worker_fault_allows_deferred_exit(fault: crate::hid::TestHidFault) {
+        let ctx = egui::Context::default();
+        let creation_context = eframe::CreationContext::_new_kittest(ctx.clone());
+        let mut app = EntropyApp::new(&creation_context);
+        let (hid_device, recorder) =
+            crate::hid::HidDevice::test_device_with_fault_after_requests(Some((2, fault)));
+        app.hid_device = Some(hid_device);
+        app.combo_entries = vec![combo([0x0004, 0x0005, 0, 0], 0x0006)];
+        app.combo_synced_entries = vec![ComboEntry::default()];
+        app.combo_dirty = true;
+        app.combo_edit_revision = 1;
+        app.maybe_start_combo_write(&ctx);
+        app.queue_touchpad_setting_write("Sniper sensitivity".to_owned(), 121, 1, 1, 2);
+        app.keycode_picker.macros_dirty = true;
+        app.exit_after_hid_write = true;
+
+        let mut close_count = 0;
+        for _ in 0..200 {
+            let output = ctx.run_ui(egui::RawInput::default(), |_ui| {
+                app.update_native_background(&ctx, 0.0, true, false);
+            });
+            close_count += output
+                .viewport_output
+                .get(&egui::ViewportId::ROOT)
+                .into_iter()
+                .flat_map(|viewport| &viewport.commands)
+                .filter(|command| **command == egui::ViewportCommand::Close)
+                .count();
+            if close_count == 1 {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+
+        assert_eq!(close_count, 1);
+        assert!(!app.exit_after_hid_write);
+        assert!(app.hid_device.is_none());
+        assert!(!app.qmk_settings_write_busy());
+        assert!(matches!(
+            app.settings_write_status(121),
+            Some(SettingsWriteStatus::Failed(_))
+        ));
+        assert!(!app.combo_dirty);
+        assert!(app.keycode_picker.macros_dirty);
+        let requests = recorder.requests();
+        assert_eq!(
+            requests
+                .iter()
+                .filter(|request| request[..3] == [0xfe, 0x0d, 0x04])
+                .count(),
+            1
+        );
+        assert_eq!(
+            requests
+                .iter()
+                .filter(|request| u16::from_le_bytes([request[2], request[3]]) == 121)
+                .count(),
+            1
+        );
+
+        let output = ctx.run_ui(egui::RawInput::default(), |_ui| {});
+        assert!(!output
+            .viewport_output
+            .get(&egui::ViewportId::ROOT)
+            .into_iter()
+            .flat_map(|viewport| &viewport.commands)
+            .any(|command| *command == egui::ViewportCommand::Close));
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn settings_disconnect_allows_deferred_exit_after_completed_combo() {
+        settings_worker_fault_allows_deferred_exit(crate::hid::TestHidFault::Disconnect);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn settings_worker_channel_failure_allows_deferred_exit_after_completed_combo() {
+        settings_worker_fault_allows_deferred_exit(crate::hid::TestHidFault::WorkerPanic);
     }
 
     #[test]

--- a/src/ui/app_lifecycle.rs
+++ b/src/ui/app_lifecycle.rs
@@ -374,8 +374,9 @@ fn should_write_dynamic_entries(
     entries_dirty: bool,
     keycode_picker_open: bool,
     _active_hid_is_bluetooth: bool,
+    hid_write_task_active: bool,
 ) -> bool {
-    entries_dirty && !keycode_picker_open
+    entries_dirty && !keycode_picker_open && !hid_write_task_active
 }
 
 pub(super) fn combo_write_lifecycle_plan(
@@ -407,19 +408,24 @@ mod tests {
 
     #[test]
     fn dirty_dynamic_entries_write_over_bluetooth() {
-        assert!(should_write_dynamic_entries(true, false, true));
+        assert!(should_write_dynamic_entries(true, false, true, false));
     }
 
     #[test]
     fn dynamic_entries_wait_while_key_picker_is_open() {
-        assert!(!should_write_dynamic_entries(true, true, true));
-        assert!(!should_write_dynamic_entries(true, true, false));
+        assert!(!should_write_dynamic_entries(true, true, true, false));
+        assert!(!should_write_dynamic_entries(true, true, false, false));
     }
 
     #[test]
     fn clean_dynamic_entries_do_not_write() {
-        assert!(!should_write_dynamic_entries(false, false, true));
-        assert!(!should_write_dynamic_entries(false, false, false));
+        assert!(!should_write_dynamic_entries(false, false, true, false));
+        assert!(!should_write_dynamic_entries(false, false, false, false));
+    }
+
+    #[test]
+    fn dirty_dynamic_entries_wait_while_hid_is_owned_by_another_write_task() {
+        assert!(!should_write_dynamic_entries(true, false, false, true));
     }
 
     fn combo(keys: [u16; 4], output: u16) -> ComboEntry {
@@ -1224,15 +1230,13 @@ impl eframe::App for EntropyApp {
             .map(|hid| hid.is_bluetooth_transport())
             .unwrap_or(false);
         #[cfg(not(target_arch = "wasm32"))]
-        let hid_lifecycle_writes_available =
-            hid_lifecycle_writes_available(self.hid_write_task_active());
+        let hid_write_task_active = self.hid_write_task_active();
         #[cfg(target_arch = "wasm32")]
-        let hid_lifecycle_writes_available = true;
+        let hid_write_task_active = false;
 
-        if hid_lifecycle_writes_available
-            && self.keycode_picker.macros_dirty
-            && !self.keycode_picker.open
-        {
+        self.flush_pending_key_override_writes();
+
+        if self.keycode_picker.macros_dirty && !self.keycode_picker.open && !hid_write_task_active {
             if self.unlock_open || self.vial_unlock_polling {
                 // Defer macro write until unlock flow fully finishes.
             } else if self.is_vial_locked() {
@@ -1260,7 +1264,6 @@ impl eframe::App for EntropyApp {
                                     .into()
                                 }
                                 Err(e) => {
-                                    self.keycode_picker.macros_dirty = false;
                                     self.status_msg = crate::i18n::tr_catalog_format(
                                         self.app_settings.language,
                                         "status_messages.macro_write_error",
@@ -1270,7 +1273,6 @@ impl eframe::App for EntropyApp {
                             }
                         }
                         Err(e) => {
-                            self.keycode_picker.macros_dirty = false;
                             self.status_msg = crate::i18n::tr_catalog_format(
                                 self.app_settings.language,
                                 "status_messages.macro_write_error",
@@ -1279,7 +1281,6 @@ impl eframe::App for EntropyApp {
                         }
                     }
                 } else {
-                    self.keycode_picker.macros_dirty = false;
                     self.status_msg = crate::i18n::tr_catalog_format(
                         self.app_settings.language,
                         "status_messages.macro_write_error",
@@ -1289,20 +1290,22 @@ impl eframe::App for EntropyApp {
             }
         }
 
-        if hid_lifecycle_writes_available
-            && self.combo_term_dirty
+        if self.combo_term_dirty
             && !self.keycode_picker.open
             && !active_hid_is_bluetooth
+            && !hid_write_task_active
         {
-            let mut term_save_ok = true;
+            let mut term_save_ok = false;
             if let (Some(hid), Some(value)) = (&self.hid_device, self.combo_term) {
-                if let Err(e) = hid.set_qmk_setting_u16(2, value) {
-                    self.status_msg = crate::i18n::tr_catalog_format(
-                        self.app_settings.language,
-                        "status_messages.combo_timeout_write_error",
-                        &[("error", &e.to_string())],
-                    );
-                    term_save_ok = false;
+                match hid.set_qmk_setting_u16(2, value) {
+                    Ok(()) => term_save_ok = true,
+                    Err(e) => {
+                        self.status_msg = crate::i18n::tr_catalog_format(
+                            self.app_settings.language,
+                            "status_messages.combo_timeout_write_error",
+                            &[("error", &e.to_string())],
+                        );
+                    }
                 }
             }
             if term_save_ok {
@@ -1334,18 +1337,17 @@ impl eframe::App for EntropyApp {
             self.combo_colors_dirty = false;
         }
 
-        if hid_lifecycle_writes_available {
+        if !hid_write_task_active {
             self.flush_due_tap_hold_numeric_writes();
         }
 
         // Write tap dance to device if changed
-        if hid_lifecycle_writes_available
-            && should_write_dynamic_entries(
-                self.keycode_picker.tap_dance_dirty,
-                self.keycode_picker.open,
-                active_hid_is_bluetooth,
-            )
-        {
+        if should_write_dynamic_entries(
+            self.keycode_picker.tap_dance_dirty,
+            self.keycode_picker.open,
+            active_hid_is_bluetooth,
+            hid_write_task_active,
+        ) {
             let entries_to_write = tap_dance_entries_to_write(
                 &self.keycode_picker.tap_dance_entries,
                 &self.keycode_picker.tap_dance_synced_entries,

--- a/src/ui/combo_write.rs
+++ b/src/ui/combo_write.rs
@@ -81,8 +81,7 @@ impl EntropyApp {
 
     #[cfg(not(target_arch = "wasm32"))]
     pub(super) fn hid_write_task_active(&self) -> bool {
-        self.hid_write_task_owner_active()
-            || !self.settings_write_queue.is_empty()
+        self.hid_write_task_owner_active() || !self.settings_write_queue.is_empty()
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/src/ui/combo_write.rs
+++ b/src/ui/combo_write.rs
@@ -73,8 +73,16 @@ impl EntropyApp {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
+    pub(super) fn hid_write_task_owner_active(&self) -> bool {
+        self.layer_write_task.is_some()
+            || self.combo_write_task.is_some()
+            || self.settings_write_task.is_some()
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
     pub(super) fn hid_write_task_active(&self) -> bool {
-        self.layer_write_task.is_some() || self.combo_write_task.is_some()
+        self.hid_write_task_owner_active()
+            || !self.settings_write_queue.is_empty()
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/src/ui/combo_write.rs
+++ b/src/ui/combo_write.rs
@@ -176,6 +176,7 @@ impl EntropyApp {
             Ok(result) => {
                 self.combo_write_task = None;
                 self.finish_combo_write(result);
+                self.continue_pending_settings_writes(ctx);
             }
             Err(std::sync::mpsc::TryRecvError::Empty) => {
                 ctx.request_repaint_after(std::time::Duration::from_millis(16));
@@ -200,6 +201,7 @@ impl EntropyApp {
                         ),
                     )],
                 );
+                self.continue_pending_settings_writes(ctx);
             }
         }
     }

--- a/src/ui/device_connect_task.rs
+++ b/src/ui/device_connect_task.rs
@@ -503,6 +503,8 @@ impl EntropyApp {
         self.selected_layer = 0;
         self.layer_write_task = None;
         self.combo_write_task = None;
+        self.settings_write_task = None;
+        self.settings_write_queue.clear();
         self.hid_device = None;
         self.undo_stack.clear();
         self.device_about_info = None;

--- a/src/ui/device_connection.rs
+++ b/src/ui/device_connection.rs
@@ -32,6 +32,8 @@ impl EntropyApp {
         self.qmk_hid_hosts.clear();
         self.layer_write_task = None;
         self.combo_write_task = None;
+        self.settings_write_task = None;
+        self.settings_write_queue.clear();
         self.hid_device = None;
         self.undo_stack.clear();
         self.connect_state = ConnectState::Idle;

--- a/src/ui/key_assignment.rs
+++ b/src/ui/key_assignment.rs
@@ -76,6 +76,12 @@ impl EntropyApp {
         encoder_visual_idx: usize,
         kc_value: u16,
     ) {
+        if self.qmk_settings_write_busy() {
+            self.status_msg =
+                crate::i18n::tr_catalog(self.app_settings.language, "settings_write.busy")
+                    .to_owned();
+            return;
+        }
         let encoder = match self
             .layout
             .as_ref()
@@ -251,6 +257,12 @@ impl EntropyApp {
     }
 
     pub(super) fn assign_keycode(&mut self, layer: usize, ki: usize, kc_value: u16) {
+        if self.qmk_settings_write_busy() {
+            self.status_msg =
+                crate::i18n::tr_catalog(self.app_settings.language, "settings_write.busy")
+                    .to_owned();
+            return;
+        }
         let old_kc = self
             .layout
             .as_ref()

--- a/src/ui/key_override_settings.rs
+++ b/src/ui/key_override_settings.rs
@@ -64,10 +64,12 @@ impl EntropyApp {
         }
     }
 
-    fn write_all_key_overrides(&mut self) {
+    fn write_all_key_overrides(&mut self) -> bool {
+        let mut saved = true;
         for idx in 0..self.key_override_entries.len() {
-            self.write_key_override(idx);
+            saved &= self.write_key_override(idx);
         }
+        saved
     }
 
     fn key_override_entry_exists(entry: &KeyOverrideEntry) -> bool {
@@ -89,14 +91,19 @@ impl EntropyApp {
         entry.options.enabled = Self::key_override_entry_exists(entry);
     }
 
-    pub(super) fn write_key_override(&mut self, idx: usize) {
+    pub(super) fn write_key_override(&mut self, idx: usize) -> bool {
         let Some(entry) = self.key_override_entries.get_mut(idx) else {
-            return;
+            return true;
         };
         Self::normalize_key_override_entry(entry);
         let entry = entry.clone();
+        if self.hid_write_task_active() {
+            self.key_override_dirty = true;
+            return false;
+        }
         let Some(hid) = &self.hid_device else {
-            return;
+            self.key_override_dirty = true;
+            return false;
         };
         if let Err(e) = hid.set_key_override(
             idx as u8,
@@ -110,6 +117,19 @@ impl EntropyApp {
         ) {
             self.status_msg = format!("Failed to save Key Override {}: {}", idx + 1, e);
             log::warn!("set_key_override({idx}) failed: {e}");
+            self.key_override_dirty = true;
+            false
+        } else {
+            true
+        }
+    }
+
+    pub(super) fn flush_pending_key_override_writes(&mut self) {
+        if self.key_override_dirty
+            && !self.hid_write_task_active()
+            && self.write_all_key_overrides()
+        {
+            self.key_override_dirty = false;
         }
     }
 

--- a/src/ui/layer_operations.rs
+++ b/src/ui/layer_operations.rs
@@ -986,6 +986,7 @@ impl EntropyApp {
             Ok(result) => {
                 self.layer_write_task = None;
                 self.finish_layer_write(result);
+                self.cancel_pending_settings_writes_without_transport();
             }
             Err(std::sync::mpsc::TryRecvError::Empty) => {
                 ctx.request_repaint_after(std::time::Duration::from_millis(16));
@@ -1013,6 +1014,7 @@ impl EntropyApp {
                         ("layer", &task.fallback.layer.to_string()),
                     ],
                 );
+                self.cancel_pending_settings_writes_without_transport();
             }
         }
     }

--- a/src/ui/layer_operations.rs
+++ b/src/ui/layer_operations.rs
@@ -986,7 +986,7 @@ impl EntropyApp {
             Ok(result) => {
                 self.layer_write_task = None;
                 self.finish_layer_write(result);
-                self.cancel_pending_settings_writes_without_transport();
+                self.continue_pending_settings_writes(ctx);
             }
             Err(std::sync::mpsc::TryRecvError::Empty) => {
                 ctx.request_repaint_after(std::time::Duration::from_millis(16));
@@ -1014,7 +1014,7 @@ impl EntropyApp {
                         ("layer", &task.fallback.layer.to_string()),
                     ],
                 );
-                self.cancel_pending_settings_writes_without_transport();
+                self.continue_pending_settings_writes(ctx);
             }
         }
     }

--- a/src/ui/module_settings.rs
+++ b/src/ui/module_settings.rs
@@ -173,7 +173,7 @@ impl EntropyApp {
                     tooltip.as_deref(),
                     switch_width + status_width,
                     |ui| {
-                        self.draw_settings_write_status(ui, field.qsid, metrics);
+                        self.draw_settings_write_status(ui, field.qsid, metrics, suppress_tooltips);
                         let resp = crate::ui_style::settings_switch_sized_stable(
                             ui,
                             ("module_settings", group_idx, field.qsid, field.bit),
@@ -202,7 +202,7 @@ impl EntropyApp {
                     tooltip.as_deref(),
                     field_width + status_width,
                     |ui| {
-                        self.draw_settings_write_status(ui, field.qsid, metrics);
+                        self.draw_settings_write_status(ui, field.qsid, metrics, suppress_tooltips);
                         let edit_id = egui::Id::new(("module_setting_edit", group_idx, field.qsid));
                         let current = raw_value.clamp(field.min, field.max);
                         let mut text = ui.ctx().data_mut(|d| {
@@ -259,7 +259,7 @@ impl EntropyApp {
                     tooltip.as_deref(),
                     dropdown_width + status_width,
                     |ui| {
-                        self.draw_settings_write_status(ui, field.qsid, metrics);
+                        self.draw_settings_write_status(ui, field.qsid, metrics, suppress_tooltips);
                         let dropdown_id = ui.make_persistent_id((
                             "module_setting_dropdown",
                             group_idx,

--- a/src/ui/module_settings.rs
+++ b/src/ui/module_settings.rs
@@ -7,12 +7,6 @@ enum ModuleSettingsRow {
     Field { group_idx: usize, field_idx: usize },
 }
 
-const MODULE_SETTING_WRITEBACK_DELAYS: [std::time::Duration; MODULE_SETTING_READBACK_ATTEMPTS] = [
-    std::time::Duration::from_millis(20),
-    std::time::Duration::from_millis(80),
-    std::time::Duration::from_millis(200),
-];
-
 impl EntropyApp {
     fn module_setting_display_title<'a>(
         &self,
@@ -113,75 +107,27 @@ impl EntropyApp {
         field: &ModuleSettingField,
         value: u16,
     ) {
-        let group_title = self
-            .module_settings
-            .groups
-            .get(group_idx)
+        let group = self.module_settings.groups.get(group_idx);
+        let group_title = group
             .map(|group| group.title.clone())
             .unwrap_or_else(|| "Modules".to_owned());
+        let group_kind = group
+            .map(|group| group.kind)
+            .unwrap_or(ModuleSettingsGroupKind::Other);
         let field_title = field.title.clone();
+        let display_label = self.module_setting_label(group_kind, &field_title);
         let old_value = self.module_settings.value(field.qsid);
         let requested = Self::module_setting_transport_value(field, value);
 
-        let Some(hid) = self.hid_device.as_ref() else {
-            self.status_msg = format!(
-                "Failed to save module setting (qsid {}): device is not connected",
-                field.qsid
-            );
-            log::warn!(
-                "module setting write skipped: group={group_title:?} field={field_title:?} qsid={} old={} requested={} readback=unavailable error=device not connected",
-                field.qsid,
-                old_value,
-                requested,
-            );
-            return;
-        };
-
-        let mut readback_attempt = 0;
-        let result = self.module_settings.write_verified_value(
+        self.queue_module_setting_write(
+            group_title,
+            field_title,
+            display_label,
             field.qsid,
+            field.width,
+            old_value,
             requested,
-            || {
-                if field.width > 1 {
-                    hid.set_qmk_setting_u16(field.qsid, requested)
-                } else {
-                    hid.set_qmk_setting_u8(field.qsid, requested as u8)
-                }
-                .map_err(|error| error.to_string())
-            },
-            || {
-                let delay = MODULE_SETTING_WRITEBACK_DELAYS
-                    [readback_attempt.min(MODULE_SETTING_WRITEBACK_DELAYS.len() - 1)];
-                readback_attempt += 1;
-                std::thread::sleep(delay);
-                if field.width > 1 {
-                    hid.get_qmk_setting_u16(field.qsid)
-                } else {
-                    hid.get_qmk_setting_u8(field.qsid)
-                        .map(|readback| readback as u16)
-                }
-                .map_err(|error| error.to_string())
-            },
         );
-
-        if let Err(error) = result {
-            let readback = match &error {
-                ModuleSettingWritebackError::ReadbackMismatch { actual, .. } => actual.to_string(),
-                _ => "unavailable".to_owned(),
-            };
-            self.status_msg = format!(
-                "Failed to save module setting {} (qsid {}): {}",
-                field_title, field.qsid, error
-            );
-            log::warn!(
-                "module setting writeback failed: group={group_title:?} field={field_title:?} qsid={} old={} requested={} readback={} error={}",
-                field.qsid,
-                old_value,
-                requested,
-                readback,
-                error,
-            );
-        }
     }
 
     fn draw_module_settings_field_row(
@@ -208,7 +154,10 @@ impl EntropyApp {
         } else {
             Some(self.module_setting_tooltip(group_kind, &field))
         };
-        let raw_value = self.module_settings.value(field.qsid);
+        let raw_value = self
+            .pending_settings_write_value(field.qsid)
+            .unwrap_or_else(|| self.module_settings.value(field.qsid));
+        let status_width = self.settings_write_status_width(metrics);
         match field.kind {
             ModuleSettingKind::Boolean => {
                 let switch_width = metrics.value(46.0);
@@ -222,8 +171,9 @@ impl EntropyApp {
                     label.as_str(),
                     true,
                     tooltip.as_deref(),
-                    switch_width,
+                    switch_width + status_width,
                     |ui| {
+                        self.draw_settings_write_status(ui, field.qsid, metrics);
                         let resp = crate::ui_style::settings_switch_sized_stable(
                             ui,
                             ("module_settings", group_idx, field.qsid, field.bit),
@@ -250,8 +200,9 @@ impl EntropyApp {
                     label.as_str(),
                     true,
                     tooltip.as_deref(),
-                    field_width,
+                    field_width + status_width,
                     |ui| {
+                        self.draw_settings_write_status(ui, field.qsid, metrics);
                         let edit_id = egui::Id::new(("module_setting_edit", group_idx, field.qsid));
                         let current = raw_value.clamp(field.min, field.max);
                         let mut text = ui.ctx().data_mut(|d| {
@@ -306,8 +257,9 @@ impl EntropyApp {
                     label.as_str(),
                     true,
                     tooltip.as_deref(),
-                    dropdown_width,
+                    dropdown_width + status_width,
                     |ui| {
+                        self.draw_settings_write_status(ui, field.qsid, metrics);
                         let dropdown_id = ui.make_persistent_id((
                             "module_setting_dropdown",
                             group_idx,

--- a/src/ui/settings_write_queue.rs
+++ b/src/ui/settings_write_queue.rs
@@ -1,0 +1,596 @@
+use super::*;
+
+const SETTINGS_WRITEBACK_DELAYS: [std::time::Duration; MODULE_SETTING_READBACK_ATTEMPTS] = [
+    std::time::Duration::from_millis(20),
+    std::time::Duration::from_millis(80),
+    std::time::Duration::from_millis(200),
+];
+const SETTINGS_WRITE_STATUS_WIDTH: f32 = 22.0;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum SettingsWriteStatus {
+    Pending,
+    Saved,
+    Failed(String),
+}
+
+#[derive(Clone, Debug)]
+enum SettingsWriteTarget {
+    Module {
+        group_title: String,
+        field_title: String,
+        display_label: String,
+    },
+    Touchpad {
+        display_label: String,
+    },
+}
+
+impl SettingsWriteTarget {
+    fn display_label(&self) -> &str {
+        match self {
+            Self::Module { display_label, .. } | Self::Touchpad { display_label } => display_label,
+        }
+    }
+
+    fn log_context(&self) -> String {
+        match self {
+            Self::Module {
+                group_title,
+                field_title,
+                ..
+            } => format!("module group={group_title:?} field={field_title:?}"),
+            Self::Touchpad { display_label } => {
+                format!("touchpad field={display_label:?}")
+            }
+        }
+    }
+
+    fn updates_module_state(&self) -> bool {
+        matches!(self, Self::Module { .. })
+    }
+}
+
+#[derive(Clone, Debug)]
+struct SettingsWriteRequest {
+    id: u64,
+    qsid: u16,
+    width: u8,
+    old_value: u16,
+    requested: u16,
+    target: SettingsWriteTarget,
+}
+
+#[derive(Clone, Debug)]
+struct SettingsWriteStatusEntry {
+    request_id: u64,
+    requested: u16,
+    status: SettingsWriteStatus,
+}
+
+#[derive(Default)]
+pub(super) struct SettingsWriteQueueState {
+    pending: std::collections::VecDeque<SettingsWriteRequest>,
+    statuses: std::collections::BTreeMap<u16, SettingsWriteStatusEntry>,
+    next_request_id: u64,
+}
+
+impl SettingsWriteQueueState {
+    fn enqueue(&mut self, mut request: SettingsWriteRequest) -> u64 {
+        self.next_request_id = self.next_request_id.wrapping_add(1).max(1);
+        request.id = self.next_request_id;
+        self.statuses.insert(
+            request.qsid,
+            SettingsWriteStatusEntry {
+                request_id: request.id,
+                requested: request.requested,
+                status: SettingsWriteStatus::Pending,
+            },
+        );
+        let id = request.id;
+        self.pending.push_back(request);
+        id
+    }
+
+    fn pop_front(&mut self) -> Option<SettingsWriteRequest> {
+        self.pending.pop_front()
+    }
+
+    fn status(&self, qsid: u16) -> Option<&SettingsWriteStatus> {
+        self.statuses.get(&qsid).map(|entry| &entry.status)
+    }
+
+    fn pending_value(&self, qsid: u16) -> Option<u16> {
+        let entry = self.statuses.get(&qsid)?;
+        matches!(entry.status, SettingsWriteStatus::Pending).then_some(entry.requested)
+    }
+
+    fn complete(&mut self, request_id: u64, qsid: u16, status: SettingsWriteStatus) -> bool {
+        let Some(entry) = self.statuses.get_mut(&qsid) else {
+            return false;
+        };
+        if entry.request_id != request_id {
+            return false;
+        }
+        entry.status = status;
+        true
+    }
+
+    fn fail_pending(&mut self, error: &str) {
+        while let Some(request) = self.pending.pop_front() {
+            self.complete(
+                request.id,
+                request.qsid,
+                SettingsWriteStatus::Failed(error.to_owned()),
+            );
+        }
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.pending.is_empty()
+    }
+
+    pub(super) fn clear(&mut self) {
+        self.pending.clear();
+        self.statuses.clear();
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(super) struct SettingsWriteTask {
+    receiver: std::sync::mpsc::Receiver<SettingsWriteResult>,
+    request: SettingsWriteRequest,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+struct SettingsWriteResult {
+    hid_device: Option<crate::hid::HidDevice>,
+    request: SettingsWriteRequest,
+    result: Result<u16, ModuleSettingWritebackError>,
+    disconnected: bool,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn run_settings_write(
+    hid: &crate::hid::HidDevice,
+    request: &SettingsWriteRequest,
+) -> (Result<u16, ModuleSettingWritebackError>, bool) {
+    let disconnected = std::cell::Cell::new(false);
+    let mut readback_attempt = 0;
+    let mut state = ModuleSettingsState::default();
+    let result = state.write_verified_value(
+        request.qsid,
+        request.requested,
+        || {
+            let result = if request.width > 1 {
+                hid.set_qmk_setting_u16(request.qsid, request.requested)
+            } else {
+                hid.set_qmk_setting_u8(request.qsid, request.requested as u8)
+            };
+            result.map_err(|error| {
+                disconnected.set(crate::hid::is_disconnect_error(&error));
+                error.to_string()
+            })
+        },
+        || {
+            let delay = SETTINGS_WRITEBACK_DELAYS
+                [readback_attempt.min(SETTINGS_WRITEBACK_DELAYS.len() - 1)];
+            readback_attempt += 1;
+            std::thread::sleep(delay);
+            let result = if request.width > 1 {
+                hid.get_qmk_setting_u16(request.qsid)
+            } else {
+                hid.get_qmk_setting_u8(request.qsid)
+                    .map(|readback| readback as u16)
+            };
+            result.map_err(|error| {
+                disconnected.set(crate::hid::is_disconnect_error(&error));
+                error.to_string()
+            })
+        },
+    );
+    (result, disconnected.get())
+}
+
+impl EntropyApp {
+    pub(super) fn qmk_settings_write_busy(&self) -> bool {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.settings_write_task.is_some() || !self.settings_write_queue.is_empty()
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            false
+        }
+    }
+
+    pub(super) fn qmk_setting_transport_available(&self) -> bool {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.hid_device.is_some() || self.hid_write_task_active()
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            false
+        }
+    }
+
+    pub(super) fn settings_write_status_width(
+        &self,
+        metrics: crate::ui_style::ResponsiveMetrics,
+    ) -> f32 {
+        metrics.value(SETTINGS_WRITE_STATUS_WIDTH)
+    }
+
+    pub(super) fn pending_settings_write_value(&self, qsid: u16) -> Option<u16> {
+        self.settings_write_queue.pending_value(qsid)
+    }
+
+    pub(super) fn draw_settings_write_status(
+        &self,
+        ui: &mut egui::Ui,
+        qsid: u16,
+        metrics: crate::ui_style::ResponsiveMetrics,
+    ) {
+        let size = egui::vec2(
+            self.settings_write_status_width(metrics),
+            metrics.settings_control_height(),
+        );
+        let (rect, response) = ui.allocate_exact_size(size, egui::Sense::hover());
+        let status = self.settings_write_queue.status(qsid).cloned();
+        let tooltip = match status.as_ref() {
+            Some(SettingsWriteStatus::Pending) => {
+                ui.put(
+                    rect.shrink(metrics.value(4.0)),
+                    egui::Spinner::new().size(metrics.value(12.0)),
+                );
+                Some(
+                    crate::i18n::tr_catalog(self.app_settings.language, "settings_write.pending")
+                        .to_owned(),
+                )
+            }
+            Some(SettingsWriteStatus::Saved) => {
+                ui.painter().text(
+                    rect.center(),
+                    egui::Align2::CENTER_CENTER,
+                    "\u{2713}",
+                    egui::FontId::proportional(metrics.value(14.0)),
+                    egui::Color32::from_rgb(72, 158, 108),
+                );
+                Some(
+                    crate::i18n::tr_catalog(self.app_settings.language, "settings_write.saved")
+                        .to_owned(),
+                )
+            }
+            Some(SettingsWriteStatus::Failed(error)) => {
+                ui.painter().text(
+                    rect.center(),
+                    egui::Align2::CENTER_CENTER,
+                    "!",
+                    egui::FontId::proportional(metrics.value(14.0)),
+                    egui::Color32::from_rgb(205, 80, 80),
+                );
+                Some(crate::i18n::tr_catalog_format(
+                    self.app_settings.language,
+                    "settings_write.failed",
+                    &[("error", error)],
+                ))
+            }
+            None => None,
+        };
+        if let Some(tooltip) = tooltip {
+            response.on_hover_text(tooltip);
+        }
+    }
+
+    pub(super) fn queue_module_setting_write(
+        &mut self,
+        group_title: String,
+        field_title: String,
+        display_label: String,
+        qsid: u16,
+        width: u8,
+        old_value: u16,
+        requested: u16,
+    ) {
+        self.queue_settings_write(SettingsWriteRequest {
+            id: 0,
+            qsid,
+            width,
+            old_value,
+            requested,
+            target: SettingsWriteTarget::Module {
+                group_title,
+                field_title,
+                display_label,
+            },
+        });
+    }
+
+    pub(super) fn queue_touchpad_setting_write(
+        &mut self,
+        display_label: String,
+        qsid: u16,
+        width: u8,
+        old_value: u16,
+        requested: u16,
+    ) {
+        self.queue_settings_write(SettingsWriteRequest {
+            id: 0,
+            qsid,
+            width,
+            old_value,
+            requested,
+            target: SettingsWriteTarget::Touchpad { display_label },
+        });
+    }
+
+    fn queue_settings_write(&mut self, request: SettingsWriteRequest) {
+        let label = request.target.display_label().to_owned();
+        let context = request.target.log_context();
+        let qsid = request.qsid;
+        let old_value = request.old_value;
+        let requested = request.requested;
+        self.settings_write_queue.enqueue(request);
+        if !self.qmk_setting_transport_available() {
+            let error = crate::i18n::tr_catalog(
+                self.app_settings.language,
+                "settings_write.device_not_connected",
+            )
+            .to_owned();
+            self.settings_write_queue.fail_pending(&error);
+            self.status_msg = crate::i18n::tr_catalog_format(
+                self.app_settings.language,
+                "settings_write.failed_status",
+                &[("setting", &label), ("error", &error)],
+            );
+            log::warn!(
+                "settings write skipped: {context} qsid={qsid} old={old_value} requested={requested} error={error}"
+            );
+            return;
+        }
+
+        self.status_msg = crate::i18n::tr_catalog_format(
+            self.app_settings.language,
+            "settings_write.pending_status",
+            &[("setting", &label)],
+        );
+        self.start_next_settings_write();
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn start_next_settings_write(&mut self) {
+        if self.hid_write_task_owner_active() {
+            return;
+        }
+        let Some(request) = self.settings_write_queue.pop_front() else {
+            return;
+        };
+        let Some(hid_device) = self.hid_device.take() else {
+            let error = crate::i18n::tr_catalog(
+                self.app_settings.language,
+                "settings_write.device_disconnected",
+            )
+            .to_owned();
+            self.settings_write_queue.complete(
+                request.id,
+                request.qsid,
+                SettingsWriteStatus::Failed(error.clone()),
+            );
+            self.settings_write_queue.fail_pending(&error);
+            return;
+        };
+
+        let fallback = request.clone();
+        let (sender, receiver) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            #[cfg(target_os = "macos")]
+            let _hid_lock = crate::hid::macos_hid_operation_lock();
+
+            let (result, disconnected) = run_settings_write(&hid_device, &request);
+            let hid_device = (!disconnected).then_some(hid_device);
+            let _ = sender.send(SettingsWriteResult {
+                hid_device,
+                request,
+                result,
+                disconnected,
+            });
+        });
+        self.settings_write_task = Some(SettingsWriteTask {
+            receiver,
+            request: fallback,
+        });
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn start_next_settings_write(&mut self) {}
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(super) fn poll_settings_write(&mut self, ctx: &egui::Context) {
+        let result = match self.settings_write_task.as_ref() {
+            Some(task) => task.receiver.try_recv(),
+            None => {
+                self.start_next_settings_write();
+                if self.qmk_settings_write_busy() {
+                    ctx.request_repaint_after(std::time::Duration::from_millis(16));
+                }
+                return;
+            }
+        };
+
+        match result {
+            Ok(result) => {
+                self.settings_write_task = None;
+                self.finish_settings_write(result);
+                self.start_next_settings_write();
+            }
+            Err(std::sync::mpsc::TryRecvError::Empty) => {
+                ctx.request_repaint_after(std::time::Duration::from_millis(16));
+            }
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                let task = self
+                    .settings_write_task
+                    .take()
+                    .expect("settings write task checked above");
+                self.hid_device = None;
+                let error = crate::i18n::tr_catalog(
+                    self.app_settings.language,
+                    "settings_write.worker_failed",
+                )
+                .to_owned();
+                self.settings_write_queue.complete(
+                    task.request.id,
+                    task.request.qsid,
+                    SettingsWriteStatus::Failed(error.clone()),
+                );
+                self.settings_write_queue.fail_pending(&error);
+                self.status_msg = crate::i18n::tr_catalog_format(
+                    self.app_settings.language,
+                    "settings_write.failed_status",
+                    &[
+                        ("setting", task.request.target.display_label()),
+                        ("error", &error),
+                    ],
+                );
+            }
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn finish_settings_write(&mut self, result: SettingsWriteResult) {
+        let SettingsWriteResult {
+            hid_device,
+            request,
+            result,
+            disconnected,
+        } = result;
+        self.hid_device = hid_device;
+        let context = request.target.log_context();
+        match result {
+            Ok(readback) => {
+                if request.target.updates_module_state() {
+                    self.module_settings.set_value(request.qsid, readback);
+                }
+                let current = self.settings_write_queue.complete(
+                    request.id,
+                    request.qsid,
+                    SettingsWriteStatus::Saved,
+                );
+                if current {
+                    self.status_msg = crate::i18n::tr_catalog_format(
+                        self.app_settings.language,
+                        "settings_write.saved_status",
+                        &[("setting", request.target.display_label())],
+                    );
+                }
+                log::info!(
+                    "settings write saved: {context} qsid={} old={} requested={} readback={}",
+                    request.qsid,
+                    request.old_value,
+                    request.requested,
+                    readback,
+                );
+            }
+            Err(error) => {
+                let error_text = error.to_string();
+                let current = self.settings_write_queue.complete(
+                    request.id,
+                    request.qsid,
+                    SettingsWriteStatus::Failed(error_text.clone()),
+                );
+                if current {
+                    self.status_msg = crate::i18n::tr_catalog_format(
+                        self.app_settings.language,
+                        "settings_write.failed_status",
+                        &[
+                            ("setting", request.target.display_label()),
+                            ("error", &error_text),
+                        ],
+                    );
+                }
+                log::warn!(
+                    "settings write failed: {context} qsid={} old={} requested={} error={}",
+                    request.qsid,
+                    request.old_value,
+                    request.requested,
+                    error_text,
+                );
+            }
+        }
+
+        if disconnected {
+            let error = crate::i18n::tr_catalog(
+                self.app_settings.language,
+                "settings_write.device_disconnected",
+            );
+            self.settings_write_queue.fail_pending(error);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request(qsid: u16, requested: u16) -> SettingsWriteRequest {
+        SettingsWriteRequest {
+            id: 0,
+            qsid,
+            width: 1,
+            old_value: 1,
+            requested,
+            target: SettingsWriteTarget::Touchpad {
+                display_label: "Setting".to_owned(),
+            },
+        }
+    }
+
+    #[test]
+    fn settings_write_queue_is_fifo() {
+        let mut queue = SettingsWriteQueueState::default();
+        let first_id = queue.enqueue(request(1, 10));
+        let second_id = queue.enqueue(request(2, 20));
+
+        assert_eq!(queue.pop_front().map(|request| request.id), Some(first_id));
+        assert_eq!(queue.pop_front().map(|request| request.id), Some(second_id));
+        assert!(queue.pop_front().is_none());
+    }
+
+    #[test]
+    fn older_completion_keeps_newer_same_qsid_pending() {
+        let mut queue = SettingsWriteQueueState::default();
+        let first_id = queue.enqueue(request(122, 10));
+        let second_id = queue.enqueue(request(122, 11));
+
+        assert_eq!(queue.pending_value(122), Some(11));
+        assert!(!queue.complete(first_id, 122, SettingsWriteStatus::Saved));
+        assert_eq!(queue.status(122), Some(&SettingsWriteStatus::Pending));
+        assert_eq!(queue.pending_value(122), Some(11));
+        assert!(queue.complete(second_id, 122, SettingsWriteStatus::Saved));
+        assert_eq!(queue.status(122), Some(&SettingsWriteStatus::Saved));
+        assert_eq!(queue.pending_value(122), None);
+    }
+
+    #[test]
+    fn failed_transport_marks_all_queued_settings() {
+        let mut queue = SettingsWriteQueueState::default();
+        queue.enqueue(request(121, 10));
+        queue.enqueue(request(122, 11));
+
+        queue.fail_pending("device disconnected");
+
+        assert_eq!(
+            queue.status(121),
+            Some(&SettingsWriteStatus::Failed(
+                "device disconnected".to_owned()
+            ))
+        );
+        assert_eq!(
+            queue.status(122),
+            Some(&SettingsWriteStatus::Failed(
+                "device disconnected".to_owned()
+            ))
+        );
+        assert!(queue.is_empty());
+    }
+}

--- a/src/ui/settings_write_queue.rs
+++ b/src/ui/settings_write_queue.rs
@@ -244,6 +244,11 @@ impl EntropyApp {
         self.settings_write_queue.pending_value(qsid)
     }
 
+    #[cfg(test)]
+    pub(super) fn settings_write_status(&self, qsid: u16) -> Option<&SettingsWriteStatus> {
+        self.settings_write_queue.status(qsid)
+    }
+
     pub(super) fn draw_settings_write_status(
         &self,
         ui: &mut egui::Ui,
@@ -423,6 +428,18 @@ impl EntropyApp {
         });
     }
 
+    /// Continue Settings work in same frame that another HID owner returns
+    /// transport, rather than waiting for background-update cadence.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(super) fn continue_pending_settings_writes(&mut self, ctx: &egui::Context) {
+        self.cancel_pending_settings_writes_without_transport();
+        self.start_next_settings_write();
+
+        if self.qmk_settings_write_busy() {
+            ctx.request_repaint_after(std::time::Duration::from_millis(16));
+        }
+    }
+
     #[cfg(target_arch = "wasm32")]
     fn start_next_settings_write(&mut self) {}
 
@@ -431,11 +448,7 @@ impl EntropyApp {
         let result = match self.settings_write_task.as_ref() {
             Some(task) => task.receiver.try_recv(),
             None => {
-                self.cancel_pending_settings_writes_without_transport();
-                self.start_next_settings_write();
-                if self.qmk_settings_write_busy() {
-                    ctx.request_repaint_after(std::time::Duration::from_millis(16));
-                }
+                self.continue_pending_settings_writes(ctx);
                 return;
             }
         };
@@ -444,7 +457,7 @@ impl EntropyApp {
             Ok(result) => {
                 self.settings_write_task = None;
                 self.finish_settings_write(result);
-                self.start_next_settings_write();
+                self.continue_pending_settings_writes(ctx);
             }
             Err(std::sync::mpsc::TryRecvError::Empty) => {
                 ctx.request_repaint_after(std::time::Duration::from_millis(16));
@@ -474,6 +487,7 @@ impl EntropyApp {
                         ("error", &error),
                     ],
                 );
+                self.continue_pending_settings_writes(ctx);
             }
         }
     }

--- a/src/ui/settings_write_queue.rs
+++ b/src/ui/settings_write_queue.rs
@@ -46,8 +46,26 @@ impl SettingsWriteTarget {
         }
     }
 
-    fn updates_module_state(&self) -> bool {
-        matches!(self, Self::Module { .. })
+    fn reconcile_readback(
+        &self,
+        module_settings: &mut ModuleSettingsState,
+        touchpad_settings: &mut TouchpadSettingsState,
+        qsid: u16,
+        readback: u16,
+    ) {
+        match self {
+            Self::Module { .. } => module_settings.set_value(qsid, readback),
+            Self::Touchpad { .. } => match qsid {
+                120 => touchpad_settings.dpi = readback,
+                121 => touchpad_settings.sniper_sens = readback.min(u8::MAX as u16) as u8,
+                122 => touchpad_settings.scroll_sens = readback.min(u8::MAX as u16) as u8,
+                123 => touchpad_settings.text_sens = readback.min(u8::MAX as u16) as u8,
+                124 => touchpad_settings.bits = readback.min(u8::MAX as u16) as u8,
+                142 => touchpad_settings.auto_layer_enable = readback != 0,
+                143 => touchpad_settings.auto_layer = readback.min(u8::MAX as u16) as u8,
+                _ => {}
+            },
+        }
     }
 }
 
@@ -231,6 +249,7 @@ impl EntropyApp {
         ui: &mut egui::Ui,
         qsid: u16,
         metrics: crate::ui_style::ResponsiveMetrics,
+        suppress_tooltips: bool,
     ) {
         let size = egui::vec2(
             self.settings_write_status_width(metrics),
@@ -278,8 +297,10 @@ impl EntropyApp {
             }
             None => None,
         };
-        if let Some(tooltip) = tooltip {
-            response.on_hover_text(tooltip);
+        if !suppress_tooltips {
+            if let Some(tooltip) = tooltip {
+                response.on_hover_text(tooltip);
+            }
         }
     }
 
@@ -410,6 +431,7 @@ impl EntropyApp {
         let result = match self.settings_write_task.as_ref() {
             Some(task) => task.receiver.try_recv(),
             None => {
+                self.cancel_pending_settings_writes_without_transport();
                 self.start_next_settings_write();
                 if self.qmk_settings_write_busy() {
                     ctx.request_repaint_after(std::time::Duration::from_millis(16));
@@ -468,15 +490,18 @@ impl EntropyApp {
         let context = request.target.log_context();
         match result {
             Ok(readback) => {
-                if request.target.updates_module_state() {
-                    self.module_settings.set_value(request.qsid, readback);
-                }
                 let current = self.settings_write_queue.complete(
                     request.id,
                     request.qsid,
                     SettingsWriteStatus::Saved,
                 );
                 if current {
+                    request.target.reconcile_readback(
+                        &mut self.module_settings,
+                        &mut self.touchpad_settings,
+                        request.qsid,
+                        readback,
+                    );
                     self.status_msg = crate::i18n::tr_catalog_format(
                         self.app_settings.language,
                         "settings_write.saved_status",
@@ -499,6 +524,14 @@ impl EntropyApp {
                     SettingsWriteStatus::Failed(error_text.clone()),
                 );
                 if current {
+                    if let ModuleSettingWritebackError::ReadbackMismatch { actual, .. } = &error {
+                        request.target.reconcile_readback(
+                            &mut self.module_settings,
+                            &mut self.touchpad_settings,
+                            request.qsid,
+                            *actual,
+                        );
+                    }
                     self.status_msg = crate::i18n::tr_catalog_format(
                         self.app_settings.language,
                         "settings_write.failed_status",
@@ -526,6 +559,19 @@ impl EntropyApp {
             self.settings_write_queue.fail_pending(error);
         }
     }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(super) fn cancel_pending_settings_writes_without_transport(&mut self) {
+        if self.hid_device.is_some() || self.hid_write_task_owner_active() {
+            return;
+        }
+
+        let error = crate::i18n::tr_catalog(
+            self.app_settings.language,
+            "settings_write.device_disconnected",
+        );
+        self.settings_write_queue.fail_pending(error);
+    }
 }
 
 #[cfg(test)]
@@ -543,6 +589,12 @@ mod tests {
                 display_label: "Setting".to_owned(),
             },
         }
+    }
+
+    fn test_app() -> EntropyApp {
+        let ctx = egui::Context::default();
+        let creation_context = eframe::CreationContext::_new_kittest(ctx);
+        EntropyApp::new(&creation_context)
     }
 
     #[test]
@@ -592,5 +644,121 @@ mod tests {
             ))
         );
         assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn readback_reconciliation_updates_module_and_touchpad_state() {
+        let mut module_settings = ModuleSettingsState::default();
+        let mut touchpad_settings = TouchpadSettingsState::default();
+
+        SettingsWriteTarget::Module {
+            group_title: "Modules".to_owned(),
+            field_title: "Mode".to_owned(),
+            display_label: "Mode".to_owned(),
+        }
+        .reconcile_readback(&mut module_settings, &mut touchpad_settings, 7, 3);
+        SettingsWriteTarget::Touchpad {
+            display_label: "Scroll sensitivity".to_owned(),
+        }
+        .reconcile_readback(&mut module_settings, &mut touchpad_settings, 122, 9);
+
+        assert_eq!(module_settings.value(7), 3);
+        assert_eq!(touchpad_settings.scroll_sens, 9);
+    }
+
+    #[test]
+    fn readback_mismatch_reconciles_module_and_touchpad_state() {
+        let mut app = test_app();
+        let mut module_request = request(7, 3);
+        module_request.target = SettingsWriteTarget::Module {
+            group_title: "Modules".to_owned(),
+            field_title: "Mode".to_owned(),
+            display_label: "Mode".to_owned(),
+        };
+        app.settings_write_queue.enqueue(module_request);
+        let module_request = app
+            .settings_write_queue
+            .pop_front()
+            .expect("queued module request");
+        app.finish_settings_write(SettingsWriteResult {
+            hid_device: None,
+            request: module_request,
+            result: Err(ModuleSettingWritebackError::ReadbackMismatch {
+                expected: 3,
+                actual: 2,
+            }),
+            disconnected: false,
+        });
+
+        let mut touchpad_request = request(122, 9);
+        touchpad_request.target = SettingsWriteTarget::Touchpad {
+            display_label: "Scroll sensitivity".to_owned(),
+        };
+        app.settings_write_queue.enqueue(touchpad_request);
+        let touchpad_request = app
+            .settings_write_queue
+            .pop_front()
+            .expect("queued touchpad request");
+        app.finish_settings_write(SettingsWriteResult {
+            hid_device: None,
+            request: touchpad_request,
+            result: Err(ModuleSettingWritebackError::ReadbackMismatch {
+                expected: 9,
+                actual: 7,
+            }),
+            disconnected: false,
+        });
+
+        assert_eq!(app.module_settings.value(7), 2);
+        assert_eq!(app.touchpad_settings.scroll_sens, 7);
+    }
+
+    #[test]
+    fn stale_readback_mismatch_does_not_replace_newer_touchpad_value() {
+        let mut app = test_app();
+        let old_request = request(122, 7);
+        app.settings_write_queue.enqueue(old_request);
+        let old_request = app
+            .settings_write_queue
+            .pop_front()
+            .expect("queued old request");
+        app.settings_write_queue.enqueue(request(122, 9));
+        app.touchpad_settings.scroll_sens = 9;
+
+        app.finish_settings_write(SettingsWriteResult {
+            hid_device: None,
+            request: old_request,
+            result: Err(ModuleSettingWritebackError::ReadbackMismatch {
+                expected: 7,
+                actual: 6,
+            }),
+            disconnected: false,
+        });
+
+        assert_eq!(app.touchpad_settings.scroll_sens, 9);
+        assert_eq!(
+            app.settings_write_queue.status(122),
+            Some(&SettingsWriteStatus::Pending)
+        );
+    }
+
+    #[test]
+    fn handle_loss_cancels_queued_settings_and_clears_busy_state() {
+        let mut app = test_app();
+        app.settings_write_queue.enqueue(request(121, 10));
+
+        app.cancel_pending_settings_writes_without_transport();
+
+        assert!(!app.qmk_settings_write_busy());
+        assert_eq!(
+            app.settings_write_queue.status(121),
+            Some(&SettingsWriteStatus::Failed(
+                crate::i18n::tr_catalog(
+                    app.app_settings.language,
+                    "settings_write.device_disconnected"
+                )
+                .to_owned()
+            ))
+        );
     }
 }

--- a/src/ui/touchpad_settings.rs
+++ b/src/ui/touchpad_settings.rs
@@ -202,7 +202,7 @@ impl EntropyApp {
                         },
                         dropdown_width + status_width,
                         |ui| {
-                            self.draw_settings_write_status(ui, 120, metrics);
+                            self.draw_settings_write_status(ui, 120, metrics, suppress_tooltips);
                             if variants.is_empty() {
                                 let current = self.touchpad_settings.dpi;
                                 let edit_id = egui::Id::new(("touchpad_edit", 120u16));
@@ -330,7 +330,7 @@ impl EntropyApp {
                         },
                         slider_control_width + status_width,
                         |ui| {
-                            self.draw_settings_write_status(ui, qsid, metrics);
+                            self.draw_settings_write_status(ui, qsid, metrics, suppress_tooltips);
                             ui.spacing_mut().item_spacing.x = 0.0;
                             let slider_fill = if dark {
                                 Color32::from_rgb(92, 92, 96)
@@ -411,7 +411,7 @@ impl EntropyApp {
                         },
                         switch_width + status_width,
                         |ui| {
-                            self.draw_settings_write_status(ui, 124, metrics);
+                            self.draw_settings_write_status(ui, 124, metrics, suppress_tooltips);
                             let old_bits = self.touchpad_settings.bits;
                             let mut value = self.touchpad_settings.bit(bit);
                             let resp = crate::ui_style::settings_switch_sized_stable(
@@ -445,7 +445,7 @@ impl EntropyApp {
                         },
                         switch_width + status_width,
                         |ui| {
-                            self.draw_settings_write_status(ui, 142, metrics);
+                            self.draw_settings_write_status(ui, 142, metrics, suppress_tooltips);
                             let mut value = self.touchpad_settings.auto_layer_enable;
                             let resp = crate::ui_style::settings_switch_sized_stable(
                                 ui,
@@ -485,7 +485,7 @@ impl EntropyApp {
                         },
                         dropdown_width + status_width,
                         |ui| {
-                            self.draw_settings_write_status(ui, 143, metrics);
+                            self.draw_settings_write_status(ui, 143, metrics, suppress_tooltips);
                             let dropdown_id = ui.make_persistent_id("touchpad_auto_layer_dropdown");
                             let (_, picked) = Self::draw_touchpad_select_control(
                                 ui,

--- a/src/ui/touchpad_settings.rs
+++ b/src/ui/touchpad_settings.rs
@@ -19,45 +19,63 @@ impl EntropyApp {
         }
     }
 
-    fn write_touchpad_numeric_setting(&mut self, qsid: u16, value: u16) {
-        let Some(hid) = &self.hid_device else {
-            return;
-        };
+    fn write_touchpad_numeric_setting(
+        &mut self,
+        qsid: u16,
+        old_value: u16,
+        value: u16,
+        display_label: &str,
+    ) {
         let value = value.clamp(1, 255) as u8;
-        if let Err(e) = hid.set_qmk_setting_u8(qsid, value) {
-            self.status_msg = format!("Failed to save Touchpad setting (qsid {qsid}): {}", e);
-            log::warn!("set_qmk_setting_u8(touchpad qsid {qsid}) failed: {e}");
-        }
+        self.queue_touchpad_setting_write(
+            display_label.to_owned(),
+            qsid,
+            1,
+            old_value,
+            value as u16,
+        );
     }
 
-    fn write_touchpad_select_setting(&mut self, qsid: u16, value: u8) {
-        let Some(hid) = &self.hid_device else {
-            return;
-        };
-        if let Err(e) = hid.set_qmk_setting_u8(qsid, value) {
-            self.status_msg = format!("Failed to save Touchpad setting (qsid {qsid}): {}", e);
-            log::warn!("set_qmk_setting_u8(touchpad qsid {qsid}) failed: {e}");
-        }
+    fn write_touchpad_select_setting(
+        &mut self,
+        qsid: u16,
+        old_value: u16,
+        value: u8,
+        display_label: &str,
+    ) {
+        self.queue_touchpad_setting_write(
+            display_label.to_owned(),
+            qsid,
+            1,
+            old_value,
+            value as u16,
+        );
     }
 
-    fn write_touchpad_bool_setting(&mut self, qsid: u16, value: bool) {
-        let Some(hid) = &self.hid_device else {
-            return;
-        };
-        if let Err(e) = hid.set_qmk_setting_u8(qsid, u8::from(value)) {
-            self.status_msg = format!("Failed to save Touchpad setting (qsid {qsid}): {}", e);
-            log::warn!("set_qmk_setting_u8(touchpad qsid {qsid}) failed: {e}");
-        }
+    fn write_touchpad_bool_setting(
+        &mut self,
+        qsid: u16,
+        old_value: bool,
+        value: bool,
+        display_label: &str,
+    ) {
+        self.queue_touchpad_setting_write(
+            display_label.to_owned(),
+            qsid,
+            1,
+            u16::from(old_value),
+            u16::from(value),
+        );
     }
 
-    fn write_touchpad_bits(&mut self) {
-        let Some(hid) = &self.hid_device else {
-            return;
-        };
-        if let Err(e) = hid.set_qmk_setting_u8(124, self.touchpad_settings.bits) {
-            self.status_msg = format!("Failed to save Touchpad options: {}", e);
-            log::warn!("set_qmk_setting_u8(touchpad qsid 124) failed: {e}");
-        }
+    fn write_touchpad_bits(&mut self, old_value: u8, display_label: &str) {
+        self.queue_touchpad_setting_write(
+            display_label.to_owned(),
+            124,
+            1,
+            old_value as u16,
+            self.touchpad_settings.bits as u16,
+        );
     }
 
     pub(super) fn draw_touchpad_select_control(
@@ -155,11 +173,16 @@ impl EntropyApp {
         let switch_width = metrics.value(46.0);
         let switch_size = metrics.size(46.0, 24.0);
         let dropdown_width = metrics.value(120.0);
+        let status_width = self.settings_write_status_width(metrics);
         let dark = ui.visuals().dark_mode;
 
         for row_idx in row_range {
             match row_idx {
                 0 => {
+                    let label = crate::i18n::tr_catalog(
+                        self.app_settings.language,
+                        "touchpad_settings.dpi",
+                    );
                     let variants = self.touchpad_settings.dpi_variants.clone();
                     let selected_idx =
                         (self.touchpad_settings.dpi as usize).min(variants.len().saturating_sub(1));
@@ -167,10 +190,7 @@ impl EntropyApp {
                         ui,
                         content_width,
                         row_height,
-                        crate::i18n::tr_catalog(
-                            self.app_settings.language,
-                            "touchpad_settings.dpi",
-                        ),
+                        label,
                         true,
                         if suppress_tooltips {
                             None
@@ -180,8 +200,9 @@ impl EntropyApp {
                                 "touchpad_settings.touchpad_pointer_resolution_in_dots_per_inch",
                             ))
                         },
-                        dropdown_width,
+                        dropdown_width + status_width,
                         |ui| {
+                            self.draw_settings_write_status(ui, 120, metrics);
                             if variants.is_empty() {
                                 let current = self.touchpad_settings.dpi;
                                 let edit_id = egui::Id::new(("touchpad_edit", 120u16));
@@ -213,19 +234,13 @@ impl EntropyApp {
                                             let value = value.clamp(100, 1000);
                                             if value != current {
                                                 self.touchpad_settings.dpi = value;
-                                                if let Some(hid) = &self.hid_device {
-                                                    if let Err(e) =
-                                                        hid.set_qmk_setting_u16(120, value)
-                                                    {
-                                                        self.status_msg = format!(
-                                                            "Failed to save Touchpad setting (qsid 120): {}",
-                                                            e
-                                                        );
-                                                        log::warn!(
-                                                            "set_qmk_setting_u16(touchpad qsid 120) failed: {e}"
-                                                        );
-                                                    }
-                                                }
+                                                self.queue_touchpad_setting_write(
+                                                    label.to_owned(),
+                                                    120,
+                                                    2,
+                                                    current,
+                                                    value,
+                                                );
                                             }
                                             text = value.to_string();
                                         }
@@ -244,8 +259,14 @@ impl EntropyApp {
                                     dropdown_width,
                                 );
                                 if let Some(picked) = picked {
+                                    let old_value = self.touchpad_settings.dpi;
                                     self.touchpad_settings.dpi = picked as u16;
-                                    self.write_touchpad_select_setting(120, picked as u8);
+                                    self.write_touchpad_select_setting(
+                                        120,
+                                        old_value,
+                                        picked as u8,
+                                        label,
+                                    );
                                 }
                             }
                         },
@@ -307,8 +328,9 @@ impl EntropyApp {
                         } else {
                             Some(tooltip)
                         },
-                        slider_control_width,
+                        slider_control_width + status_width,
                         |ui| {
+                            self.draw_settings_write_status(ui, qsid, metrics);
                             ui.spacing_mut().item_spacing.x = 0.0;
                             let slider_fill = if dark {
                                 Color32::from_rgb(92, 92, 96)
@@ -351,7 +373,9 @@ impl EntropyApp {
                                                 as u16;
                                         if new_value != current {
                                             self.set_touchpad_numeric_value(qsid, new_value);
-                                            self.write_touchpad_numeric_setting(qsid, new_value);
+                                            self.write_touchpad_numeric_setting(
+                                                qsid, current, new_value, label,
+                                            );
                                         }
                                     }
                                 },
@@ -385,8 +409,10 @@ impl EntropyApp {
                         } else {
                             Some(tooltip)
                         },
-                        switch_width,
+                        switch_width + status_width,
                         |ui| {
+                            self.draw_settings_write_status(ui, 124, metrics);
+                            let old_bits = self.touchpad_settings.bits;
                             let mut value = self.touchpad_settings.bit(bit);
                             let resp = crate::ui_style::settings_switch_sized_stable(
                                 ui,
@@ -396,28 +422,30 @@ impl EntropyApp {
                             );
                             if resp.changed() {
                                 self.touchpad_settings.set_bit(bit, value);
-                                self.write_touchpad_bits();
+                                self.write_touchpad_bits(old_bits, label);
                             }
                         },
                     );
                 }
                 7 if self.touchpad_settings.auto_layer_enable_supported => {
+                    let label = crate::i18n::tr_catalog(
+                        self.app_settings.language,
+                        "touchpad_settings.auto_layer_enable",
+                    );
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
                         content_width,
                         row_height,
-                        crate::i18n::tr_catalog(
-                            self.app_settings.language,
-                            "touchpad_settings.auto_layer_enable",
-                        ),
+                        label,
                         true,
                         if suppress_tooltips {
                             None
                         } else {
                             Some(crate::i18n::tr_catalog(self.app_settings.language, "touchpad_settings.automatically_switch_to_the_selected_layer_while_the_touchpad_is_activ"))
                         },
-                        switch_width,
+                        switch_width + status_width,
                         |ui| {
+                            self.draw_settings_write_status(ui, 142, metrics);
                             let mut value = self.touchpad_settings.auto_layer_enable;
                             let resp = crate::ui_style::settings_switch_sized_stable(
                                 ui,
@@ -426,13 +454,18 @@ impl EntropyApp {
                                 switch_size,
                             );
                             if resp.changed() {
+                                let old_value = self.touchpad_settings.auto_layer_enable;
                                 self.touchpad_settings.auto_layer_enable = value;
-                                self.write_touchpad_bool_setting(142, value);
+                                self.write_touchpad_bool_setting(142, old_value, value, label);
                             }
                         },
                     );
                 }
                 8 if self.touchpad_settings.auto_layer_supported() => {
+                    let label = crate::i18n::tr_catalog(
+                        self.app_settings.language,
+                        "touchpad_settings.auto_layer",
+                    );
                     let variants = self.touchpad_settings.auto_layer_variants.clone();
                     let selected_idx = (self.touchpad_settings.auto_layer as usize)
                         .min(variants.len().saturating_sub(1));
@@ -440,10 +473,7 @@ impl EntropyApp {
                         ui,
                         content_width,
                         row_height,
-                        crate::i18n::tr_catalog(
-                            self.app_settings.language,
-                            "touchpad_settings.auto_layer",
-                        ),
+                        label,
                         true,
                         if suppress_tooltips {
                             None
@@ -453,8 +483,9 @@ impl EntropyApp {
                                 "touchpad_settings.layer_selected_automatically_while_the_touchpad_is_active",
                             ))
                         },
-                        dropdown_width,
+                        dropdown_width + status_width,
                         |ui| {
+                            self.draw_settings_write_status(ui, 143, metrics);
                             let dropdown_id = ui.make_persistent_id("touchpad_auto_layer_dropdown");
                             let (_, picked) = Self::draw_touchpad_select_control(
                                 ui,
@@ -465,8 +496,14 @@ impl EntropyApp {
                                 dropdown_width,
                             );
                             if let Some(picked) = picked {
+                                let old_value = self.touchpad_settings.auto_layer;
                                 self.touchpad_settings.auto_layer = picked as u8;
-                                self.write_touchpad_select_setting(143, picked as u8);
+                                self.write_touchpad_select_setting(
+                                    143,
+                                    old_value as u16,
+                                    picked as u8,
+                                    label,
+                                );
                             }
                         },
                     );
@@ -487,7 +524,7 @@ impl EntropyApp {
         let hid_ready = {
             #[cfg(not(target_arch = "wasm32"))]
             {
-                self.hid_device.is_some()
+                self.qmk_setting_transport_available()
             }
             #[cfg(target_arch = "wasm32")]
             {

--- a/src/ui/window_lifecycle.rs
+++ b/src/ui/window_lifecycle.rs
@@ -38,6 +38,14 @@ impl EntropyApp {
             return;
         }
 
+        // Keep unsaved state and its failure status for a later retry, but do
+        // not block close forever when no transport remains to drain it.
+        if self.hid_device.is_none() {
+            self.exit_after_hid_write = false;
+            ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+            return;
+        }
+
         self.flush_pending_tap_hold_numeric_writes();
         self.fallback_entropy_display_presets_before_exit();
 

--- a/src/ui/window_lifecycle.rs
+++ b/src/ui/window_lifecycle.rs
@@ -11,6 +11,16 @@ fn should_keep_vial_unlock_visible(unlock_open: bool, unlock_polling: bool) -> b
 
 impl EntropyApp {
     #[cfg(not(target_arch = "wasm32"))]
+    fn deferred_exit_has_pending_hid_writes(&self) -> bool {
+        self.keycode_picker.macros_dirty
+            || self.combo_dirty
+            || self.combo_term_dirty
+            || self.keycode_picker.tap_dance_dirty
+            || self.key_override_dirty
+            || !self.pending_tap_hold_numeric_writes.is_empty()
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
     pub(super) fn defer_exit_until_hid_write_returns(&mut self, ctx: &egui::Context) -> bool {
         if !self.hid_write_task_active() {
             return false;
@@ -28,9 +38,15 @@ impl EntropyApp {
             return;
         }
 
-        self.exit_after_hid_write = false;
         self.flush_pending_tap_hold_numeric_writes();
         self.fallback_entropy_display_presets_before_exit();
+
+        if self.deferred_exit_has_pending_hid_writes() {
+            ctx.request_repaint_after(std::time::Duration::from_millis(16));
+            return;
+        }
+
+        self.exit_after_hid_write = false;
         ctx.send_viewport_cmd(egui::ViewportCommand::Close);
     }
 


### PR DESCRIPTION
## EN

### Problem

Module and touchpad controls performed QMK HID writes synchronously inside UI callbacks. A slow write, retry, or readback could block Entropy for hundreds of milliseconds or longer and leave no clear indication whether firmware saved the value.

### Fix

- Move module and touchpad QMK setting writes to one serialized background queue per connected device.
- Keep one HID command in flight, preserve FIFO ordering, and return the HID handle before starting the next command.
- Verify each write with delayed firmware readback and expose per-setting Saving, Saved, or Failed state.
- Protect repeated writes to the same QSID so an older completion cannot overwrite newer pending UI state.
- Pause device scanning, switching, key assignment, whole-layer operations, and undo while the queue owns HID transport.
- Preserve detailed group, field, QSID, old value, requested value, and readback diagnostics.

Debouncing and coalescing rapid slider writes remain separate follow-up work.

### Verification

- `cargo test --locked`: 194 passed.
- `cargo test settings_write --locked`: 3 passed.
- `cargo clippy --locked --all-targets`: passed with existing repository warnings.
- `python3 scripts/check_i18n.py`: passed.
- Scoped `rustfmt` and `git diff --check`: passed.
- `TARGET=aarch64-apple-darwin scripts/build_macos_app.sh`: arm64 app, DMG, and ZIP built; plist and code-signature validation passed.
- Built executable verified as Mach-O 64-bit arm64.

## RU

### Проблема

Настройки модулей и тачпада выполняли QMK HID-запись синхронно внутри UI-callback. Медленная запись, повтор или контрольное чтение могли блокировать Entropy на сотни миллисекунд или дольше, при этом интерфейс не показывал, сохранила ли прошивка значение.

### Исправление

- Запись QMK-настроек модулей и тачпада перенесена в одну последовательную фоновую очередь для подключенного устройства.
- Одновременно выполняется только одна HID-команда; порядок FIFO сохраняется, а HID-handle возвращается перед запуском следующей команды.
- Каждая запись проверяется отложенным чтением из прошивки; для настройки показываются состояния Сохранение, Сохранено или Ошибка.
- Для повторных записей одного QSID старый результат больше не может перезаписать новое ожидающее состояние интерфейса.
- Пока очередь владеет HID-транспортом, приостанавливаются сканирование и переключение устройства, назначение клавиш, операции целого слоя и undo.
- В диагностике сохраняются группа, поле, QSID, старое и запрошенное значения, а также результат контрольного чтения.

Debounce и объединение быстрых изменений слайдера остаются отдельной следующей задачей.

### Проверка

- `cargo test --locked`: прошли 194 теста.
- `cargo test settings_write --locked`: прошли 3 теста.
- `cargo clippy --locked --all-targets`: прошел с существующими предупреждениями репозитория.
- `python3 scripts/check_i18n.py`: прошел.
- Scoped `rustfmt` и `git diff --check`: прошли.
- `TARGET=aarch64-apple-darwin scripts/build_macos_app.sh`: собраны arm64-приложение, DMG и ZIP; plist и подпись прошли проверку.
- Исполняемый файл проверен как Mach-O 64-bit arm64.