### PR TITLE
Match QMK settings HID responses

### DIFF
--- a/src/hid.rs
+++ b/src/hid.rs
@@ -588,12 +588,12 @@ fn read_response(
             resp.copy_from_slice(&read_buf[..MSG_LEN]);
         }
 
-        if !transport.is_bluetooth() || response_matches_command(command, &resp) {
+        if response_matches_command(command, &resp) {
             return Ok(resp);
         }
 
         last_error = Some(anyhow::anyhow!(
-            "HID stale or unrelated BLE report for command {:02X}: {:02X?}",
+            "HID stale or unrelated report for command {:02X}: {:02X?}",
             command.first().copied().unwrap_or(0),
             &resp[..command.len().clamp(3, 8)]
         ));
@@ -664,16 +664,49 @@ fn response_matches_vial_command(command: &[u8], resp: &[u8; MSG_LEN]) -> bool {
         }
         CMD_VIAL_GET_UNLOCK_STATUS => matches!(resp[0], 0 | 1) && matches!(resp[1], 0 | 1),
         CMD_VIAL_UNLOCK_POLL => matches!(resp[0], 0 | 1) && matches!(resp[1], 0 | 1),
-        CMD_VIAL_QMK_SETTINGS_GET
-        | CMD_VIAL_QMK_SETTINGS_SET
-        | CMD_VIAL_DYNAMIC_ENTRY_OP
+        CMD_VIAL_QMK_SETTINGS_QUERY => response_matches_qmk_settings_query(command, resp),
+        CMD_VIAL_QMK_SETTINGS_GET => response_matches_qmk_settings_get(command, resp),
+        CMD_VIAL_QMK_SETTINGS_SET => response_echoes_vial_command(command, resp),
+        CMD_VIAL_DYNAMIC_ENTRY_OP
         | CMD_VIAL_GET_ENCODER
         | CMD_VIAL_SET_ENCODER
-        | CMD_VIAL_QMK_SETTINGS_QUERY
         | CMD_VIAL_UNLOCK_START
         | CMD_VIAL_LOCK => true,
         _ => true,
     }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn response_echoes_vial_command(command: &[u8], resp: &[u8; MSG_LEN]) -> bool {
+    command.len() >= 2
+        && command.len() <= MSG_LEN
+        && resp[1..command.len()] == command[1..]
+        && resp[command.len()..].iter().all(|byte| *byte == 0)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn response_matches_qmk_settings_get(command: &[u8], resp: &[u8; MSG_LEN]) -> bool {
+    command.len() >= 4 && (resp[0] == 0 || response_echoes_vial_command(command, resp))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn response_matches_qmk_settings_query(command: &[u8], resp: &[u8; MSG_LEN]) -> bool {
+    let Some(qsid_bytes) = command.get(2..4) else {
+        return false;
+    };
+    let cursor = u16::from_le_bytes([qsid_bytes[0], qsid_bytes[1]]);
+    let mut reached_terminator = false;
+
+    for chunk in resp.chunks_exact(2) {
+        let qsid = u16::from_le_bytes([chunk[0], chunk[1]]);
+        if qsid == u16::MAX {
+            reached_terminator = true;
+        } else if reached_terminator || qsid <= cursor {
+            return false;
+        }
+    }
+
+    true
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -874,5 +907,102 @@ fn hex_nibble(byte: u8) -> Result<u8> {
         b'a'..=b'f' => Ok(byte - b'a' + 10),
         b'A'..=b'F' => Ok(byte - b'A' + 10),
         _ => bail!("invalid hex digit"),
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+
+    fn qmk_settings_command(subcommand: u8, qsid: u16) -> [u8; MSG_LEN] {
+        let mut command = [0u8; MSG_LEN];
+        command[0] = CMD_VIA_VIAL_PREFIX;
+        command[1] = subcommand;
+        command[2..4].copy_from_slice(&qsid.to_le_bytes());
+        command
+    }
+
+    #[test]
+    fn qmk_settings_set_accepts_echoed_command_response() {
+        let mut command = qmk_settings_command(CMD_VIAL_QMK_SETTINGS_SET, 300);
+        command[4..6].copy_from_slice(&2048u16.to_le_bytes());
+        let mut response = command;
+        response[0] = 0;
+
+        assert!(response_matches_command(&command, &response));
+    }
+
+    #[test]
+    fn qmk_settings_set_rejects_stale_get_response() {
+        let mut command = qmk_settings_command(CMD_VIAL_QMK_SETTINGS_SET, 300);
+        command[4] = 2;
+        let mut stale_response = [0u8; MSG_LEN];
+        stale_response[0] = 0;
+        stale_response[1] = 2;
+        stale_response[2..4].copy_from_slice(&300u16.to_le_bytes());
+
+        assert!(!response_matches_command(&command, &stale_response));
+    }
+
+    #[test]
+    fn qmk_settings_set_rejects_echo_for_another_qsid() {
+        let command = qmk_settings_command(CMD_VIAL_QMK_SETTINGS_SET, 300);
+        let mut stale_response = qmk_settings_command(CMD_VIAL_QMK_SETTINGS_SET, 301);
+        stale_response[0] = 0;
+
+        assert!(!response_matches_command(&command, &stale_response));
+    }
+
+    #[test]
+    fn qmk_settings_get_accepts_success_and_echoed_error_shapes() {
+        let command = qmk_settings_command(CMD_VIAL_QMK_SETTINGS_GET, 300);
+        let mut success = [0u8; MSG_LEN];
+        success[0] = 0;
+        success[1..3].copy_from_slice(&2048u16.to_le_bytes());
+        let mut error = command;
+        error[0] = u8::MAX;
+
+        assert!(response_matches_command(&command, &success));
+        assert!(response_matches_command(&command, &error));
+    }
+
+    #[test]
+    fn qmk_settings_get_rejects_impossible_status_payload() {
+        let command = qmk_settings_command(CMD_VIAL_QMK_SETTINGS_GET, 300);
+        let mut response = [0u8; MSG_LEN];
+        response[0] = 0x7F;
+        response[1] = 0x42;
+
+        assert!(!response_matches_command(&command, &response));
+    }
+
+    #[test]
+    fn qmk_settings_query_accepts_advancing_qsids_and_terminator() {
+        let command = qmk_settings_command(CMD_VIAL_QMK_SETTINGS_QUERY, 100);
+        let mut response = [u8::MAX; MSG_LEN];
+        response[0..2].copy_from_slice(&101u16.to_le_bytes());
+        response[2..4].copy_from_slice(&300u16.to_le_bytes());
+
+        assert!(response_matches_command(&command, &response));
+    }
+
+    #[test]
+    fn qmk_settings_query_rejects_stale_nonadvancing_batch() {
+        let command = qmk_settings_command(CMD_VIAL_QMK_SETTINGS_QUERY, 300);
+        let mut stale_response = [u8::MAX; MSG_LEN];
+        stale_response[0..2].copy_from_slice(&101u16.to_le_bytes());
+        stale_response[2..4].copy_from_slice(&300u16.to_le_bytes());
+
+        assert!(!response_matches_command(&command, &stale_response));
+    }
+
+    #[test]
+    fn qmk_settings_query_rejects_values_after_terminator() {
+        let command = qmk_settings_command(CMD_VIAL_QMK_SETTINGS_QUERY, 100);
+        let mut response = [u8::MAX; MSG_LEN];
+        response[0..2].copy_from_slice(&101u16.to_le_bytes());
+        response[4..6].copy_from_slice(&300u16.to_le_bytes());
+
+        assert!(!response_matches_command(&command, &response));
     }
 }


### PR DESCRIPTION
## EN

### Problem

Stale or unrelated HID reports could be accepted as QMK settings responses. USB accepted the first full-length report without command matching, while Bluetooth treated every QMK settings GET, SET, and QUERY payload as valid. During controller tuning this could make an old report look like a successful write or a current setting value.

### Fix

- Apply existing command-response matching on both USB and Bluetooth transports.
- Require QMK settings SET responses to echo the requested subcommand, QSID, and value payload.
- Accept QUERY batches only when every QSID advances beyond the requested cursor and no values appear after the `0xFFFF` terminator.
- Accept GET responses only as protocol-valid success payloads or command-echoing error responses.
- Keep reading until the existing command deadline after rejecting a stale report.
- Add focused fixtures for valid responses, stale GET/SET crossover, wrong QSIDs, non-advancing queries, and malformed terminator placement.

Successful Vial GET responses do not carry a QSID or transaction ID, so matching cannot distinguish two successful GETs for the same payload shape. This PR enforces every invariant the protocol exposes without rejecting valid setting values.

### Verification

- `cargo test --locked --all-targets`: 199 passed.
- `cargo test --locked qmk_settings_`: 8 passed.
- `cargo clippy --locked --all-targets`: passed with existing repository warnings.
- `python3 scripts/check_i18n.py`: passed.
- Scoped `rustfmt --check` and `git diff --check`: passed.
- `TARGET=aarch64-apple-darwin scripts/build_macos_app.sh`: arm64 app, DMG, and ZIP built; plist, architecture, and code-signature validation passed.

## RU

### Проблема

Устаревшие или посторонние HID-отчеты могли приниматься как ответы на команды настроек QMK. USB принимал первый отчет правильной длины без сопоставления с командой, а Bluetooth считал допустимым любой ответ на QMK settings GET, SET и QUERY. При настройке контроллеров старый отчет мог выглядеть как успешная запись или актуальное значение настройки.

### Исправление

- Существующее сопоставление команды и ответа применяется для USB и Bluetooth.
- Ответ SET должен повторять подкоманду, QSID и записываемое значение.
- Пакет QUERY принимается только когда каждый QSID больше запрошенного курсора и после терминатора `0xFFFF` нет значений.
- Ответ GET принимается только как допустимый успешный payload протокола или как ответ с ошибкой, повторяющий команду.
- После отклонения устаревшего отчета чтение продолжается до существующего дедлайна команды.
- Добавлены фикстуры для корректных ответов, пересечения устаревших GET/SET, неверных QSID, запросов без продвижения и неправильного положения терминатора.

Успешный ответ Vial GET не содержит QSID или идентификатор транзакции, поэтому протокол не позволяет различить два успешных GET с одинаковой формой payload. PR проверяет все доступные инварианты, не отклоняя допустимые значения настроек.

### Проверка

- `cargo test --locked --all-targets`: прошли 199 тестов.
- `cargo test --locked qmk_settings_`: прошли 8 тестов.
- `cargo clippy --locked --all-targets`: прошел с существующими предупреждениями репозитория.
- `python3 scripts/check_i18n.py`: прошел.
- Scoped `rustfmt --check` и `git diff --check`: прошли.
- `TARGET=aarch64-apple-darwin scripts/build_macos_app.sh`: собраны arm64-приложение, DMG и ZIP; plist, архитектура и подпись прошли проверку.
