### PR TITLE
Debounce rapid QMK settings writes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,10 @@ jobs:
         if: matrix.kind == 'macos'
         run: TARGET="${{ matrix.target }}" scripts/build_macos_app.sh
 
+      - name: Test
+        if: matrix.kind == 'linux'
+        run: cargo test --all-targets
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/src/app.rs
+++ b/src/app.rs
@@ -139,6 +139,9 @@ mod module_settings_ui;
 mod mouse_keys_settings_ui;
 #[path = "ui/onboarding_tour.rs"]
 mod onboarding_tour;
+#[path = "ui/qmk_settings_write_queue.rs"]
+mod qmk_settings_write_queue;
+use qmk_settings_write_queue::QmkSettingsWriteQueue;
 #[path = "ui/rgb_settings.rs"]
 mod rgb_settings_ui;
 #[path = "ui/settings_shell.rs"]

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -37,8 +37,10 @@ impl EntropyApp {
             combo_write_task: None,
             settings_write_task: None,
             settings_write_queue: SettingsWriteQueueState::default(),
+            settings_write_generation: 0,
             #[cfg(not(target_arch = "wasm32"))]
             qmk_hid_hosts: std::collections::HashMap::new(),
+            pending_device_connect: None,
             firmware: FirmwareProtocol::Vial,
             undo_stack: Vec::new(),
             layer_clipboard: None,

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -32,6 +32,7 @@ impl EntropyApp {
             hid_device: None,
             #[cfg(not(target_arch = "wasm32"))]
             layer_write_task: None,
+            qmk_settings_write_queue: QmkSettingsWriteQueue::default(),
             #[cfg(not(target_arch = "wasm32"))]
             combo_write_task: None,
             settings_write_task: None,

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -2706,6 +2706,7 @@ pub struct EntropyApp {
     #[cfg(not(target_arch = "wasm32"))]
     pub(super) settings_write_task: Option<SettingsWriteTask>,
     pub(super) settings_write_queue: SettingsWriteQueueState,
+    pub(super) qmk_settings_write_queue: QmkSettingsWriteQueue,
     /// Built-in qmk-hid-host bridges for displays/presets that need host data
     #[cfg(not(target_arch = "wasm32"))]
     pub(crate) qmk_hid_hosts:

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -2706,7 +2706,9 @@ pub struct EntropyApp {
     #[cfg(not(target_arch = "wasm32"))]
     pub(super) settings_write_task: Option<SettingsWriteTask>,
     pub(super) settings_write_queue: SettingsWriteQueueState,
+    pub(super) settings_write_generation: u64,
     pub(super) qmk_settings_write_queue: QmkSettingsWriteQueue,
+    pub(super) pending_device_connect: Option<usize>,
     /// Built-in qmk-hid-host bridges for displays/presets that need host data
     #[cfg(not(target_arch = "wasm32"))]
     pub(crate) qmk_hid_hosts:

--- a/src/ui/about_device.rs
+++ b/src/ui/about_device.rs
@@ -614,7 +614,7 @@ impl EntropyApp {
                     button_size,
                 );
                 #[cfg(not(target_arch = "wasm32"))]
-                let refresh_enabled = !self.hid_write_task_active();
+                let refresh_enabled = !self.hid_write_lifecycle_busy();
                 #[cfg(target_arch = "wasm32")]
                 let refresh_enabled = true;
                 crate::ui_style::allocate_ui_at_rect(ui, actions_rect, |ui| {

--- a/src/ui/app_lifecycle.rs
+++ b/src/ui/app_lifecycle.rs
@@ -96,6 +96,7 @@ impl EntropyApp {
         selected_device_is_bluetooth: bool,
     ) {
         self.poll_settings_write(ctx);
+        self.flush_due_qmk_setting_writes();
         if should_poll_device_scan(main_window_hidden_to_tray) {
             if hid_lifecycle_writes_available(self.hid_write_task_active()) {
                 self.handle_pending_imports(ctx, now);
@@ -1579,6 +1580,7 @@ impl eframe::App for EntropyApp {
         }
 
         if !hid_write_task_active {
+            self.flush_due_qmk_setting_writes();
             self.flush_due_tap_hold_numeric_writes();
         }
 

--- a/src/ui/app_lifecycle.rs
+++ b/src/ui/app_lifecycle.rs
@@ -98,15 +98,15 @@ impl EntropyApp {
         self.poll_settings_write(ctx);
         self.flush_due_qmk_setting_writes();
         if should_poll_device_scan(main_window_hidden_to_tray) {
-            if hid_lifecycle_writes_available(self.hid_write_task_active()) {
+            if hid_lifecycle_writes_available(self.hid_write_lifecycle_busy()) {
                 self.handle_pending_imports(ctx, now);
             }
-            if !self.hid_write_task_active() {
+            if !self.hid_write_lifecycle_busy() {
                 self.poll_device_scan(ctx);
             }
 
             let is_connecting = matches!(self.connect_state, ConnectState::Loading { .. });
-            let hid_write_active = self.hid_write_task_active();
+            let hid_write_active = self.hid_write_lifecycle_busy();
             #[cfg(target_os = "macos")]
             let hid_session_active = self.hid_device.is_some();
             #[cfg(not(target_os = "macos"))]

--- a/src/ui/combo_write.rs
+++ b/src/ui/combo_write.rs
@@ -85,6 +85,11 @@ impl EntropyApp {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
+    pub(super) fn hid_write_lifecycle_busy(&self) -> bool {
+        self.hid_write_task_active() || self.qmk_settings_write_pending()
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
     pub(super) fn maybe_start_combo_write(&mut self, ctx: &egui::Context) {
         if self.hid_write_task_active()
             || self.combo_attempted_revision == Some(self.combo_edit_revision)
@@ -177,6 +182,7 @@ impl EntropyApp {
                 self.combo_write_task = None;
                 self.finish_combo_write(result);
                 self.continue_pending_settings_writes(ctx);
+                self.resume_pending_device_connect();
             }
             Err(std::sync::mpsc::TryRecvError::Empty) => {
                 ctx.request_repaint_after(std::time::Duration::from_millis(16));
@@ -202,6 +208,7 @@ impl EntropyApp {
                     )],
                 );
                 self.continue_pending_settings_writes(ctx);
+                self.resume_pending_device_connect();
             }
         }
     }

--- a/src/ui/combo_write.rs
+++ b/src/ui/combo_write.rs
@@ -81,8 +81,7 @@ impl EntropyApp {
 
     #[cfg(not(target_arch = "wasm32"))]
     pub(super) fn hid_write_task_active(&self) -> bool {
-        self.hid_write_task_owner_active()
-            || !self.settings_write_queue.is_empty()
+        self.hid_write_task_owner_active() || !self.settings_write_queue.is_empty()
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/src/ui/combo_write.rs
+++ b/src/ui/combo_write.rs
@@ -81,7 +81,8 @@ impl EntropyApp {
 
     #[cfg(not(target_arch = "wasm32"))]
     pub(super) fn hid_write_task_active(&self) -> bool {
-        self.hid_write_task_owner_active() || !self.settings_write_queue.is_empty()
+        self.hid_write_task_owner_active()
+            || !self.settings_write_queue.is_empty()
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/src/ui/device_connect_task.rs
+++ b/src/ui/device_connect_task.rs
@@ -486,9 +486,17 @@ impl EntropyApp {
 
     pub(super) fn start_connect(&mut self, device_idx: usize) {
         if self.hid_write_task_active() {
+            self.pending_device_connect = Some(device_idx);
             return;
         }
-        self.cancel_pending_qmk_setting_writes();
+        if self.qmk_settings_write_pending() {
+            self.pending_device_connect = Some(device_idx);
+            self.flush_pending_qmk_setting_writes();
+            if self.qmk_settings_write_busy() {
+                return;
+            }
+        }
+        self.pending_device_connect = None;
         let dev = match self.device_manager.devices().get(device_idx) {
             Some(d) => d.clone(),
             None => {
@@ -505,7 +513,7 @@ impl EntropyApp {
         self.layer_write_task = None;
         self.combo_write_task = None;
         self.settings_write_task = None;
-        self.settings_write_queue.clear();
+        self.reset_settings_write_context();
         self.qmk_settings_write_queue.clear();
         self.hid_device = None;
         self.undo_stack.clear();
@@ -1358,6 +1366,15 @@ impl EntropyApp {
 
             let _ = tx.send(ConnectTaskMessage::Done(Box::new(result)));
         });
+    }
+
+    pub(super) fn resume_pending_device_connect(&mut self) {
+        if self.layer_write_task.is_some() || self.qmk_settings_write_busy() {
+            return;
+        }
+        if let Some(device_idx) = self.pending_device_connect.take() {
+            self.start_connect(device_idx);
+        }
     }
 }
 

--- a/src/ui/device_connect_task.rs
+++ b/src/ui/device_connect_task.rs
@@ -488,6 +488,7 @@ impl EntropyApp {
         if self.hid_write_task_active() {
             return;
         }
+        self.cancel_pending_qmk_setting_writes();
         let dev = match self.device_manager.devices().get(device_idx) {
             Some(d) => d.clone(),
             None => {
@@ -505,6 +506,7 @@ impl EntropyApp {
         self.combo_write_task = None;
         self.settings_write_task = None;
         self.settings_write_queue.clear();
+        self.qmk_settings_write_queue.clear();
         self.hid_device = None;
         self.undo_stack.clear();
         self.device_about_info = None;

--- a/src/ui/device_connect_task.rs
+++ b/src/ui/device_connect_task.rs
@@ -446,7 +446,7 @@ fn supports_vial_macro_ext_keycodes(vial_protocol: u32, json: &serde_json::Value
 impl EntropyApp {
     pub(super) fn refresh_current_device_data(&mut self) {
         let lang = self.app_settings.language;
-        if self.hid_write_task_active() {
+        if self.hid_write_lifecycle_busy() {
             self.status_msg =
                 crate::i18n::tr_catalog(lang, "status_messages.refresh_device_data_pending_write")
                     .to_owned();

--- a/src/ui/device_connection.rs
+++ b/src/ui/device_connection.rs
@@ -34,6 +34,8 @@ impl EntropyApp {
         self.combo_write_task = None;
         self.settings_write_task = None;
         self.settings_write_queue.clear();
+        self.cancel_pending_qmk_setting_writes();
+        self.qmk_settings_write_queue.clear();
         self.hid_device = None;
         self.undo_stack.clear();
         self.connect_state = ConnectState::Idle;

--- a/src/ui/device_connection.rs
+++ b/src/ui/device_connection.rs
@@ -33,9 +33,10 @@ impl EntropyApp {
         self.layer_write_task = None;
         self.combo_write_task = None;
         self.settings_write_task = None;
-        self.settings_write_queue.clear();
+        self.reset_settings_write_context();
         self.cancel_pending_qmk_setting_writes();
         self.qmk_settings_write_queue.clear();
+        self.pending_device_connect = None;
         self.hid_device = None;
         self.undo_stack.clear();
         self.connect_state = ConnectState::Idle;

--- a/src/ui/layer_operations.rs
+++ b/src/ui/layer_operations.rs
@@ -987,6 +987,7 @@ impl EntropyApp {
                 self.layer_write_task = None;
                 self.finish_layer_write(result);
                 self.continue_pending_settings_writes(ctx);
+                self.resume_pending_device_connect();
             }
             Err(std::sync::mpsc::TryRecvError::Empty) => {
                 ctx.request_repaint_after(std::time::Duration::from_millis(16));
@@ -1015,6 +1016,7 @@ impl EntropyApp {
                     ],
                 );
                 self.continue_pending_settings_writes(ctx);
+                self.resume_pending_device_connect();
             }
         }
     }

--- a/src/ui/layout_device_dropdown.rs
+++ b/src/ui/layout_device_dropdown.rs
@@ -150,7 +150,7 @@ impl EntropyApp {
                                     {
                                         let is_selected = self.selected_device == Some(i);
                                         #[cfg(not(target_arch = "wasm32"))]
-                                        let switch_enabled = !self.hid_write_task_active();
+                                        let switch_enabled = !self.hid_write_lifecycle_busy();
                                         #[cfg(target_arch = "wasm32")]
                                         let switch_enabled = true;
                                         let cached_display_name = self

--- a/src/ui/layout_top_tabs.rs
+++ b/src/ui/layout_top_tabs.rs
@@ -205,7 +205,7 @@ impl EntropyApp {
         self.draw_ui_scale_controls(ui, zoom_left_top);
 
         #[cfg(not(target_arch = "wasm32"))]
-        let undo_enabled = !self.undo_stack.is_empty() && !self.hid_write_task_active();
+        let undo_enabled = !self.undo_stack.is_empty() && !self.hid_write_lifecycle_busy();
         #[cfg(target_arch = "wasm32")]
         let undo_enabled = !self.undo_stack.is_empty();
         let undo_resp = ui.allocate_rect(undo_rect, Sense::CLICK);

--- a/src/ui/module_settings.rs
+++ b/src/ui/module_settings.rs
@@ -103,7 +103,7 @@ impl EntropyApp {
 
     fn write_module_setting_value(
         &mut self,
-        ctx: &egui::Context,
+        _ctx: &egui::Context,
         group_idx: usize,
         field: &ModuleSettingField,
         value: u16,

--- a/src/ui/module_settings.rs
+++ b/src/ui/module_settings.rs
@@ -103,6 +103,7 @@ impl EntropyApp {
 
     fn write_module_setting_value(
         &mut self,
+        ctx: &egui::Context,
         group_idx: usize,
         field: &ModuleSettingField,
         value: u16,
@@ -186,7 +187,7 @@ impl EntropyApp {
                             } else {
                                 raw_value & !mask
                             };
-                            self.write_module_setting_value(group_idx, &field, new_value);
+                            self.write_module_setting_value(ui.ctx(), group_idx, &field, new_value);
                         }
                     },
                 );
@@ -231,7 +232,12 @@ impl EntropyApp {
                                 Ok(value) => {
                                     let value = value.clamp(field.min, field.max);
                                     if value != raw_value {
-                                        self.write_module_setting_value(group_idx, &field, value);
+                                        self.write_module_setting_value(
+                                            ui.ctx(),
+                                            group_idx,
+                                            &field,
+                                            value,
+                                        );
                                     }
                                     text = value.to_string();
                                 }
@@ -274,7 +280,12 @@ impl EntropyApp {
                             dropdown_width,
                         );
                         if let Some(picked) = picked {
-                            self.write_module_setting_value(group_idx, &field, picked as u16);
+                            self.write_module_setting_value(
+                                ui.ctx(),
+                                group_idx,
+                                &field,
+                                picked as u16,
+                            );
                         }
                     },
                 );

--- a/src/ui/qmk_settings_write_queue.rs
+++ b/src/ui/qmk_settings_write_queue.rs
@@ -1,0 +1,166 @@
+use super::*;
+
+const QMK_SETTINGS_WRITE_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(180);
+
+#[derive(Clone, Debug)]
+struct QmkSettingWriteRequest {
+    qsid: u16,
+    old_value: u16,
+    requested: u16,
+    due_at: std::time::Instant,
+    display_label: String,
+}
+
+#[derive(Default)]
+pub(super) struct QmkSettingsWriteQueue {
+    pending: std::collections::BTreeMap<u16, QmkSettingWriteRequest>,
+}
+
+impl QmkSettingsWriteQueue {
+    fn enqueue(&mut self, mut request: QmkSettingWriteRequest) -> bool {
+        if let Some(previous) = self.pending.get(&request.qsid) {
+            // Keep the confirmed pre-burst value so returning to it cancels the write.
+            request.old_value = previous.old_value;
+        }
+        if request.requested == request.old_value {
+            self.pending.remove(&request.qsid);
+            return false;
+        }
+        self.pending.insert(request.qsid, request);
+        true
+    }
+
+    fn take_due(&mut self, now: std::time::Instant) -> Vec<QmkSettingWriteRequest> {
+        let due_qsids = self
+            .pending
+            .iter()
+            .filter_map(|(qsid, request)| (request.due_at <= now).then_some(*qsid))
+            .collect::<Vec<_>>();
+        due_qsids
+            .into_iter()
+            .filter_map(|qsid| self.pending.remove(&qsid))
+            .collect()
+    }
+
+    fn take_all(&mut self) -> Vec<QmkSettingWriteRequest> {
+        std::mem::take(&mut self.pending).into_values().collect()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.pending.is_empty()
+    }
+
+    pub(super) fn clear(&mut self) {
+        self.pending.clear();
+    }
+}
+
+impl EntropyApp {
+    pub(super) fn qmk_settings_write_pending(&self) -> bool {
+        !self.qmk_settings_write_queue.is_empty()
+    }
+
+    pub(super) fn debounce_touchpad_setting_write(
+        &mut self,
+        ctx: &egui::Context,
+        display_label: String,
+        qsid: u16,
+        old_value: u16,
+        requested: u16,
+    ) {
+        let request = QmkSettingWriteRequest {
+            qsid,
+            old_value,
+            requested,
+            due_at: std::time::Instant::now() + QMK_SETTINGS_WRITE_DEBOUNCE,
+            display_label,
+        };
+        if self.qmk_settings_write_queue.enqueue(request) {
+            ctx.request_repaint_after(QMK_SETTINGS_WRITE_DEBOUNCE);
+        }
+    }
+
+    pub(super) fn flush_due_qmk_setting_writes(&mut self) {
+        let requests = self
+            .qmk_settings_write_queue
+            .take_due(std::time::Instant::now());
+        for request in requests {
+            // The worker queue owns the HID handle and retains this request while a
+            // layer write is in flight. It also provides verified readback.
+            self.queue_touchpad_setting_write(
+                request.display_label,
+                request.qsid,
+                1,
+                request.old_value,
+                request.requested,
+            );
+        }
+    }
+
+    pub(super) fn cancel_pending_qmk_setting_writes(&mut self) {
+        for request in self.qmk_settings_write_queue.take_all() {
+            self.set_touchpad_numeric_value(request.qsid, request.old_value);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request(
+        qsid: u16,
+        old_value: u16,
+        requested: u16,
+        due_at: std::time::Instant,
+    ) -> QmkSettingWriteRequest {
+        QmkSettingWriteRequest {
+            qsid,
+            old_value,
+            requested,
+            due_at,
+            display_label: "Scroll sensitivity".to_owned(),
+        }
+    }
+
+    #[test]
+    fn repeated_qsid_write_keeps_only_latest_value() {
+        let now = std::time::Instant::now();
+        let mut queue = QmkSettingsWriteQueue::default();
+        queue.enqueue(request(122, 8, 9, now + QMK_SETTINGS_WRITE_DEBOUNCE));
+        queue.enqueue(request(
+            122,
+            9,
+            12,
+            now + QMK_SETTINGS_WRITE_DEBOUNCE + std::time::Duration::from_millis(60),
+        ));
+
+        assert!(queue.take_due(now + QMK_SETTINGS_WRITE_DEBOUNCE).is_empty());
+        let writes = queue.take_due(now + QMK_SETTINGS_WRITE_DEBOUNCE + std::time::Duration::from_millis(60));
+        assert_eq!(writes.len(), 1);
+        assert_eq!(writes[0].old_value, 8);
+        assert_eq!(writes[0].requested, 12);
+    }
+
+    #[test]
+    fn returning_to_original_value_cancels_pending_write() {
+        let now = std::time::Instant::now();
+        let mut queue = QmkSettingsWriteQueue::default();
+        assert!(queue.enqueue(request(123, 10, 12, now)));
+        assert!(!queue.enqueue(request(123, 12, 10, now)));
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn cancellation_returns_all_pending_requests() {
+        let now = std::time::Instant::now();
+        let mut queue = QmkSettingsWriteQueue::default();
+        queue.enqueue(request(121, 8, 9, now));
+        queue.enqueue(request(122, 10, 12, now));
+
+        let requests = queue.take_all();
+
+        assert_eq!(requests.len(), 2);
+        assert!(queue.is_empty());
+    }
+}

--- a/src/ui/qmk_settings_write_queue.rs
+++ b/src/ui/qmk_settings_write_queue.rs
@@ -50,6 +50,10 @@ impl QmkSettingsWriteQueue {
         self.pending.is_empty()
     }
 
+    fn pending_value(&self, qsid: u16) -> Option<u16> {
+        self.pending.get(&qsid).map(|request| request.requested)
+    }
+
     pub(super) fn clear(&mut self) {
         self.pending.clear();
     }
@@ -58,6 +62,10 @@ impl QmkSettingsWriteQueue {
 impl EntropyApp {
     pub(super) fn qmk_settings_write_pending(&self) -> bool {
         !self.qmk_settings_write_queue.is_empty()
+    }
+
+    pub(super) fn pending_qmk_settings_write_value(&self, qsid: u16) -> Option<u16> {
+        self.qmk_settings_write_queue.pending_value(qsid)
     }
 
     pub(super) fn debounce_touchpad_setting_write(
@@ -84,7 +92,29 @@ impl EntropyApp {
         let requests = self
             .qmk_settings_write_queue
             .take_due(std::time::Instant::now());
+        self.enqueue_debounced_qmk_setting_writes(requests);
+    }
+
+    pub(super) fn flush_pending_qmk_setting_writes(&mut self) {
+        let requests = self.qmk_settings_write_queue.take_all();
+        self.enqueue_debounced_qmk_setting_writes(requests);
+    }
+
+    fn enqueue_debounced_qmk_setting_writes(&mut self, requests: Vec<QmkSettingWriteRequest>) {
         for request in requests {
+            if !self.qmk_setting_transport_available() {
+                self.set_touchpad_numeric_value(request.qsid, request.old_value);
+                let error = crate::i18n::tr_catalog(
+                    self.app_settings.language,
+                    "settings_write.device_not_connected",
+                );
+                self.status_msg = crate::i18n::tr_catalog_format(
+                    self.app_settings.language,
+                    "settings_write.failed_status",
+                    &[("setting", &request.display_label), ("error", error)],
+                );
+                continue;
+            }
             // The worker queue owns the HID handle and retains this request while a
             // layer write is in flight. It also provides verified readback.
             self.queue_touchpad_setting_write(
@@ -107,6 +137,12 @@ impl EntropyApp {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_app() -> EntropyApp {
+        let ctx = egui::Context::default();
+        let creation_context = eframe::CreationContext::_new_kittest(ctx);
+        EntropyApp::new(&creation_context)
+    }
 
     fn request(
         qsid: u16,
@@ -136,7 +172,8 @@ mod tests {
         ));
 
         assert!(queue.take_due(now + QMK_SETTINGS_WRITE_DEBOUNCE).is_empty());
-        let writes = queue.take_due(now + QMK_SETTINGS_WRITE_DEBOUNCE + std::time::Duration::from_millis(60));
+        let writes = queue
+            .take_due(now + QMK_SETTINGS_WRITE_DEBOUNCE + std::time::Duration::from_millis(60));
         assert_eq!(writes.len(), 1);
         assert_eq!(writes[0].old_value, 8);
         assert_eq!(writes[0].requested, 12);
@@ -162,5 +199,72 @@ mod tests {
 
         assert_eq!(requests.len(), 2);
         assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn cancellation_restores_confirmed_touchpad_value() {
+        let mut app = test_app();
+        app.touchpad_settings.scroll_sens = 12;
+        app.qmk_settings_write_queue
+            .enqueue(request(122, 8, 12, std::time::Instant::now()));
+
+        app.cancel_pending_qmk_setting_writes();
+
+        assert_eq!(app.touchpad_settings.scroll_sens, 8);
+        assert!(!app.qmk_settings_write_pending());
+    }
+
+    #[test]
+    fn device_switch_cancels_debounced_write_before_selecting_next_device() {
+        let mut app = test_app();
+        app.touchpad_settings.scroll_sens = 12;
+        app.qmk_settings_write_queue
+            .enqueue(request(122, 8, 12, std::time::Instant::now()));
+
+        app.start_connect(usize::MAX);
+
+        assert_eq!(app.touchpad_settings.scroll_sens, 8);
+        assert!(!app.qmk_settings_write_pending());
+    }
+
+    #[test]
+    fn disconnect_clears_debounced_write_before_resetting_device_state() {
+        let mut app = test_app();
+        app.qmk_settings_write_queue
+            .enqueue(request(122, 8, 12, std::time::Instant::now()));
+
+        app.clear_connected_keyboard_state("device disconnected");
+
+        assert!(!app.qmk_settings_write_pending());
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn debounced_write_waits_in_background_queue_while_hid_is_owned() {
+        let mut app = test_app();
+        app.start_settings_write_for_test();
+        app.qmk_settings_write_queue
+            .enqueue(request(122, 8, 12, std::time::Instant::now()));
+
+        app.flush_pending_qmk_setting_writes();
+
+        assert_eq!(app.pending_settings_write_value(122), Some(12));
+        assert!(!app.qmk_settings_write_pending());
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn device_switch_waits_for_active_settings_write() {
+        let ctx = egui::Context::default();
+        let mut app = test_app();
+        app.start_settings_write_for_test();
+
+        app.start_connect(usize::MAX);
+        assert_eq!(app.pending_device_connect, Some(usize::MAX));
+
+        app.poll_settings_write(&ctx);
+
+        assert!(app.pending_device_connect.is_none());
+        assert_eq!(app.status_msg, "Device not found");
     }
 }

--- a/src/ui/qmk_settings_write_queue.rs
+++ b/src/ui/qmk_settings_write_queue.rs
@@ -144,6 +144,29 @@ mod tests {
         EntropyApp::new(&creation_context)
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
+    fn drain_hid_writes(app: &mut EntropyApp, ctx: &egui::Context) {
+        for _ in 0..200 {
+            app.poll_layer_write(ctx);
+            app.poll_combo_write(ctx);
+            app.poll_settings_write(ctx);
+            if !app.hid_write_task_active() {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+        panic!("HID write tasks did not drain");
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn qsid_request_count(recorder: &crate::hid::TestHidRecorder, qsid: u16) -> usize {
+        recorder
+            .requests()
+            .iter()
+            .filter(|request| request[2] == qsid as u8 && request[3] == (qsid >> 8) as u8)
+            .count()
+    }
+
     fn request(
         qsid: u16,
         old_value: u16,
@@ -215,7 +238,7 @@ mod tests {
     }
 
     #[test]
-    fn device_switch_cancels_debounced_write_before_selecting_next_device() {
+    fn device_switch_cancels_debounced_write_without_transport() {
         let mut app = test_app();
         app.touchpad_settings.scroll_sens = 12;
         app.qmk_settings_write_queue
@@ -228,43 +251,86 @@ mod tests {
     }
 
     #[test]
-    fn disconnect_clears_debounced_write_before_resetting_device_state() {
+    fn disconnect_then_reconnect_cancels_old_debounce_and_writes_new_value() {
         let mut app = test_app();
+        app.touchpad_settings.scroll_sens = 12;
         app.qmk_settings_write_queue
             .enqueue(request(122, 8, 12, std::time::Instant::now()));
 
         app.clear_connected_keyboard_state("device disconnected");
 
         assert!(!app.qmk_settings_write_pending());
+        assert_eq!(app.touchpad_settings.scroll_sens, 8);
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let ctx = egui::Context::default();
+            let (hid_device, recorder) = crate::hid::HidDevice::test_device();
+            app.hid_device = Some(hid_device);
+            app.touchpad_settings.scroll_sens = 14;
+            app.qmk_settings_write_queue
+                .enqueue(request(122, 8, 14, std::time::Instant::now()));
+            app.flush_pending_qmk_setting_writes();
+            drain_hid_writes(&mut app, &ctx);
+
+            assert_eq!(app.touchpad_settings.scroll_sens, 14);
+            assert_eq!(qsid_request_count(&recorder, 122), 2);
+        }
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
-    fn debounced_write_waits_in_background_queue_while_hid_is_owned() {
+    fn debounced_write_waits_for_combo_then_writes_only_newest_value() {
+        let ctx = egui::Context::default();
         let mut app = test_app();
-        app.start_settings_write_for_test();
-        app.qmk_settings_write_queue
-            .enqueue(request(122, 8, 12, std::time::Instant::now()));
+        let (hid_device, recorder) = crate::hid::HidDevice::test_device();
+        app.hid_device = Some(hid_device);
+        app.combo_entries = vec![ComboEntry {
+            keys: [0x0004, 0x0005, 0, 0],
+            output: 0x0006,
+        }];
+        app.combo_synced_entries = vec![ComboEntry::default()];
+        app.mark_combo_dirty();
+        app.maybe_start_combo_write(&ctx);
+        assert!(app.combo_write_task.is_some());
 
-        app.flush_pending_qmk_setting_writes();
+        app.qmk_settings_write_queue
+            .enqueue(request(122, 8, 9, std::time::Instant::now()));
+        app.qmk_settings_write_queue
+            .enqueue(request(122, 9, 12, std::time::Instant::now()));
+
+        app.flush_due_qmk_setting_writes();
 
         assert_eq!(app.pending_settings_write_value(122), Some(12));
         assert!(!app.qmk_settings_write_pending());
+        drain_hid_writes(&mut app, &ctx);
+
+        assert_eq!(
+            app.settings_write_queue.status(122),
+            Some(&SettingsWriteStatus::Saved)
+        );
+        assert_eq!(app.touchpad_settings.scroll_sens, 12);
+        assert_eq!(qsid_request_count(&recorder, 122), 2);
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
-    fn device_switch_waits_for_active_settings_write() {
+    fn device_switch_waits_for_real_debounced_settings_write() {
         let ctx = egui::Context::default();
         let mut app = test_app();
-        app.start_settings_write_for_test();
+        let (hid_device, recorder) = crate::hid::HidDevice::test_device();
+        app.hid_device = Some(hid_device);
+        app.qmk_settings_write_queue
+            .enqueue(request(122, 8, 12, std::time::Instant::now()));
 
         app.start_connect(usize::MAX);
         assert_eq!(app.pending_device_connect, Some(usize::MAX));
+        assert!(app.settings_write_task.is_some());
 
-        app.poll_settings_write(&ctx);
+        drain_hid_writes(&mut app, &ctx);
 
         assert!(app.pending_device_connect.is_none());
         assert_eq!(app.status_msg, "Device not found");
+        assert_eq!(qsid_request_count(&recorder, 122), 2);
     }
 }

--- a/src/ui/qmk_settings_write_queue.rs
+++ b/src/ui/qmk_settings_write_queue.rs
@@ -14,14 +14,18 @@ struct QmkSettingWriteRequest {
 #[derive(Default)]
 pub(super) struct QmkSettingsWriteQueue {
     pending: std::collections::BTreeMap<u16, QmkSettingWriteRequest>,
+    confirmed_values: std::collections::BTreeMap<u16, u16>,
 }
 
 impl QmkSettingsWriteQueue {
     fn enqueue(&mut self, mut request: QmkSettingWriteRequest) -> bool {
-        if let Some(previous) = self.pending.get(&request.qsid) {
-            // Keep the confirmed pre-burst value so returning to it cancels the write.
-            request.old_value = previous.old_value;
-        }
+        let confirmed_value = *self
+            .confirmed_values
+            .entry(request.qsid)
+            .or_insert(request.old_value);
+        // Keep the last verified pre-burst value. An active worker may not have
+        // reached readback yet, so its optimistic value is not safe to restore.
+        request.old_value = confirmed_value;
         if request.requested == request.old_value {
             self.pending.remove(&request.qsid);
             return false;
@@ -54,8 +58,20 @@ impl QmkSettingsWriteQueue {
         self.pending.get(&qsid).map(|request| request.requested)
     }
 
+    pub(super) fn record_confirmed_value(&mut self, qsid: u16, value: u16) {
+        self.confirmed_values.insert(qsid, value);
+        let discard_pending = self.pending.get_mut(&qsid).is_some_and(|request| {
+            request.old_value = value;
+            request.requested == value
+        });
+        if discard_pending {
+            self.pending.remove(&qsid);
+        }
+    }
+
     pub(super) fn clear(&mut self) {
         self.pending.clear();
+        self.confirmed_values.clear();
     }
 }
 
@@ -137,6 +153,7 @@ impl EntropyApp {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::settings_write_queue::SettingsWriteStatus;
 
     fn test_app() -> EntropyApp {
         let ctx = egui::Context::default();
@@ -260,7 +277,7 @@ mod tests {
         app.clear_connected_keyboard_state("device disconnected");
 
         assert!(!app.qmk_settings_write_pending());
-        assert_eq!(app.touchpad_settings.scroll_sens, 8);
+        assert_eq!(app.touchpad_settings.scroll_sens, 0);
 
         #[cfg(not(target_arch = "wasm32"))]
         {
@@ -306,7 +323,7 @@ mod tests {
         drain_hid_writes(&mut app, &ctx);
 
         assert_eq!(
-            app.settings_write_queue.status(122),
+            app.settings_write_status(122),
             Some(&SettingsWriteStatus::Saved)
         );
         assert_eq!(app.touchpad_settings.scroll_sens, 12);
@@ -332,5 +349,40 @@ mod tests {
         assert!(app.pending_device_connect.is_none());
         assert_eq!(app.status_msg, "Device not found");
         assert_eq!(qsid_request_count(&recorder, 122), 2);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn active_worker_disconnect_restores_last_confirmed_debounced_value() {
+        let ctx = egui::Context::default();
+        let mut app = test_app();
+        let (hid_device, _) = crate::hid::HidDevice::test_device_with_fault_after_requests(Some((
+            1,
+            crate::hid::TestHidFault::Disconnect,
+        )));
+        app.hid_device = Some(hid_device);
+        app.touchpad_settings.scroll_sens = 10;
+
+        app.debounce_touchpad_setting_write(&ctx, "Scroll sensitivity".to_owned(), 122, 8, 10);
+        app.flush_pending_qmk_setting_writes();
+        assert!(app.settings_write_task.is_some());
+
+        app.touchpad_settings.scroll_sens = 12;
+        app.debounce_touchpad_setting_write(&ctx, "Scroll sensitivity".to_owned(), 122, 10, 12);
+
+        for _ in 0..200 {
+            app.poll_settings_write(&ctx);
+            if app.hid_device.is_none() && app.settings_write_task.is_none() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+        assert!(app.hid_device.is_none());
+        assert!(app.settings_write_task.is_none());
+
+        app.flush_pending_qmk_setting_writes();
+
+        assert_eq!(app.touchpad_settings.scroll_sens, 8);
+        assert!(!app.qmk_settings_write_pending());
     }
 }

--- a/src/ui/settings_write_queue.rs
+++ b/src/ui/settings_write_queue.rs
@@ -46,6 +46,10 @@ impl SettingsWriteTarget {
         }
     }
 
+    fn is_touchpad(&self) -> bool {
+        matches!(self, Self::Touchpad { .. })
+    }
+
     fn reconcile_readback(
         &self,
         module_settings: &mut ModuleSettingsState,
@@ -519,6 +523,10 @@ impl EntropyApp {
         let newer_debounced_value = self.pending_qmk_settings_write_value(request.qsid);
         match result {
             Ok(readback) => {
+                if request.target.is_touchpad() {
+                    self.qmk_settings_write_queue
+                        .record_confirmed_value(request.qsid, readback);
+                }
                 let current = self.settings_write_queue.complete(
                     request.id,
                     request.qsid,
@@ -546,6 +554,12 @@ impl EntropyApp {
                 );
             }
             Err(error) => {
+                if request.target.is_touchpad() {
+                    if let ModuleSettingWritebackError::ReadbackMismatch { actual, .. } = &error {
+                        self.qmk_settings_write_queue
+                            .record_confirmed_value(request.qsid, *actual);
+                    }
+                }
                 let error_text = error.to_string();
                 let current = self.settings_write_queue.complete(
                     request.id,
@@ -606,7 +620,6 @@ impl EntropyApp {
         self.settings_write_generation = self.settings_write_generation.wrapping_add(1);
         self.settings_write_queue.clear();
     }
-
 }
 
 #[cfg(test)]
@@ -837,5 +850,56 @@ mod tests {
 
         assert_eq!(app.touchpad_settings.scroll_sens, 12);
         assert_eq!(app.pending_qmk_settings_write_value(122), Some(12));
+    }
+
+    #[test]
+    fn confirmed_readback_updates_pending_debounce_rollback_value() {
+        let ctx = egui::Context::default();
+        let mut app = test_app();
+        app.touchpad_settings.scroll_sens = 12;
+        app.debounce_touchpad_setting_write(&ctx, "Scroll sensitivity".to_owned(), 122, 8, 12);
+        app.settings_write_queue.enqueue(request(122, 10));
+        let request = app
+            .settings_write_queue
+            .pop_front()
+            .expect("queued setting write");
+
+        app.finish_settings_write(SettingsWriteResult {
+            hid_device: None,
+            request,
+            result: Ok(10),
+            disconnected: false,
+        });
+        app.flush_pending_qmk_setting_writes();
+
+        assert_eq!(app.touchpad_settings.scroll_sens, 10);
+        assert!(!app.qmk_settings_write_pending());
+    }
+
+    #[test]
+    fn readback_mismatch_updates_pending_debounce_rollback_value() {
+        let ctx = egui::Context::default();
+        let mut app = test_app();
+        app.touchpad_settings.scroll_sens = 12;
+        app.debounce_touchpad_setting_write(&ctx, "Scroll sensitivity".to_owned(), 122, 8, 12);
+        app.settings_write_queue.enqueue(request(122, 10));
+        let request = app
+            .settings_write_queue
+            .pop_front()
+            .expect("queued setting write");
+
+        app.finish_settings_write(SettingsWriteResult {
+            hid_device: None,
+            request,
+            result: Err(ModuleSettingWritebackError::ReadbackMismatch {
+                expected: 10,
+                actual: 9,
+            }),
+            disconnected: false,
+        });
+        app.flush_pending_qmk_setting_writes();
+
+        assert_eq!(app.touchpad_settings.scroll_sens, 9);
+        assert!(!app.qmk_settings_write_pending());
     }
 }

--- a/src/ui/settings_write_queue.rs
+++ b/src/ui/settings_write_queue.rs
@@ -72,6 +72,7 @@ impl SettingsWriteTarget {
 #[derive(Clone, Debug)]
 struct SettingsWriteRequest {
     id: u64,
+    generation: u64,
     qsid: u16,
     width: u8,
     old_value: u16,
@@ -261,7 +262,10 @@ impl EntropyApp {
             metrics.settings_control_height(),
         );
         let (rect, response) = ui.allocate_exact_size(size, egui::Sense::hover());
-        let status = self.settings_write_queue.status(qsid).cloned();
+        let status = self
+            .pending_qmk_settings_write_value(qsid)
+            .map(|_| SettingsWriteStatus::Pending)
+            .or_else(|| self.settings_write_queue.status(qsid).cloned());
         let tooltip = match status.as_ref() {
             Some(SettingsWriteStatus::Pending) => {
                 ui.put(
@@ -321,6 +325,7 @@ impl EntropyApp {
     ) {
         self.queue_settings_write(SettingsWriteRequest {
             id: 0,
+            generation: self.settings_write_generation,
             qsid,
             width,
             old_value,
@@ -343,6 +348,7 @@ impl EntropyApp {
     ) {
         self.queue_settings_write(SettingsWriteRequest {
             id: 0,
+            generation: self.settings_write_generation,
             qsid,
             width,
             old_value,
@@ -458,6 +464,7 @@ impl EntropyApp {
                 self.settings_write_task = None;
                 self.finish_settings_write(result);
                 self.continue_pending_settings_writes(ctx);
+                self.resume_pending_device_connect();
             }
             Err(std::sync::mpsc::TryRecvError::Empty) => {
                 ctx.request_repaint_after(std::time::Duration::from_millis(16));
@@ -467,6 +474,9 @@ impl EntropyApp {
                     .settings_write_task
                     .take()
                     .expect("settings write task checked above");
+                if task.request.generation != self.settings_write_generation {
+                    return;
+                }
                 self.hid_device = None;
                 let error = crate::i18n::tr_catalog(
                     self.app_settings.language,
@@ -488,6 +498,7 @@ impl EntropyApp {
                     ],
                 );
                 self.continue_pending_settings_writes(ctx);
+                self.resume_pending_device_connect();
             }
         }
     }
@@ -500,8 +511,12 @@ impl EntropyApp {
             result,
             disconnected,
         } = result;
+        if request.generation != self.settings_write_generation {
+            return;
+        }
         self.hid_device = hid_device;
         let context = request.target.log_context();
+        let newer_debounced_value = self.pending_qmk_settings_write_value(request.qsid);
         match result {
             Ok(readback) => {
                 let current = self.settings_write_queue.complete(
@@ -509,7 +524,7 @@ impl EntropyApp {
                     request.qsid,
                     SettingsWriteStatus::Saved,
                 );
-                if current {
+                if current && newer_debounced_value.is_none() {
                     request.target.reconcile_readback(
                         &mut self.module_settings,
                         &mut self.touchpad_settings,
@@ -537,7 +552,7 @@ impl EntropyApp {
                     request.qsid,
                     SettingsWriteStatus::Failed(error_text.clone()),
                 );
-                if current {
+                if current && newer_debounced_value.is_none() {
                     if let ModuleSettingWritebackError::ReadbackMismatch { actual, .. } = &error {
                         request.target.reconcile_readback(
                             &mut self.module_settings,
@@ -586,6 +601,12 @@ impl EntropyApp {
         );
         self.settings_write_queue.fail_pending(error);
     }
+
+    pub(super) fn reset_settings_write_context(&mut self) {
+        self.settings_write_generation = self.settings_write_generation.wrapping_add(1);
+        self.settings_write_queue.clear();
+    }
+
 }
 
 #[cfg(test)]
@@ -595,6 +616,7 @@ mod tests {
     fn request(qsid: u16, requested: u16) -> SettingsWriteRequest {
         SettingsWriteRequest {
             id: 0,
+            generation: 0,
             qsid,
             width: 1,
             old_value: 1,
@@ -774,5 +796,46 @@ mod tests {
                 .to_owned()
             ))
         );
+    }
+
+    #[test]
+    fn reset_context_discards_stale_worker_result() {
+        let mut app = test_app();
+        let request = request(122, 10);
+        app.touchpad_settings.scroll_sens = 8;
+        app.reset_settings_write_context();
+
+        app.finish_settings_write(SettingsWriteResult {
+            hid_device: None,
+            request,
+            result: Ok(10),
+            disconnected: false,
+        });
+
+        assert_eq!(app.touchpad_settings.scroll_sens, 8);
+        assert!(app.hid_device.is_none());
+    }
+
+    #[test]
+    fn older_readback_does_not_replace_newer_debounced_value() {
+        let ctx = egui::Context::default();
+        let mut app = test_app();
+        app.settings_write_queue.enqueue(request(122, 10));
+        let request = app
+            .settings_write_queue
+            .pop_front()
+            .expect("queued setting write");
+        app.touchpad_settings.scroll_sens = 12;
+        app.debounce_touchpad_setting_write(&ctx, "Scroll sensitivity".to_owned(), 122, 10, 12);
+
+        app.finish_settings_write(SettingsWriteResult {
+            hid_device: None,
+            request,
+            result: Ok(10),
+            disconnected: false,
+        });
+
+        assert_eq!(app.touchpad_settings.scroll_sens, 12);
+        assert_eq!(app.pending_qmk_settings_write_value(122), Some(12));
     }
 }

--- a/src/ui/touchpad_settings.rs
+++ b/src/ui/touchpad_settings.rs
@@ -10,7 +10,7 @@ impl EntropyApp {
         }
     }
 
-    fn set_touchpad_numeric_value(&mut self, qsid: u16, value: u16) {
+    pub(super) fn set_touchpad_numeric_value(&mut self, qsid: u16, value: u16) {
         match qsid {
             121 => self.touchpad_settings.sniper_sens = value.min(u8::MAX as u16) as u8,
             122 => self.touchpad_settings.scroll_sens = value.min(u8::MAX as u16) as u8,
@@ -21,16 +21,17 @@ impl EntropyApp {
 
     fn write_touchpad_numeric_setting(
         &mut self,
+        ctx: &egui::Context,
         qsid: u16,
         old_value: u16,
         value: u16,
         display_label: &str,
     ) {
         let value = value.clamp(1, 255) as u8;
-        self.queue_touchpad_setting_write(
+        self.debounce_touchpad_setting_write(
+            ctx,
             display_label.to_owned(),
             qsid,
-            1,
             old_value,
             value as u16,
         );
@@ -374,7 +375,11 @@ impl EntropyApp {
                                         if new_value != current {
                                             self.set_touchpad_numeric_value(qsid, new_value);
                                             self.write_touchpad_numeric_setting(
-                                                qsid, current, new_value, label,
+                                                ui.ctx(),
+                                                qsid,
+                                                current,
+                                                new_value,
+                                                label,
                                             );
                                         }
                                     }

--- a/src/ui/window_lifecycle.rs
+++ b/src/ui/window_lifecycle.rs
@@ -213,6 +213,7 @@ impl EntropyApp {
                 self.close_to_tray_prompt_open = true;
                 self.close_to_tray_prompt_remember = false;
                 ctx.request_repaint();
+                return;
             }
             CloseToTrayBehavior::Ask | CloseToTrayBehavior::Close | CloseToTrayBehavior::Tray => {
                 #[cfg(not(target_arch = "wasm32"))]

--- a/src/ui/window_lifecycle.rs
+++ b/src/ui/window_lifecycle.rs
@@ -18,11 +18,12 @@ impl EntropyApp {
             || self.keycode_picker.tap_dance_dirty
             || self.key_override_dirty
             || !self.pending_tap_hold_numeric_writes.is_empty()
+            || self.qmk_settings_write_pending()
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     pub(super) fn defer_exit_until_hid_write_returns(&mut self, ctx: &egui::Context) -> bool {
-        if !self.hid_write_task_active() {
+        if !self.hid_write_lifecycle_busy() && !self.deferred_exit_has_pending_hid_writes() {
             return false;
         }
 
@@ -34,7 +35,13 @@ impl EntropyApp {
 
     #[cfg(not(target_arch = "wasm32"))]
     pub(super) fn finish_deferred_exit_after_hid_write(&mut self, ctx: &egui::Context) {
-        if !self.exit_after_hid_write || self.hid_write_task_active() {
+        if !self.exit_after_hid_write {
+            return;
+        }
+
+        self.flush_pending_qmk_setting_writes();
+        if self.hid_write_lifecycle_busy() {
+            ctx.request_repaint_after(std::time::Duration::from_millis(16));
             return;
         }
 
@@ -1022,5 +1029,56 @@ mod tests {
         assert!(should_keep_vial_unlock_visible(false, true));
         assert!(should_keep_vial_unlock_visible(true, true));
         assert!(!should_keep_vial_unlock_visible(false, false));
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn deferred_exit_flushes_debounce_added_after_close_request() {
+        let ctx = egui::Context::default();
+        let creation_context = eframe::CreationContext::_new_kittest(ctx.clone());
+        let mut app = EntropyApp::new(&creation_context);
+        let (hid_device, recorder) = crate::hid::HidDevice::test_device();
+        app.hid_device = Some(hid_device);
+        app.exit_after_hid_write = true;
+        app.touchpad_settings.scroll_sens = 12;
+        app.debounce_touchpad_setting_write(&ctx, "Scroll sensitivity".to_owned(), 122, 8, 12);
+
+        let first_output = ctx.run_ui(egui::RawInput::default(), |_ui| {
+            app.finish_deferred_exit_after_hid_write(&ctx);
+        });
+        assert!(app.settings_write_task.is_some());
+        assert!(!first_output
+            .viewport_output
+            .get(&egui::ViewportId::ROOT)
+            .into_iter()
+            .flat_map(|viewport| &viewport.commands)
+            .any(|command| *command == egui::ViewportCommand::Close));
+
+        let mut close_sent = false;
+        for _ in 0..200 {
+            app.poll_settings_write(&ctx);
+            let output = ctx.run_ui(egui::RawInput::default(), |_ui| {
+                app.finish_deferred_exit_after_hid_write(&ctx);
+            });
+            close_sent |= output
+                .viewport_output
+                .get(&egui::ViewportId::ROOT)
+                .is_some_and(|viewport| viewport.commands.contains(&egui::ViewportCommand::Close));
+            if close_sent {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+
+        assert!(close_sent);
+        assert!(!app.qmk_settings_write_pending());
+        assert!(
+            recorder
+                .requests()
+                .iter()
+                .filter(|request| request[2] == 122 && request[3] == 0)
+                .count()
+                >= 2
+        );
     }
 }

--- a/src/ui/window_lifecycle.rs
+++ b/src/ui/window_lifecycle.rs
@@ -170,6 +170,9 @@ impl EntropyApp {
             return;
         }
 
+        #[cfg(not(target_arch = "wasm32"))]
+        self.flush_pending_qmk_setting_writes();
+
         if should_keep_vial_unlock_visible(self.unlock_open, self.vial_unlock_polling) {
             ctx.send_viewport_cmd(egui::ViewportCommand::CancelClose);
             self.keep_vial_unlock_visible(ctx);


### PR DESCRIPTION
## EN

### Problem

Touchpad sensitivity sliders sent a QMK HID command for every UI change while dragging. Slow USB or Bluetooth transports could receive a burst of stale writes for the same QSID, increasing latency and making the final firmware value less predictable.

### Fix

- Add a per-QSID settings scheduler that replaces pending writes with the newest requested value.
- Debounce touchpad sensitivity sliders for 180 ms, while keeping module fields, dropdowns, and toggles immediate through the same queue.
- Let immediate writes for another QSID bypass a delayed slider write.
- Cancel a pending write when the control returns to its original value.
- Flush pending settings before device switches and app close, clear them on disconnect, and pause automatic device scans while a write is pending.
- Preserve existing verified module-setting readback behavior.

This PR complements #89; if #89 merges first, this scheduler will be rebased onto its background HID worker so debounce remains separate from transport threading.

### Verification

- `cargo test --locked`: 194 passed.
- `cargo test qmk_settings_write_queue --locked`: 3 passed.
- `cargo clippy --locked --all-targets`: passed with existing repository warnings.
- `python3 scripts/check_i18n.py`: passed.
- Scoped `rustfmt --check` and `git diff --check`: passed.
- `TARGET=aarch64-apple-darwin scripts/build_macos_app.sh`: arm64 app, DMG, and ZIP built; plist and code-signature validation passed.
- Built executable verified as Mach-O 64-bit arm64.

## RU

### Проблема

Слайдеры чувствительности тачпада отправляли QMK HID-команду при каждом изменении во время перетаскивания. Медленный USB- или Bluetooth-транспорт мог получить очередь устаревших записей одного QSID, что увеличивало задержку и делало итоговое значение в прошивке менее предсказуемым.

### Исправление

- Добавлен планировщик настроек по QSID, который заменяет ожидающую запись последним запрошенным значением.
- Для слайдеров чувствительности тачпада добавлен debounce 180 мс; поля модулей, выпадающие списки и переключатели остаются немедленными, но проходят через ту же очередь.
- Немедленная запись другого QSID не блокируется отложенной записью слайдера.
- Если значение возвращается к исходному, ожидающая запись отменяется.
- Ожидающие настройки сохраняются перед переключением устройства и закрытием приложения, очищаются при отключении; автоматическое сканирование устройства приостанавливается до завершения записи.
- Существующая проверка настроек модулей контрольным чтением сохранена.

PR намеренно дополняет #89; если #89 будет смержен первым, планировщик будет изменен на его фоновый HID-worker, чтобы debounce оставался отдельным от transport threading.

### Проверка

- `cargo test --locked`: прошли 194 теста.
- `cargo test qmk_settings_write_queue --locked`: прошли 3 теста.
- `cargo clippy --locked --all-targets`: прошел с существующими предупреждениями репозитория.
- `python3 scripts/check_i18n.py`: прошел.
- Scoped `rustfmt --check` и `git diff --check`: прошли.
- `TARGET=aarch64-apple-darwin scripts/build_macos_app.sh`: собраны arm64-приложение, DMG и ZIP; plist и подпись прошли проверку.
- Исполняемый файл проверен как Mach-O 64-bit arm64.
