### PR TITLE
Stabilize module settings grouping

### DIFF
--- a/src/ui/device_settings_helpers.rs
+++ b/src/ui/device_settings_helpers.rs
@@ -874,21 +874,39 @@ impl EntropyApp {
         widths
     }
 
-    fn module_settings_group_kind(tab_name: &str) -> ModuleSettingsGroupKind {
-        let name = tab_name.to_ascii_lowercase();
-        if name.contains("left") {
-            ModuleSettingsGroupKind::Left
-        } else if name.contains("right") {
-            ModuleSettingsGroupKind::Right
-        } else if name.contains("auto") && name.contains("layer") {
-            ModuleSettingsGroupKind::AutoLayer
-        } else {
-            ModuleSettingsGroupKind::Other
+    fn module_setting_words(value: &str) -> Vec<String> {
+        value
+            .split(|character: char| !character.is_ascii_alphanumeric())
+            .filter(|word| !word.is_empty())
+            .map(str::to_ascii_lowercase)
+            .collect()
+    }
+
+    fn module_settings_kind_from_words(words: &[String]) -> Option<ModuleSettingsGroupKind> {
+        match words.first().map(String::as_str) {
+            Some("left") => Some(ModuleSettingsGroupKind::Left),
+            Some("right") => Some(ModuleSettingsGroupKind::Right),
+            _ if words
+                .windows(2)
+                .any(|pair| pair[0] == "auto" && pair[1] == "layer") =>
+            {
+                Some(ModuleSettingsGroupKind::AutoLayer)
+            }
+            _ => None,
         }
     }
 
-    fn is_module_settings_tab(normalized_title: &str) -> bool {
-        let words = Self::settings_title_words(normalized_title);
+    fn module_settings_metadata_kind(value: &serde_json::Value) -> Option<ModuleSettingsGroupKind> {
+        ["side", "module_side", "moduleSide"]
+            .iter()
+            .filter_map(|key| value.get(key).and_then(serde_json::Value::as_str))
+            .find_map(|side| {
+                Self::module_settings_kind_from_words(&Self::module_setting_words(side))
+            })
+    }
+
+    fn is_module_settings_title(title: &str) -> bool {
+        let words = Self::module_setting_words(title);
         let identifies_side = words
             .iter()
             .any(|word| matches!(word.as_str(), "left" | "right"));
@@ -899,10 +917,57 @@ impl EntropyApp {
             )
         });
 
-        normalized_title.contains("module")
-            || normalized_title.contains("trackball")
-            || (normalized_title.contains("auto") && normalized_title.contains("layer"))
+        words
+            .iter()
+            .any(|word| matches!(word.as_str(), "module" | "modules" | "trackball"))
+            || words
+                .windows(2)
+                .any(|pair| pair[0] == "auto" && pair[1] == "layer")
             || (identifies_side && identifies_controller)
+    }
+
+    fn is_module_setting_field_title(title: &str) -> bool {
+        let words = Self::module_setting_words(title);
+        if Self::module_settings_kind_from_words(&words).is_none() {
+            return false;
+        }
+
+        words.iter().skip(1).any(|word| {
+            matches!(
+                word.as_str(),
+                "module"
+                    | "modules"
+                    | "trackball"
+                    | "ball"
+                    | "touchpad"
+                    | "scroll"
+                    | "pointer"
+                    | "pointing"
+                    | "mode"
+                    | "cpi"
+                    | "dpi"
+                    | "acceleration"
+                    | "layer"
+            )
+        })
+    }
+
+    fn module_settings_group_title(
+        tab_title: &str,
+        tab_kind: Option<ModuleSettingsGroupKind>,
+        group_kind: ModuleSettingsGroupKind,
+    ) -> String {
+        if tab_kind == Some(group_kind) || group_kind == ModuleSettingsGroupKind::Other {
+            return tab_title.to_string();
+        }
+
+        let prefix = match group_kind {
+            ModuleSettingsGroupKind::Left => "Left",
+            ModuleSettingsGroupKind::Right => "Right",
+            ModuleSettingsGroupKind::AutoLayer => "Auto Layer",
+            ModuleSettingsGroupKind::Other => unreachable!(),
+        };
+        format!("{prefix} {tab_title}")
     }
 
     pub(super) fn module_settings_groups(
@@ -913,32 +978,74 @@ impl EntropyApp {
             return Vec::new();
         };
 
-        let mut groups = tabs
-            .iter()
-            .filter_map(|tab| {
-                let title = tab.get("name")?.as_str()?.trim().to_string();
-                let normalized_title = title.to_ascii_lowercase();
-                if !Self::is_module_settings_tab(&normalized_title) {
-                    return None;
-                }
-                let fields = tab
-                    .get("fields")
-                    .and_then(|value| value.as_array())?
-                    .iter()
-                    .filter_map(|field| {
-                        Self::parse_module_setting_field(field, supported_qmk_settings)
-                    })
-                    .collect::<Vec<_>>();
-                if fields.is_empty() {
-                    return None;
-                }
-                Some(ModuleSettingsGroup {
-                    kind: Self::module_settings_group_kind(&title),
-                    title,
-                    fields,
+        let mut groups = Vec::new();
+        for tab in tabs {
+            let Some(title) = tab
+                .get("name")
+                .and_then(serde_json::Value::as_str)
+                .map(str::trim)
+                .filter(|title| !title.is_empty())
+            else {
+                continue;
+            };
+            let tab_metadata_kind = Self::module_settings_metadata_kind(tab);
+            let tab_kind = tab_metadata_kind.or_else(|| {
+                Self::module_settings_kind_from_words(&Self::module_setting_words(title))
+            });
+            let title_identifies_modules = Self::is_module_settings_title(title);
+            let Some(raw_fields) = tab.get("fields").and_then(serde_json::Value::as_array) else {
+                continue;
+            };
+
+            let parsed_fields = raw_fields
+                .iter()
+                .filter_map(|raw_field| {
+                    let field =
+                        Self::parse_module_setting_field(raw_field, supported_qmk_settings)?;
+                    let metadata_kind = Self::module_settings_metadata_kind(raw_field);
+                    let title_kind = Self::module_settings_kind_from_words(
+                        &Self::module_setting_words(&field.title),
+                    );
+                    let identifies_modules = metadata_kind.is_some()
+                        || Self::is_module_setting_field_title(&field.title);
+                    Some((field, metadata_kind.or(title_kind), identifies_modules))
                 })
-            })
-            .collect::<Vec<_>>();
+                .collect::<Vec<_>>();
+            if parsed_fields.is_empty()
+                || (!title_identifies_modules
+                    && tab_metadata_kind.is_none()
+                    && !parsed_fields
+                        .iter()
+                        .any(|(_, _, identifies_modules)| *identifies_modules))
+            {
+                continue;
+            }
+
+            let mut partitioned = Vec::<(ModuleSettingsGroupKind, Vec<ModuleSettingField>)>::new();
+            for (field, field_kind, _) in parsed_fields {
+                let kind = field_kind
+                    .or(tab_kind)
+                    .unwrap_or(ModuleSettingsGroupKind::Other);
+                if let Some((_, fields)) = partitioned
+                    .iter_mut()
+                    .find(|(existing_kind, _)| *existing_kind == kind)
+                {
+                    fields.push(field);
+                } else {
+                    partitioned.push((kind, vec![field]));
+                }
+            }
+
+            groups.extend(
+                partitioned
+                    .into_iter()
+                    .map(|(kind, fields)| ModuleSettingsGroup {
+                        title: Self::module_settings_group_title(title, tab_kind, kind),
+                        kind,
+                        fields,
+                    }),
+            );
+        }
 
         groups.sort_by_key(|group| match group.kind {
             ModuleSettingsGroupKind::Left => 0,
@@ -1386,6 +1493,132 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![135, 128]
         );
+    }
+
+    #[test]
+    fn module_settings_groups_keep_known_split_controller_tabs() {
+        let json = serde_json::json!({
+            "settings": [
+                {
+                    "name": "Left Modules",
+                    "fields": [module_select_field("Left Mode", 120)]
+                },
+                {
+                    "name": "Right Modules",
+                    "fields": [module_select_field("Right Mode", 121)]
+                },
+                {
+                    "name": "Auto Layer",
+                    "fields": [module_select_field("Timeout", 122)]
+                }
+            ]
+        });
+
+        let groups = EntropyApp::module_settings_groups(&json, &[120, 121, 122]);
+
+        assert_eq!(groups.len(), 3);
+        assert_eq!(groups[0].title, "Left Modules");
+        assert_eq!(groups[0].kind, ModuleSettingsGroupKind::Left);
+        assert_eq!(groups[0].fields[0].title, "Left Mode");
+        assert_eq!(groups[1].title, "Right Modules");
+        assert_eq!(groups[1].kind, ModuleSettingsGroupKind::Right);
+        assert_eq!(groups[1].fields[0].title, "Right Mode");
+        assert_eq!(groups[2].kind, ModuleSettingsGroupKind::AutoLayer);
+    }
+
+    #[test]
+    fn module_settings_groups_split_mixed_controller_tabs() {
+        let json = serde_json::json!({
+            "settings": [{
+                "name": "Modules",
+                "fields": [
+                    module_select_field("Left Mode", 120),
+                    module_select_field("Right Mode", 121),
+                    module_select_field("Shared Resolution", 122)
+                ]
+            }]
+        });
+
+        let groups = EntropyApp::module_settings_groups(&json, &[120, 121, 122]);
+
+        assert_eq!(groups.len(), 3);
+        assert_eq!(groups[0].title, "Left Modules");
+        assert_eq!(groups[0].kind, ModuleSettingsGroupKind::Left);
+        assert_eq!(groups[0].fields[0].title, "Left Mode");
+        assert_eq!(groups[1].title, "Right Modules");
+        assert_eq!(groups[1].kind, ModuleSettingsGroupKind::Right);
+        assert_eq!(groups[1].fields[0].title, "Right Mode");
+        assert_eq!(groups[2].title, "Modules");
+        assert_eq!(groups[2].kind, ModuleSettingsGroupKind::Other);
+        assert_eq!(groups[2].fields[0].title, "Shared Resolution");
+    }
+
+    #[test]
+    fn module_settings_groups_prefer_explicit_side_metadata() {
+        let json = serde_json::json!({
+            "settings": [{
+                "name": "Controller Settings",
+                "fields": [
+                    module_select_field("Mode", 120).with_value("side", "left"),
+                    module_select_field("Mode", 121).with_value("module_side", "right")
+                ]
+            }]
+        });
+
+        let groups = EntropyApp::module_settings_groups(&json, &[120, 121]);
+
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0].title, "Left Controller Settings");
+        assert_eq!(groups[0].kind, ModuleSettingsGroupKind::Left);
+        assert_eq!(groups[1].title, "Right Controller Settings");
+        assert_eq!(groups[1].kind, ModuleSettingsGroupKind::Right);
+    }
+
+    #[test]
+    fn module_settings_groups_do_not_match_side_name_substrings() {
+        let json = serde_json::json!({
+            "settings": [
+                {
+                    "name": "Brightness Modules",
+                    "fields": [module_select_field("Brightness", 120)]
+                },
+                {
+                    "name": "Modulator",
+                    "fields": [module_select_field("Left Shift", 121)]
+                },
+                {
+                    "name": "Left Keyboard",
+                    "fields": [module_select_field("Layout", 122)]
+                }
+            ]
+        });
+
+        let groups = EntropyApp::module_settings_groups(&json, &[120, 121, 122]);
+
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].title, "Brightness Modules");
+        assert_eq!(groups[0].kind, ModuleSettingsGroupKind::Other);
+        assert_eq!(groups[0].fields[0].qsid, 120);
+    }
+
+    trait JsonValueExt {
+        fn with_value(self, key: &str, value: &str) -> serde_json::Value;
+    }
+
+    impl JsonValueExt for serde_json::Value {
+        fn with_value(mut self, key: &str, value: &str) -> serde_json::Value {
+            self[key] = serde_json::Value::String(value.to_string());
+            self
+        }
+    }
+
+    fn module_select_field(title: &str, qsid: u16) -> serde_json::Value {
+        serde_json::json!({
+            "title": title,
+            "qsid": qsid,
+            "type": "select",
+            "variants": ["Normal", "Scrolling"]
+        })
     }
 
     fn test_module_field(title: &str, qsid: u16) -> ModuleSettingField {

--- a/src/ui/device_settings_helpers.rs
+++ b/src/ui/device_settings_helpers.rs
@@ -874,14 +874,6 @@ impl EntropyApp {
         widths
     }
 
-    fn module_setting_words(value: &str) -> Vec<String> {
-        value
-            .split(|character: char| !character.is_ascii_alphanumeric())
-            .filter(|word| !word.is_empty())
-            .map(str::to_ascii_lowercase)
-            .collect()
-    }
-
     fn module_settings_kind_from_words(words: &[String]) -> Option<ModuleSettingsGroupKind> {
         match words.first().map(String::as_str) {
             Some("left") => Some(ModuleSettingsGroupKind::Left),
@@ -901,12 +893,12 @@ impl EntropyApp {
             .iter()
             .filter_map(|key| value.get(key).and_then(serde_json::Value::as_str))
             .find_map(|side| {
-                Self::module_settings_kind_from_words(&Self::module_setting_words(side))
+                Self::module_settings_kind_from_words(&Self::settings_title_words(side))
             })
     }
 
     fn is_module_settings_title(title: &str) -> bool {
-        let words = Self::module_setting_words(title);
+        let words = Self::settings_title_words(title);
         let identifies_side = words
             .iter()
             .any(|word| matches!(word.as_str(), "left" | "right"));
@@ -927,7 +919,7 @@ impl EntropyApp {
     }
 
     fn is_module_setting_field_title(title: &str) -> bool {
-        let words = Self::module_setting_words(title);
+        let words = Self::settings_title_words(title);
         if Self::module_settings_kind_from_words(&words).is_none() {
             return false;
         }
@@ -990,7 +982,7 @@ impl EntropyApp {
             };
             let tab_metadata_kind = Self::module_settings_metadata_kind(tab);
             let tab_kind = tab_metadata_kind.or_else(|| {
-                Self::module_settings_kind_from_words(&Self::module_setting_words(title))
+                Self::module_settings_kind_from_words(&Self::settings_title_words(title))
             });
             let title_identifies_modules = Self::is_module_settings_title(title);
             let Some(raw_fields) = tab.get("fields").and_then(serde_json::Value::as_array) else {
@@ -1004,7 +996,7 @@ impl EntropyApp {
                         Self::parse_module_setting_field(raw_field, supported_qmk_settings)?;
                     let metadata_kind = Self::module_settings_metadata_kind(raw_field);
                     let title_kind = Self::module_settings_kind_from_words(
-                        &Self::module_setting_words(&field.title),
+                        &Self::settings_title_words(&field.title),
                     );
                     let identifies_modules = metadata_kind.is_some()
                         || Self::is_module_setting_field_title(&field.title);
@@ -1047,13 +1039,32 @@ impl EntropyApp {
             );
         }
 
-        groups.sort_by_key(|group| match group.kind {
+        let mut coalesced_side_groups = Vec::<ModuleSettingsGroup>::new();
+        for group in groups {
+            if matches!(
+                group.kind,
+                ModuleSettingsGroupKind::Left
+                    | ModuleSettingsGroupKind::Right
+                    | ModuleSettingsGroupKind::AutoLayer
+            ) {
+                if let Some(existing) = coalesced_side_groups
+                    .iter_mut()
+                    .find(|existing| existing.kind == group.kind)
+                {
+                    existing.fields.extend(group.fields);
+                    continue;
+                }
+            }
+            coalesced_side_groups.push(group);
+        }
+
+        coalesced_side_groups.sort_by_key(|group| match group.kind {
             ModuleSettingsGroupKind::Left => 0,
             ModuleSettingsGroupKind::Right => 1,
             ModuleSettingsGroupKind::AutoLayer => 2,
             ModuleSettingsGroupKind::Other => 3,
         });
-        groups
+        coalesced_side_groups
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -1524,6 +1535,73 @@ mod tests {
         assert_eq!(groups[1].kind, ModuleSettingsGroupKind::Right);
         assert_eq!(groups[1].fields[0].title, "Right Mode");
         assert_eq!(groups[2].kind, ModuleSettingsGroupKind::AutoLayer);
+    }
+
+    #[test]
+    fn module_settings_groups_coalesce_kinds_across_tabs() {
+        let json = serde_json::json!({
+            "settings": [
+                {
+                    "name": "Left Modules",
+                    "fields": [module_select_field("Left Mode", 120)]
+                },
+                {
+                    "name": "Right Modules",
+                    "fields": [module_select_field("Right Mode", 121)]
+                },
+                {
+                    "name": "Auto Layer",
+                    "fields": [module_select_field("Timeout", 122)]
+                },
+                {
+                    "name": "Controller Settings",
+                    "fields": [
+                        module_select_field("Left Scroll Sens", 123),
+                        module_select_field("Right Scroll Sens", 124),
+                        module_select_field("Auto Layer Timeout", 125)
+                    ]
+                }
+            ]
+        });
+
+        let groups = EntropyApp::module_settings_groups(&json, &[120, 121, 122, 123, 124, 125]);
+
+        assert_eq!(groups.len(), 3);
+        assert_eq!(groups[0].kind, ModuleSettingsGroupKind::Left);
+        assert_eq!(
+            groups[0]
+                .fields
+                .iter()
+                .map(|field| field.qsid)
+                .collect::<Vec<_>>(),
+            vec![120, 123]
+        );
+        assert_eq!(groups[1].kind, ModuleSettingsGroupKind::Right);
+        assert_eq!(
+            groups[1]
+                .fields
+                .iter()
+                .map(|field| field.qsid)
+                .collect::<Vec<_>>(),
+            vec![121, 124]
+        );
+        assert_eq!(groups[2].kind, ModuleSettingsGroupKind::AutoLayer);
+        assert_eq!(
+            groups[2]
+                .fields
+                .iter()
+                .map(|field| field.qsid)
+                .collect::<Vec<_>>(),
+            vec![122, 125]
+        );
+        let mut state = ModuleSettingsState {
+            groups,
+            selected_module_group: 0,
+            ..Default::default()
+        };
+        assert_eq!(state.selected_module_group(), Some(0));
+        state.set_selected_module_group(1);
+        assert_eq!(state.selected_module_group(), Some(1));
     }
 
     #[test]


### PR DESCRIPTION
## EN

### Problem

Module settings classification relied on broad title substrings and created one group per firmware tab. Names such as `Brightness Modules` could be mistaken for right-controller settings, while a tab containing both left and right controller fields could not preserve side ownership reliably.

### Fix

- Parse normalized whole-word tokens instead of loose `left`, `right`, and `module` substrings.
- Prefer explicit `side`, `module_side`, or `moduleSide` metadata when firmware provides it.
- Split mixed controller tabs into stable Left, Right, Auto Layer, and Other groups.
- Keep original firmware field titles and add side labels to generated mixed-tab group titles.
- Admit generic controller tabs only when field metadata or recognized module field vocabulary proves they contain module settings.
- Add fixtures for known split tabs, mixed tabs, explicit side metadata, auto-layer settings, and substring collisions.

This PR complements the diagnostics work in #88 without duplicating it.

### Verification

- `cargo test --locked --all-targets`: 195 passed.
- `cargo test module_settings_groups`: 5 passed.
- `cargo clippy --locked --all-targets`: passed with existing repository warnings.
- `python3 scripts/check_i18n.py`: passed.
- Scoped `rustfmt --check` and `git diff --check`: passed.
- `TARGET=aarch64-apple-darwin scripts/build_macos_app.sh`: arm64 app, DMG, and ZIP built; plist and code-signature validation passed.
- Built executable architecture validated as arm64 by the packaging script.

## RU

### Проблема

Группировка настроек модулей опиралась на широкие совпадения подстрок в заголовках и создавала одну группу на вкладку прошивки. Например, `Brightness Modules` могла ошибочно определяться как настройки правого контроллера, а вкладка с полями левого и правого контроллеров не сохраняла принадлежность сторон надежно.

### Исправление

- Вместо широкого поиска подстрок `left`, `right` и `module` используются нормализованные отдельные слова.
- При наличии в прошивке приоритет отдается явным метаданным `side`, `module_side` или `moduleSide`.
- Смешанные вкладки контроллеров разделяются на стабильные группы Left, Right, Auto Layer и Other.
- Исходные названия полей прошивки сохраняются; созданные из смешанных вкладок группы получают обозначение стороны.
- Общие вкладки контроллеров включаются только при наличии метаданных поля или распознанной лексики настроек модулей.
- Добавлены фикстуры для отдельных вкладок сторон, смешанных вкладок, явных метаданных стороны, Auto Layer и конфликтующих подстрок.

PR дополняет диагностическую работу в #88, не дублируя ее.

### Проверка

- `cargo test --locked --all-targets`: прошли 195 тестов.
- `cargo test module_settings_groups`: прошли 5 тестов.
- `cargo clippy --locked --all-targets`: прошел с существующими предупреждениями репозитория.
- `python3 scripts/check_i18n.py`: прошел.
- Scoped `rustfmt --check` и `git diff --check`: прошли.
- `TARGET=aarch64-apple-darwin scripts/build_macos_app.sh`: собраны arm64-приложение, DMG и ZIP; plist и подпись прошли проверку.
- Архитектура исполняемого файла проверена скриптом упаковки как arm64.