### PR TITLE
Protect settings during device refresh

### DIFF
--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -48,6 +48,8 @@ impl EntropyApp {
             layer_clipboard: None,
             scan_frame: 0,
             last_device_scan_at: 0.0,
+            #[cfg(target_os = "macos")]
+            last_device_liveness_check_at: 0.0,
             hover_layer: None,
             last_layout_geometry: None,
             prev_hovered_key: None,

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -386,9 +386,19 @@ pub(crate) enum ConnectState {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DeviceScanTrigger {
+    Automatic,
+    Manual,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) enum DeviceScanState {
     Idle,
-    Scanning(mpsc::Receiver<Vec<Device>>),
+    Scanning {
+        rx: mpsc::Receiver<Vec<Device>>,
+        trigger: DeviceScanTrigger,
+    },
 }
 
 pub(crate) fn toggle_handed_modifier(value: u16) -> Option<u16> {

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -396,7 +396,7 @@ pub(crate) enum DeviceScanTrigger {
 pub(crate) enum DeviceScanState {
     Idle,
     Scanning {
-        rx: mpsc::Receiver<Vec<Device>>,
+        rx: mpsc::Receiver<Result<Vec<Device>, String>>,
         trigger: DeviceScanTrigger,
     },
 }
@@ -2838,6 +2838,10 @@ pub struct EntropyApp {
     pub(crate) scan_frame: u32,
     /// Last device scan timestamp in egui seconds
     pub(crate) last_device_scan_at: f64,
+    /// Last direct HID liveness check on macOS, where enumeration cannot run
+    /// while an open HID handle exists.
+    #[cfg(target_os = "macos")]
+    pub(crate) last_device_liveness_check_at: f64,
     /// Layer to preview on hover (None = show selected_layer)
     pub(crate) hover_layer: Option<usize>,
     /// Last main keyboard layout geometry: offset_x, offset_y, unit, padding

--- a/src/device.rs
+++ b/src/device.rs
@@ -59,44 +59,47 @@ impl DeviceManager {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn scan_devices() -> Vec<Device> {
+    pub fn scan_devices() -> anyhow::Result<Vec<Device>> {
         let mut devices = Vec::new();
 
         #[cfg(target_os = "macos")]
         if crate::hid::macos_hid_scan_disabled_for_rosetta() {
-            return devices;
+            return Ok(devices);
         }
 
         #[cfg(target_os = "macos")]
         let _hid_lock = crate::hid::macos_hid_operation_lock();
-        if let Ok(api) = hidapi::HidApi::new() {
-            for info in api.device_list() {
-                // Filter: Vial usage page 0xFF60, usage 0x61
-                if info.usage_page() == 0xFF60 && info.usage() == 0x61 {
-                    devices.push(Device {
-                        name: info
-                            .product_string()
-                            .unwrap_or("Unknown Keyboard")
-                            .to_string(),
-                        vendor_id: info.vendor_id(),
-                        product_id: info.product_id(),
-                        manufacturer: info.manufacturer_string().unwrap_or("").to_string(),
-                        serial_number: info.serial_number().unwrap_or("").to_string(),
-                        bus_type: format!("{:?}", info.bus_type()),
-                        path: info.path().to_string_lossy().to_string(),
-                        firmware: FirmwareProtocol::Vial,
-                    });
-                }
+        let api =
+            hidapi::HidApi::new().map_err(|error| anyhow::anyhow!("HID scan failed: {error}"))?;
+        for info in api.device_list() {
+            // Filter: Vial usage page 0xFF60, usage 0x61
+            if info.usage_page() == 0xFF60 && info.usage() == 0x61 {
+                devices.push(Device {
+                    name: info
+                        .product_string()
+                        .unwrap_or("Unknown Keyboard")
+                        .to_string(),
+                    vendor_id: info.vendor_id(),
+                    product_id: info.product_id(),
+                    manufacturer: info.manufacturer_string().unwrap_or("").to_string(),
+                    serial_number: info.serial_number().unwrap_or("").to_string(),
+                    bus_type: format!("{:?}", info.bus_type()),
+                    path: info.path().to_string_lossy().to_string(),
+                    firmware: FirmwareProtocol::Vial,
+                });
             }
         }
 
-        devices
+        Ok(devices)
     }
 
     pub fn scan(&mut self) {
         #[cfg(not(target_arch = "wasm32"))]
         {
-            self.devices = Self::scan_devices();
+            match Self::scan_devices() {
+                Ok(devices) => self.devices = devices,
+                Err(error) => log::warn!("device scan failed: {error}"),
+            }
         }
 
         log::info!("Found {} Vial device(s)", self.devices.len());

--- a/src/ui/app_lifecycle.rs
+++ b/src/ui/app_lifecycle.rs
@@ -71,6 +71,16 @@ fn hid_lifecycle_writes_available(hid_write_task_active: bool) -> bool {
     !hid_write_task_active
 }
 
+#[cfg(target_os = "macos")]
+fn macos_hid_liveness_check_due(
+    last_check_at: f64,
+    now: f64,
+    hid_present: bool,
+    refresh_blocked: bool,
+) -> bool {
+    hid_present && !refresh_blocked && (last_check_at == 0.0 || now - last_check_at >= 1.0)
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 fn connection_replaces_layout_canvas(connect_state: &ConnectState) -> bool {
     matches!(connect_state, ConnectState::Loading { .. })
@@ -110,6 +120,9 @@ impl EntropyApp {
                 self.poll_device_scan(ctx);
             }
 
+            #[cfg(target_os = "macos")]
+            self.poll_macos_hid_liveness(now);
+
             let is_connecting = matches!(self.connect_state, ConnectState::Loading { .. });
             let hid_write_active = self.hid_write_lifecycle_busy();
             #[cfg(target_os = "macos")]
@@ -137,6 +150,35 @@ impl EntropyApp {
         self.auto_reload_text_expander_rules_file(now);
         self.poll_single_instance_signal(ctx);
         self.poll_connect(ctx);
+    }
+
+    #[cfg(target_os = "macos")]
+    fn poll_macos_hid_liveness(&mut self, now: f64) {
+        if !macos_hid_liveness_check_due(
+            self.last_device_liveness_check_at,
+            now,
+            self.hid_device.is_some(),
+            self.device_refresh_blocked(),
+        ) {
+            return;
+        }
+        self.last_device_liveness_check_at = now;
+
+        let error = self
+            .hid_device
+            .as_ref()
+            .and_then(|hid| hid.get_protocol_version().err());
+        match error {
+            Some(error) if crate::hid::is_disconnect_error(&error) => {
+                self.selected_device = None;
+                self.clear_connected_keyboard_state(crate::i18n::tr(
+                    self.app_settings.language,
+                    crate::i18n::Key::NoDevicesFound,
+                ));
+            }
+            Some(error) => log::warn!("macOS HID liveness check failed: {error}"),
+            None => {}
+        }
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -428,6 +470,15 @@ mod tests {
     use super::*;
     use crate::keyboard::{KeyboardLayout, LayoutOption, PhysicalKey};
 
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_liveness_uses_open_handle_without_enumeration() {
+        assert!(macos_hid_liveness_check_due(0.0, 1.0, true, false));
+        assert!(!macos_hid_liveness_check_due(1.0, 1.5, true, false));
+        assert!(!macos_hid_liveness_check_due(1.0, 2.0, false, false));
+        assert!(!macos_hid_liveness_check_due(1.0, 2.0, true, true));
+    }
+
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn only_device_connection_replaces_the_layout_canvas() {
@@ -468,19 +519,25 @@ mod tests {
 
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
-    fn background_starts_disconnect_scan_while_hid_is_connected() {
+    fn background_uses_platform_safe_connected_liveness() {
         let ctx = egui::Context::default();
         let creation_context = eframe::CreationContext::_new_kittest(ctx.clone());
         let mut app = EntropyApp::new(&creation_context);
         app.hid_device = Some(crate::hid::HidDevice::test_device().0);
         app.last_device_scan_at = 0.0;
 
-        app.update_native_background(&ctx, 0.0, false, false);
+        app.update_native_background(&ctx, 1.0, false, false);
 
+        #[cfg(not(target_os = "macos"))]
         assert!(matches!(
             app.device_scan_state,
             DeviceScanState::Scanning { .. }
         ));
+        #[cfg(target_os = "macos")]
+        {
+            assert!(matches!(app.device_scan_state, DeviceScanState::Idle));
+            assert_eq!(app.last_device_liveness_check_at, 1.0);
+        }
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/src/ui/app_lifecycle.rs
+++ b/src/ui/app_lifecycle.rs
@@ -468,6 +468,23 @@ mod tests {
 
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
+    fn background_starts_disconnect_scan_while_hid_is_connected() {
+        let ctx = egui::Context::default();
+        let creation_context = eframe::CreationContext::_new_kittest(ctx.clone());
+        let mut app = EntropyApp::new(&creation_context);
+        app.hid_device = Some(crate::hid::HidDevice::test_device().0);
+        app.last_device_scan_at = 0.0;
+
+        app.update_native_background(&ctx, 0.0, false, false);
+
+        assert!(matches!(
+            app.device_scan_state,
+            DeviceScanState::Scanning { .. }
+        ));
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
     fn settings_task_defers_and_drains_hid_writes_before_exit() {
         let ctx = egui::Context::default();
         let creation_context = eframe::CreationContext::_new_kittest(ctx.clone());

--- a/src/ui/device_connect_apply.rs
+++ b/src/ui/device_connect_apply.rs
@@ -55,6 +55,27 @@ fn is_hid_open_failure(error: &str) -> bool {
     error.starts_with("Open failed:")
 }
 
+fn restored_selection(previous: usize, row_count: usize) -> usize {
+    previous.min(row_count.saturating_sub(1))
+}
+
+fn restore_module_settings_group(
+    settings: &mut ModuleSettingsState,
+    previous: Option<&(ModuleSettingsGroupKind, String)>,
+) {
+    let Some((kind, title)) = previous else {
+        return;
+    };
+    let matching_group = settings
+        .groups
+        .iter()
+        .position(|group| group.kind == *kind && group.title == *title)
+        .or_else(|| settings.groups.iter().position(|group| group.kind == *kind));
+    if let Some(group_idx) = matching_group {
+        settings.selected_module_group = group_idx;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -282,6 +303,42 @@ mod tests {
         let failed = sync_layer_names_to_store(&store, &names, 2);
         assert!(failed.is_empty());
         assert!(store.writes.borrow().is_empty());
+    #[test]
+    fn reconnect_selection_is_preserved_and_clamped() {
+        assert_eq!(restored_selection(3, 5), 3);
+        assert_eq!(restored_selection(3, 2), 1);
+        assert_eq!(restored_selection(3, 0), 0);
+    }
+
+    #[test]
+    fn reconnect_restores_module_group_by_stable_identity() {
+        let mut settings = ModuleSettingsState {
+            groups: vec![
+                ModuleSettingsGroup {
+                    title: "Auto layer".into(),
+                    kind: ModuleSettingsGroupKind::AutoLayer,
+                    fields: Vec::new(),
+                },
+                ModuleSettingsGroup {
+                    title: "Left".into(),
+                    kind: ModuleSettingsGroupKind::Left,
+                    fields: Vec::new(),
+                },
+                ModuleSettingsGroup {
+                    title: "Right".into(),
+                    kind: ModuleSettingsGroupKind::Right,
+                    fields: Vec::new(),
+                },
+            ],
+            ..Default::default()
+        };
+
+        restore_module_settings_group(
+            &mut settings,
+            Some(&(ModuleSettingsGroupKind::Right, "Right".into())),
+        );
+
+        assert_eq!(settings.selected_module_group, 2);
     }
 }
 
@@ -342,6 +399,13 @@ impl EntropyApp {
 
         match result {
             Ok(r) => {
+                let selected_alt_repeat = self.selected_alt_repeat;
+                let selected_key_override = self.selected_key_override;
+                let selected_module_group = self
+                    .module_settings
+                    .groups
+                    .get(self.module_settings.selected_module_group)
+                    .map(|group| (group.kind, group.title.clone()));
                 self.pending_tap_hold_numeric_writes.clear();
                 self.tap_hold_numeric_write_due = None;
                 log::info!(
@@ -379,7 +443,8 @@ impl EntropyApp {
                 self.alt_repeat_names
                     .resize(self.alt_repeat_entries.len(), String::new());
                 self.alt_repeat_undo_stack.clear();
-                self.selected_alt_repeat = 0;
+                self.selected_alt_repeat =
+                    restored_selection(selected_alt_repeat, self.alt_repeat_entries.len());
                 self.alt_repeat_visible_count = if self.alt_repeat_entries.is_empty() {
                     1
                 } else {
@@ -390,7 +455,8 @@ impl EntropyApp {
                     .resize(self.key_override_entries.len(), String::new());
                 self.key_override_visible_count = 1;
                 self.key_override_undo_stack.clear();
-                self.selected_key_override = 0;
+                self.selected_key_override =
+                    restored_selection(selected_key_override, self.key_override_entries.len());
                 self.combo_names = load_combo_names(&self.current_device_name);
                 self.combo_names
                     .resize(self.combo_entries.len(), String::new());
@@ -408,6 +474,10 @@ impl EntropyApp {
                 self.touchpad_settings = r.touchpad_settings;
                 self.bluetooth_settings = r.bluetooth_settings;
                 self.module_settings = r.module_settings;
+                restore_module_settings_group(
+                    &mut self.module_settings,
+                    selected_module_group.as_ref(),
+                );
                 self.tap_hold_settings = r.tap_hold_settings;
                 self.magic_settings = r.magic_settings;
                 self.one_shot_settings = r.one_shot_settings;

--- a/src/ui/device_connect_apply.rs
+++ b/src/ui/device_connect_apply.rs
@@ -303,6 +303,8 @@ mod tests {
         let failed = sync_layer_names_to_store(&store, &names, 2);
         assert!(failed.is_empty());
         assert!(store.writes.borrow().is_empty());
+    }
+
     #[test]
     fn reconnect_selection_is_preserved_and_clamped() {
         assert_eq!(restored_selection(3, 5), 3);

--- a/src/ui/device_connect_task.rs
+++ b/src/ui/device_connect_task.rs
@@ -542,7 +542,6 @@ impl EntropyApp {
         self.alt_repeat_entries.clear();
         self.alt_repeat_names.clear();
         self.alt_repeat_undo_stack.clear();
-        self.selected_alt_repeat = 0;
         self.alt_repeat_visible_count = 1;
         self.alt_repeat_pick_target = None;
         self.rgb_settings = RgbSettingsState::default();
@@ -558,7 +557,6 @@ impl EntropyApp {
         self.key_override_names.clear();
         self.key_override_visible_count = 1;
         self.key_override_undo_stack.clear();
-        self.selected_key_override = 0;
         self.key_override_pick_target = None;
         self.reset_matrix_tester_state();
 

--- a/src/ui/device_scan.rs
+++ b/src/ui/device_scan.rs
@@ -10,8 +10,8 @@ enum DeviceScanResultAction {
     Apply,
 }
 
-fn device_scan_result_action(refresh_blocked: bool, devices_empty: bool) -> DeviceScanResultAction {
-    if devices_empty || !refresh_blocked {
+fn device_scan_result_action(refresh_blocked: bool) -> DeviceScanResultAction {
+    if !refresh_blocked {
         DeviceScanResultAction::Apply
     } else {
         DeviceScanResultAction::Discard
@@ -42,6 +42,13 @@ impl EntropyApp {
         if !matches!(self.device_scan_state, DeviceScanState::Idle) {
             return false;
         }
+        // hidapi's macOS IOHIDManager cannot enumerate while this process owns
+        // an open handle. Automatic liveness uses that handle directly instead.
+        #[cfg(target_os = "macos")]
+        if self.hid_device.is_some() {
+            log::debug!("skipping macOS HID scan while a device handle is open");
+            return false;
+        }
         #[cfg(target_os = "macos")]
         if crate::hid::macos_hid_scan_disabled_for_rosetta() {
             if self.status_msg.is_empty() {
@@ -53,7 +60,7 @@ impl EntropyApp {
         let (tx, rx) = mpsc::channel();
         self.device_scan_state = DeviceScanState::Scanning { rx, trigger };
         std::thread::spawn(move || {
-            let _ = tx.send(DeviceManager::scan_devices());
+            let _ = tx.send(DeviceManager::scan_devices().map_err(|error| error.to_string()));
         });
         true
     }
@@ -83,18 +90,29 @@ impl EntropyApp {
         let devices = match &self.device_scan_state {
             DeviceScanState::Idle => return,
             DeviceScanState::Scanning { rx, .. } => match rx.try_recv() {
-                Ok(devices) => Some(devices),
+                Ok(Ok(devices)) => Some(devices),
+                Ok(Err(error)) => {
+                    self.device_scan_state = DeviceScanState::Idle;
+                    self.status_msg = format!("Device scan failed: {error}");
+                    log::warn!("device scan worker failed: {error}");
+                    return;
+                }
                 Err(mpsc::TryRecvError::Empty) => {
                     ctx.request_repaint_after(std::time::Duration::from_millis(25));
                     return;
                 }
-                Err(mpsc::TryRecvError::Disconnected) => Some(Vec::new()),
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    self.device_scan_state = DeviceScanState::Idle;
+                    self.status_msg = "Device scan worker stopped".into();
+                    log::warn!("device scan worker stopped before returning a result");
+                    return;
+                }
             },
         };
 
         self.device_scan_state = DeviceScanState::Idle;
         if let Some(devices) = devices {
-            match device_scan_result_action(self.device_refresh_blocked(), devices.is_empty()) {
+            match device_scan_result_action(self.device_refresh_blocked()) {
                 DeviceScanResultAction::Apply => self.apply_device_scan_result(devices, trigger),
                 DeviceScanResultAction::Discard => {}
             }
@@ -245,7 +263,7 @@ mod tests {
     #[test]
     fn pending_settings_work_discards_nonempty_scan_results() {
         assert_eq!(
-            device_scan_result_action(true, false),
+            device_scan_result_action(true),
             DeviceScanResultAction::Discard
         );
     }
@@ -253,11 +271,7 @@ mod tests {
     #[test]
     fn automatic_scan_applies_when_connected_to_detect_disconnects() {
         assert_eq!(
-            device_scan_result_action(false, false),
-            DeviceScanResultAction::Apply
-        );
-        assert_eq!(
-            device_scan_result_action(true, true),
+            device_scan_result_action(false),
             DeviceScanResultAction::Apply
         );
     }
@@ -267,11 +281,11 @@ mod tests {
         let ctx = egui::Context::default();
         let mut app = test_app();
         let device = test_device("/test/keyboard");
-        app.device_manager.replace_devices(vec![device]);
+        app.device_manager.replace_devices(vec![device.clone()]);
         app.selected_device = Some(0);
         app.hid_device = Some(crate::hid::HidDevice::test_device().0);
         let (tx, rx) = mpsc::channel();
-        tx.send(Vec::new()).unwrap();
+        tx.send(Ok(Vec::new())).unwrap();
         app.device_scan_state = DeviceScanState::Scanning {
             rx,
             trigger: DeviceScanTrigger::Automatic,
@@ -285,16 +299,16 @@ mod tests {
     }
 
     #[test]
-    fn automatic_empty_scan_clears_connected_keyboard_with_pending_combo() {
+    fn automatic_empty_scan_preserves_pending_combo() {
         let ctx = egui::Context::default();
         let mut app = test_app();
         let device = test_device("/test/keyboard");
-        app.device_manager.replace_devices(vec![device]);
+        app.device_manager.replace_devices(vec![device.clone()]);
         app.selected_device = Some(0);
         app.hid_device = Some(crate::hid::HidDevice::test_device().0);
         app.combo_dirty = true;
         let (tx, rx) = mpsc::channel();
-        tx.send(Vec::new()).unwrap();
+        tx.send(Ok(Vec::new())).unwrap();
         app.device_scan_state = DeviceScanState::Scanning {
             rx,
             trigger: DeviceScanTrigger::Automatic,
@@ -302,8 +316,10 @@ mod tests {
 
         app.poll_device_scan(&ctx);
 
-        assert!(app.hid_device.is_none());
-        assert!(app.selected_device.is_none());
+        assert!(app.hid_device.is_some());
+        assert_eq!(app.selected_device, Some(0));
+        assert!(app.combo_dirty);
+        assert_eq!(app.device_manager.devices()[0].path, device.path);
         assert!(matches!(app.device_scan_state, DeviceScanState::Idle));
     }
 
@@ -317,7 +333,7 @@ mod tests {
         app.hid_device = Some(crate::hid::HidDevice::test_device().0);
         app.combo_dirty = true;
         let (tx, rx) = mpsc::channel();
-        tx.send(vec![test_device("/test/keyboard-b")]).unwrap();
+        tx.send(Ok(vec![test_device("/test/keyboard-b")])).unwrap();
         app.device_scan_state = DeviceScanState::Scanning {
             rx,
             trigger: DeviceScanTrigger::Automatic,
@@ -339,7 +355,7 @@ mod tests {
         app.selected_device = Some(0);
         app.hid_device = Some(crate::hid::HidDevice::test_device().0);
         let (tx, rx) = mpsc::channel();
-        tx.send(vec![device]).unwrap();
+        tx.send(Ok(vec![device])).unwrap();
         app.device_scan_state = DeviceScanState::Scanning {
             rx,
             trigger: DeviceScanTrigger::Manual,
@@ -363,7 +379,7 @@ mod tests {
         app.selected_device = Some(0);
         app.hid_device = Some(crate::hid::HidDevice::test_device().0);
         let (tx, rx) = mpsc::channel();
-        tx.send(vec![reenumerated]).unwrap();
+        tx.send(Ok(vec![reenumerated])).unwrap();
         app.device_scan_state = DeviceScanState::Scanning {
             rx,
             trigger: DeviceScanTrigger::Automatic,
@@ -388,5 +404,38 @@ mod tests {
 
         assert!(app.hid_device.is_some());
         assert!(matches!(app.connect_state, ConnectState::Idle));
+    }
+
+    #[test]
+    fn scan_worker_failure_preserves_connected_session() {
+        let ctx = egui::Context::default();
+        let mut app = test_app();
+        let device = test_device("/test/keyboard");
+        app.device_manager.replace_devices(vec![device]);
+        app.selected_device = Some(0);
+        app.hid_device = Some(crate::hid::HidDevice::test_device().0);
+        let (tx, rx) = mpsc::channel();
+        tx.send(Err("hidapi initialization failed".to_owned()))
+            .unwrap();
+        app.device_scan_state = DeviceScanState::Scanning {
+            rx,
+            trigger: DeviceScanTrigger::Automatic,
+        };
+
+        app.poll_device_scan(&ctx);
+
+        assert!(app.hid_device.is_some());
+        assert_eq!(app.selected_device, Some(0));
+        assert!(app.status_msg.starts_with("Device scan failed:"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_manual_scan_never_enumerates_with_open_hid() {
+        let mut app = test_app();
+        app.hid_device = Some(crate::hid::HidDevice::test_device().0);
+
+        assert!(!app.start_manual_device_scan());
+        assert!(matches!(app.device_scan_state, DeviceScanState::Idle));
     }
 }

--- a/src/ui/device_scan.rs
+++ b/src/ui/device_scan.rs
@@ -6,23 +6,27 @@ fn should_wait_for_manual_device_selection(status_msg: &str) -> bool {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum DeviceScanResultAction {
-    Wait,
+    Discard,
     Apply,
 }
 
-fn device_scan_result_action(refresh_blocked: bool) -> DeviceScanResultAction {
-    if refresh_blocked {
-        DeviceScanResultAction::Wait
-    } else {
+fn device_scan_result_action(refresh_blocked: bool, devices_empty: bool) -> DeviceScanResultAction {
+    if devices_empty || !refresh_blocked {
         DeviceScanResultAction::Apply
+    } else {
+        DeviceScanResultAction::Discard
     }
 }
 
 fn same_keyboard_after_reenumeration(previous: &Device, candidate: &Device) -> bool {
-    previous.vendor_id == candidate.vendor_id
-        && previous.product_id == candidate.product_id
-        && !previous.serial_number.is_empty()
-        && previous.serial_number == candidate.serial_number
+    if previous.vendor_id != candidate.vendor_id || previous.product_id != candidate.product_id {
+        return false;
+    }
+    if !previous.serial_number.is_empty() || !candidate.serial_number.is_empty() {
+        return !previous.serial_number.is_empty()
+            && previous.serial_number == candidate.serial_number;
+    }
+    previous.name == candidate.name && previous.manufacturer == candidate.manufacturer
 }
 
 impl EntropyApp {
@@ -38,10 +42,6 @@ impl EntropyApp {
         if !matches!(self.device_scan_state, DeviceScanState::Idle) {
             return false;
         }
-        if self.device_refresh_blocked() {
-            return false;
-        }
-
         #[cfg(target_os = "macos")]
         if crate::hid::macos_hid_scan_disabled_for_rosetta() {
             if self.status_msg.is_empty() {
@@ -80,15 +80,6 @@ impl EntropyApp {
             DeviceScanState::Idle => return,
             DeviceScanState::Scanning { trigger, .. } => *trigger,
         };
-        let action = device_scan_result_action(self.device_refresh_blocked());
-        match action {
-            DeviceScanResultAction::Wait => {
-                ctx.request_repaint_after(std::time::Duration::from_millis(25));
-                return;
-            }
-            DeviceScanResultAction::Apply => {}
-        }
-
         let devices = match &self.device_scan_state {
             DeviceScanState::Idle => return,
             DeviceScanState::Scanning { rx, .. } => match rx.try_recv() {
@@ -103,7 +94,10 @@ impl EntropyApp {
 
         self.device_scan_state = DeviceScanState::Idle;
         if let Some(devices) = devices {
-            self.apply_device_scan_result(devices, trigger);
+            match device_scan_result_action(self.device_refresh_blocked(), devices.is_empty()) {
+                DeviceScanResultAction::Apply => self.apply_device_scan_result(devices, trigger),
+                DeviceScanResultAction::Discard => {}
+            }
         }
     }
 
@@ -130,13 +124,16 @@ impl EntropyApp {
                 self.selected_device = None;
                 self.clear_connected_keyboard_state(crate::i18n::tr(
                     self.app_settings.language,
-                    TrKey::NoDevicesFound,
+                    crate::i18n::Key::NoDevicesFound,
                 ));
             } else {
                 self.qmk_hid_hosts.clear();
                 if trigger == DeviceScanTrigger::Manual {
-                    self.status_msg =
-                        crate::i18n::tr(self.app_settings.language, TrKey::NoDevicesFound).into();
+                    self.status_msg = crate::i18n::tr(
+                        self.app_settings.language,
+                        crate::i18n::Key::NoDevicesFound,
+                    )
+                    .into();
                 }
             }
             return;
@@ -170,10 +167,20 @@ impl EntropyApp {
         }
 
         if let Some(previous_device) = previous_device {
-            if let Some(idx) = self.device_manager.devices().iter().position(|candidate| {
+            let exact_match = self.device_manager.devices().iter().position(|candidate| {
                 candidate.display_name_cache_key() == previous_device.display_name_cache_key()
-                    || same_keyboard_after_reenumeration(&previous_device, candidate)
-            }) {
+            });
+            let reenumerated_match = exact_match.or_else(|| {
+                let mut matches = self.device_manager.devices().iter().enumerate().filter_map(
+                    |(idx, candidate)| {
+                        same_keyboard_after_reenumeration(&previous_device, candidate)
+                            .then_some(idx)
+                    },
+                );
+                let matched = matches.next()?;
+                matches.next().is_none().then_some(matched)
+            });
+            if let Some(idx) = reenumerated_match {
                 let reenumerated = self.device_manager.devices()[idx].display_name_cache_key()
                     != previous_device.display_name_cache_key();
                 self.selected_device = Some(idx);
@@ -190,7 +197,7 @@ impl EntropyApp {
                 self.selected_device = None;
                 self.clear_connected_keyboard_state(crate::i18n::tr(
                     self.app_settings.language,
-                    TrKey::NoDevicesFound,
+                    crate::i18n::Key::NoDevicesFound,
                 ));
                 return;
             }
@@ -236,17 +243,21 @@ mod tests {
     }
 
     #[test]
-    fn pending_settings_work_defers_scan_results() {
+    fn pending_settings_work_discards_nonempty_scan_results() {
         assert_eq!(
-            device_scan_result_action(true),
-            DeviceScanResultAction::Wait
+            device_scan_result_action(true, false),
+            DeviceScanResultAction::Discard
         );
     }
 
     #[test]
     fn automatic_scan_applies_when_connected_to_detect_disconnects() {
         assert_eq!(
-            device_scan_result_action(false),
+            device_scan_result_action(false, false),
+            DeviceScanResultAction::Apply
+        );
+        assert_eq!(
+            device_scan_result_action(true, true),
             DeviceScanResultAction::Apply
         );
     }
@@ -274,6 +285,52 @@ mod tests {
     }
 
     #[test]
+    fn automatic_empty_scan_clears_connected_keyboard_with_pending_combo() {
+        let ctx = egui::Context::default();
+        let mut app = test_app();
+        let device = test_device("/test/keyboard");
+        app.device_manager.replace_devices(vec![device]);
+        app.selected_device = Some(0);
+        app.hid_device = Some(crate::hid::HidDevice::test_device().0);
+        app.combo_dirty = true;
+        let (tx, rx) = mpsc::channel();
+        tx.send(Vec::new()).unwrap();
+        app.device_scan_state = DeviceScanState::Scanning {
+            rx,
+            trigger: DeviceScanTrigger::Automatic,
+        };
+
+        app.poll_device_scan(&ctx);
+
+        assert!(app.hid_device.is_none());
+        assert!(app.selected_device.is_none());
+        assert!(matches!(app.device_scan_state, DeviceScanState::Idle));
+    }
+
+    #[test]
+    fn pending_combo_discards_nonempty_automatic_scan_result() {
+        let ctx = egui::Context::default();
+        let mut app = test_app();
+        let previous = test_device("/test/keyboard-a");
+        app.device_manager.replace_devices(vec![previous.clone()]);
+        app.selected_device = Some(0);
+        app.hid_device = Some(crate::hid::HidDevice::test_device().0);
+        app.combo_dirty = true;
+        let (tx, rx) = mpsc::channel();
+        tx.send(vec![test_device("/test/keyboard-b")]).unwrap();
+        app.device_scan_state = DeviceScanState::Scanning {
+            rx,
+            trigger: DeviceScanTrigger::Automatic,
+        };
+
+        app.poll_device_scan(&ctx);
+
+        assert!(app.hid_device.is_some());
+        assert_eq!(app.device_manager.devices()[0].path, previous.path);
+        assert!(matches!(app.device_scan_state, DeviceScanState::Idle));
+    }
+
+    #[test]
     fn manual_same_device_scan_reopens_stale_hid() {
         let ctx = egui::Context::default();
         let mut app = test_app();
@@ -286,6 +343,30 @@ mod tests {
         app.device_scan_state = DeviceScanState::Scanning {
             rx,
             trigger: DeviceScanTrigger::Manual,
+        };
+
+        app.poll_device_scan(&ctx);
+
+        assert!(app.hid_device.is_none());
+        assert!(matches!(app.connect_state, ConnectState::Loading { .. }));
+    }
+
+    #[test]
+    fn automatic_empty_serial_reenumeration_reopens_hid() {
+        let ctx = egui::Context::default();
+        let mut app = test_app();
+        let mut previous = test_device("/test/keyboard-old");
+        previous.serial_number.clear();
+        let mut reenumerated = test_device("/test/keyboard-new");
+        reenumerated.serial_number.clear();
+        app.device_manager.replace_devices(vec![previous]);
+        app.selected_device = Some(0);
+        app.hid_device = Some(crate::hid::HidDevice::test_device().0);
+        let (tx, rx) = mpsc::channel();
+        tx.send(vec![reenumerated]).unwrap();
+        app.device_scan_state = DeviceScanState::Scanning {
+            rx,
+            trigger: DeviceScanTrigger::Automatic,
         };
 
         app.poll_device_scan(&ctx);

--- a/src/ui/device_scan.rs
+++ b/src/ui/device_scan.rs
@@ -4,10 +4,42 @@ fn should_wait_for_manual_device_selection(status_msg: &str) -> bool {
     status_msg.starts_with("Open failed:") || status_msg.starts_with("Connect timeout")
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DeviceScanResultAction {
+    Wait,
+    Apply,
+}
+
+fn device_scan_result_action(refresh_blocked: bool) -> DeviceScanResultAction {
+    if refresh_blocked {
+        DeviceScanResultAction::Wait
+    } else {
+        DeviceScanResultAction::Apply
+    }
+}
+
+fn same_keyboard_after_reenumeration(previous: &Device, candidate: &Device) -> bool {
+    previous.vendor_id == candidate.vendor_id
+        && previous.product_id == candidate.product_id
+        && !previous.serial_number.is_empty()
+        && previous.serial_number == candidate.serial_number
+}
+
 impl EntropyApp {
     pub(super) fn start_device_scan(&mut self) {
+        self.start_device_scan_with_trigger(DeviceScanTrigger::Automatic);
+    }
+
+    pub(super) fn start_manual_device_scan(&mut self) -> bool {
+        self.start_device_scan_with_trigger(DeviceScanTrigger::Manual)
+    }
+
+    fn start_device_scan_with_trigger(&mut self, trigger: DeviceScanTrigger) -> bool {
         if !matches!(self.device_scan_state, DeviceScanState::Idle) {
-            return;
+            return false;
+        }
+        if self.device_refresh_blocked() {
+            return false;
         }
 
         #[cfg(target_os = "macos")]
@@ -15,21 +47,51 @@ impl EntropyApp {
             if self.status_msg.is_empty() {
                 self.status_msg = crate::hid::macos_rosetta_hid_status_message().into();
             }
-            return;
+            return false;
         }
 
         let (tx, rx) = mpsc::channel();
-        self.device_scan_state = DeviceScanState::Scanning(rx);
+        self.device_scan_state = DeviceScanState::Scanning { rx, trigger };
         std::thread::spawn(move || {
             let _ = tx.send(DeviceManager::scan_devices());
         });
+        true
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(super) fn device_refresh_blocked(&self) -> bool {
+        self.hid_write_task_active()
+            || matches!(self.connect_state, ConnectState::Loading { .. })
+            || self.layer_write_task.is_some()
+            || !self.pending_tap_hold_numeric_writes.is_empty()
+            || self.tap_hold_numeric_write_due.is_some()
+            || self.keycode_picker.macros_dirty
+            || self.keycode_picker.tap_dance_dirty
+            || self.combo_dirty
+            || self.combo_term_dirty
+            || self.key_override_dirty
+            || self.pending_entlayout_import_path.is_some()
+            || self.pending_entsettings_import_path.is_some()
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     pub(super) fn poll_device_scan(&mut self, ctx: &egui::Context) {
+        let trigger = match &self.device_scan_state {
+            DeviceScanState::Idle => return,
+            DeviceScanState::Scanning { trigger, .. } => *trigger,
+        };
+        let action = device_scan_result_action(self.device_refresh_blocked());
+        match action {
+            DeviceScanResultAction::Wait => {
+                ctx.request_repaint_after(std::time::Duration::from_millis(25));
+                return;
+            }
+            DeviceScanResultAction::Apply => {}
+        }
+
         let devices = match &self.device_scan_state {
             DeviceScanState::Idle => return,
-            DeviceScanState::Scanning(rx) => match rx.try_recv() {
+            DeviceScanState::Scanning { rx, .. } => match rx.try_recv() {
                 Ok(devices) => Some(devices),
                 Err(mpsc::TryRecvError::Empty) => {
                     ctx.request_repaint_after(std::time::Duration::from_millis(25));
@@ -41,16 +103,16 @@ impl EntropyApp {
 
         self.device_scan_state = DeviceScanState::Idle;
         if let Some(devices) = devices {
-            self.apply_device_scan_result(devices);
+            self.apply_device_scan_result(devices, trigger);
         }
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    fn apply_device_scan_result(&mut self, devices: Vec<Device>) {
-        let previous_device_key = self
+    fn apply_device_scan_result(&mut self, devices: Vec<Device>, trigger: DeviceScanTrigger) {
+        let previous_device = self
             .selected_device
             .and_then(|idx| self.device_manager.devices().get(idx))
-            .map(Device::display_name_cache_key);
+            .cloned();
         let was_loading = matches!(self.connect_state, ConnectState::Loading { .. });
 
         self.device_manager.replace_devices(devices);
@@ -66,11 +128,26 @@ impl EntropyApp {
         if self.device_manager.devices().is_empty() {
             if self.selected_device.is_some() || self.layout.is_some() || was_loading {
                 self.selected_device = None;
-                self.clear_connected_keyboard_state("No device detected");
+                self.clear_connected_keyboard_state(crate::i18n::tr(
+                    self.app_settings.language,
+                    TrKey::NoDevicesFound,
+                ));
             } else {
                 self.qmk_hid_hosts.clear();
+                if trigger == DeviceScanTrigger::Manual {
+                    self.status_msg =
+                        crate::i18n::tr(self.app_settings.language, TrKey::NoDevicesFound).into();
+                }
             }
             return;
+        }
+
+        if trigger == DeviceScanTrigger::Manual {
+            self.status_msg = match self.app_settings.language {
+                crate::i18n::Language::Russian => "Список устройств обновлён",
+                crate::i18n::Language::English => "Device list refreshed",
+            }
+            .into();
         }
 
         if self.selected_device.is_none()
@@ -92,19 +169,29 @@ impl EntropyApp {
             return;
         }
 
-        if let Some(device_key) = previous_device_key {
-            if let Some(idx) = self
-                .device_manager
-                .devices()
-                .iter()
-                .position(|dev| dev.display_name_cache_key() == device_key)
-            {
+        if let Some(previous_device) = previous_device {
+            if let Some(idx) = self.device_manager.devices().iter().position(|candidate| {
+                candidate.display_name_cache_key() == previous_device.display_name_cache_key()
+                    || same_keyboard_after_reenumeration(&previous_device, candidate)
+            }) {
+                let reenumerated = self.device_manager.devices()[idx].display_name_cache_key()
+                    != previous_device.display_name_cache_key();
                 self.selected_device = Some(idx);
-                if self.layout.is_none() && !was_loading {
+                if (trigger == DeviceScanTrigger::Manual || reenumerated || self.layout.is_none())
+                    && !was_loading
+                {
                     self.start_connect(idx);
                 } else {
                     self.sync_qmk_hid_host_bridges();
                 }
+                return;
+            }
+            if trigger == DeviceScanTrigger::Automatic {
+                self.selected_device = None;
+                self.clear_connected_keyboard_state(crate::i18n::tr(
+                    self.app_settings.language,
+                    TrKey::NoDevicesFound,
+                ));
                 return;
             }
         }
@@ -118,6 +205,25 @@ impl EntropyApp {
 mod tests {
     use super::*;
 
+    fn test_app() -> EntropyApp {
+        let ctx = egui::Context::default();
+        let creation_context = eframe::CreationContext::_new_kittest(ctx);
+        EntropyApp::new(&creation_context)
+    }
+
+    fn test_device(path: &str) -> Device {
+        Device {
+            name: "Test Keyboard".to_owned(),
+            vendor_id: 0x1209,
+            product_id: 0x2327,
+            manufacturer: "Entropy".to_owned(),
+            serial_number: "serial".to_owned(),
+            bus_type: "USB".to_owned(),
+            path: path.to_owned(),
+            firmware: FirmwareProtocol::Vial,
+        }
+    }
+
     #[test]
     fn manual_device_selection_waits_after_open_failure() {
         assert!(should_wait_for_manual_device_selection(
@@ -127,5 +233,79 @@ mod tests {
             "Connect timeout — RMK/Vial device did not finish loading"
         ));
         assert!(!should_wait_for_manual_device_selection(""));
+    }
+
+    #[test]
+    fn pending_settings_work_defers_scan_results() {
+        assert_eq!(
+            device_scan_result_action(true),
+            DeviceScanResultAction::Wait
+        );
+    }
+
+    #[test]
+    fn automatic_scan_applies_when_connected_to_detect_disconnects() {
+        assert_eq!(
+            device_scan_result_action(false),
+            DeviceScanResultAction::Apply
+        );
+    }
+
+    #[test]
+    fn automatic_empty_scan_clears_connected_keyboard_state() {
+        let ctx = egui::Context::default();
+        let mut app = test_app();
+        let device = test_device("/test/keyboard");
+        app.device_manager.replace_devices(vec![device]);
+        app.selected_device = Some(0);
+        app.hid_device = Some(crate::hid::HidDevice::test_device().0);
+        let (tx, rx) = mpsc::channel();
+        tx.send(Vec::new()).unwrap();
+        app.device_scan_state = DeviceScanState::Scanning {
+            rx,
+            trigger: DeviceScanTrigger::Automatic,
+        };
+
+        app.poll_device_scan(&ctx);
+
+        assert!(app.hid_device.is_none());
+        assert!(app.selected_device.is_none());
+        assert!(matches!(app.connect_state, ConnectState::Idle));
+    }
+
+    #[test]
+    fn manual_same_device_scan_reopens_stale_hid() {
+        let ctx = egui::Context::default();
+        let mut app = test_app();
+        let device = test_device("/test/keyboard");
+        app.device_manager.replace_devices(vec![device.clone()]);
+        app.selected_device = Some(0);
+        app.hid_device = Some(crate::hid::HidDevice::test_device().0);
+        let (tx, rx) = mpsc::channel();
+        tx.send(vec![device]).unwrap();
+        app.device_scan_state = DeviceScanState::Scanning {
+            rx,
+            trigger: DeviceScanTrigger::Manual,
+        };
+
+        app.poll_device_scan(&ctx);
+
+        assert!(app.hid_device.is_none());
+        assert!(matches!(app.connect_state, ConnectState::Loading { .. }));
+    }
+
+    #[test]
+    fn refresh_data_with_pending_combo_keeps_connected_session() {
+        let mut app = test_app();
+        app.device_manager
+            .replace_devices(vec![test_device("/test/keyboard")]);
+        app.selected_device = Some(0);
+        app.hid_device = Some(crate::hid::HidDevice::test_device().0);
+        app.combo_dirty = true;
+
+        app.refresh_current_device_data();
+
+        assert!(app.hid_device.is_some());
+        assert!(matches!(app.connect_state, ConnectState::Idle));
     }
 }

--- a/src/ui/layout_device_dropdown.rs
+++ b/src/ui/layout_device_dropdown.rs
@@ -28,6 +28,20 @@ fn about_device_label(lang: crate::i18n::Language) -> &'static str {
     }
 }
 
+fn refresh_devices_label(lang: crate::i18n::Language) -> &'static str {
+    match lang {
+        crate::i18n::Language::Russian => "Обновить устройства",
+        crate::i18n::Language::English => "Refresh devices",
+    }
+}
+
+fn refreshing_devices_status(lang: crate::i18n::Language) -> &'static str {
+    match lang {
+        crate::i18n::Language::Russian => "Обновление списка устройств…",
+        crate::i18n::Language::English => "Refreshing device list…",
+    }
+}
+
 impl EntropyApp {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn draw_layout_device_dropdown(
@@ -51,6 +65,7 @@ impl EntropyApp {
             let device_count = self.device_manager.devices().len();
             let device_rows = device_count.max(1) as f32;
             let devices_h = 12.0 + device_rows * 30.0;
+            let refresh_devices_h = 36.0;
             let sticky_layout_h = 36.0;
             #[cfg(not(target_arch = "wasm32"))]
             let import_export_h = 102.0;
@@ -73,6 +88,7 @@ impl EntropyApp {
                     })
                     .collect()
             };
+            device_menu_labels.push(refresh_devices_label(lang).to_owned());
             if show_key_legend_switcher {
                 if let Some(order_key) = self.app_settings.key_legend_layout.order_i18n_key() {
                     device_menu_labels.push(crate::i18n::tr_catalog(lang, order_key).to_owned());
@@ -94,6 +110,7 @@ impl EntropyApp {
                     152.0,
                 ),
                 devices_h
+                    + refresh_devices_h
                     + key_legend_switcher_h
                     + import_export_h
                     + sticky_layout_h
@@ -178,6 +195,33 @@ impl EntropyApp {
                                 if self.selected_device != prev_selected {
                                     if let Some(idx) = self.selected_device {
                                         self.start_connect(idx);
+                                    }
+                                }
+
+                                #[cfg(not(target_arch = "wasm32"))]
+                                {
+                                    ui.add_space(6.0);
+                                    let refresh_enabled = matches!(
+                                        self.device_scan_state,
+                                        DeviceScanState::Idle
+                                    ) && !self.device_refresh_blocked();
+                                    if top_dropdown_item(
+                                        ui,
+                                        dropdown_size.x - 16.0,
+                                        refresh_devices_label(lang),
+                                        refresh_enabled,
+                                        false,
+                                    )
+                                    .clicked()
+                                        && refresh_enabled
+                                    {
+                                        self.close_top_dropdowns(ctx);
+                                        if self.start_manual_device_scan() {
+                                            self.status_msg =
+                                                refreshing_devices_status(lang).into();
+                                        }
+                                        ctx.request_repaint();
+                                        device_clicked = true;
                                     }
                                 }
 


### PR DESCRIPTION
## EN

### Problem

Background device scans could clear or switch an active keyboard when HID enumeration briefly changed, even while firmware settings still had pending writes. A reconnect also returned module and list editors to their first row, making a refresh look like the user's selected controller or setting had disappeared. Connected users had no explicit refresh command to control when device enumeration was applied.

### Fix

- Run automatic device discovery only while disconnected, and discard a late automatic result if a keyboard connected while that scan was in flight.
- Defer scan results and device switches while layer, macro, tap-dance, combo, tap-hold, or settings-import work is pending.
- Add an explicit Refresh devices command to the connected-device menu in English and Russian; manual results may update the active device list when no write is pending.
- Preserve the selected module group by stable kind/title and retain key-override and alternate-repeat rows across reconnects, clamped to the refreshed entry count.
- Add focused tests for pending-write deferral, automatic/manual scan policy, and reconnect selection restoration.

### Verification

- `cargo test`: 196 passed.
- Focused device refresh/reconnect tests: 6 passed.
- `cargo clippy --all-targets`: passed with existing repository warnings.
- `python3 scripts/check_i18n.py`: passed.
- Scoped `rustfmt --check` and `git diff --check`: passed. Repository-wide `cargo fmt --check` remains blocked by pre-existing formatting differences in `src/keycode.rs`.
- `TARGET=aarch64-apple-darwin scripts/build_macos_app.sh`: arm64 app, DMG, and ZIP built; architecture and code-signature validation passed.

## RU

### Проблема

Фоновое сканирование устройств могло сбросить или переключить активную клавиатуру при кратковременном изменении результатов HID-поиска, даже если запись настроек прошивки еще не завершилась. После переподключения редакторы модулей и списков также возвращались к первой строке, поэтому выбранный контроллер или параметр выглядел потерянным. Для подключенного устройства не было явной команды обновления, позволяющей пользователю выбрать момент применения результатов поиска.

### Исправление

- Автоматический поиск устройств выполняется только без подключенной клавиатуры; поздний результат автоматического поиска отбрасывается, если подключение завершилось во время сканирования.
- Результаты поиска и переключение устройств откладываются, пока выполняется запись слоев, макросов, tap dance, combos, tap-hold или импорт настроек.
- В меню подключенного устройства добавлена явная команда обновления списка на английском и русском языках; ручной результат применяется только при отсутствии незавершенной записи.
- Выбранная группа модулей восстанавливается по стабильным типу и названию, а строки Key Overrides и Alt Repeat сохраняются с ограничением по новому числу записей.
- Добавлены целевые тесты ожидания незавершенной записи, политики автоматического/ручного поиска и восстановления выбора после переподключения.

### Проверка

- `cargo test`: прошли 196 тестов.
- Целевые тесты обновления устройств и переподключения: прошли 6 тестов.
- `cargo clippy --all-targets`: прошел с существующими предупреждениями репозитория.
- `python3 scripts/check_i18n.py`: прошел.
- Scoped `rustfmt --check` и `git diff --check`: прошли. Общий `cargo fmt --check` по-прежнему блокируется существующими отличиями форматирования в `src/keycode.rs`.
- `TARGET=aarch64-apple-darwin scripts/build_macos_app.sh`: собраны arm64-приложение, DMG и ZIP; архитектура и подпись прошли проверку.
