### PR TITLE
Add module settings parser coverage

### DIFF
--- a/src/ui/device_settings_helpers.rs
+++ b/src/ui/device_settings_helpers.rs
@@ -808,7 +808,7 @@ impl EntropyApp {
         field: &serde_json::Value,
         supported_qmk_settings: &[u16],
     ) -> Option<ModuleSettingField> {
-        let qsid = field.get("qsid")?.as_u64()? as u16;
+        let qsid = u16::try_from(field.get("qsid")?.as_u64()?).ok()?;
         if !supported_qmk_settings.contains(&qsid) {
             return None;
         }
@@ -866,6 +866,17 @@ impl EntropyApp {
                 .min(u16::MAX as u64) as u16,
             variants,
         })
+    }
+
+    fn module_setting_widths(fields: &[ModuleSettingField]) -> std::collections::BTreeMap<u16, u8> {
+        let mut widths = std::collections::BTreeMap::<u16, u8>::new();
+        for field in fields {
+            widths
+                .entry(field.qsid)
+                .and_modify(|width| *width = (*width).max(field.width))
+                .or_insert(field.width);
+        }
+        widths
     }
 
     fn module_settings_group_kind(tab_name: &str) -> ModuleSettingsGroupKind {
@@ -953,14 +964,7 @@ impl EntropyApp {
             values: std::collections::BTreeMap::new(),
             supported: true,
         };
-        let mut widths = std::collections::BTreeMap::<u16, u8>::new();
-        for field in &settings.fields {
-            widths
-                .entry(field.qsid)
-                .and_modify(|width| *width = (*width).max(field.width))
-                .or_insert(field.width);
-        }
-        for (qsid, width) in widths {
+        for (qsid, width) in Self::module_setting_widths(&settings.fields) {
             let value = if width > 1 {
                 dev_conn.get_qmk_setting_u16(qsid)
             } else {
@@ -1348,5 +1352,118 @@ mod tests {
         assert!(EntropyApp::module_settings_encoder_visible(
             &settings, &layout, 0
         ));
+    }
+
+    #[test]
+    fn module_setting_parser_preserves_integer_width_and_bounds() {
+        let field = EntropyApp::parse_module_setting_field(
+            &serde_json::json!({
+                "title": " Ball DPI ",
+                "qsid": 120,
+                "type": "integer",
+                "width": 2,
+                "min": 100,
+                "max": 16000
+            }),
+            &[120],
+        )
+        .expect("supported integer field should parse");
+
+        assert_eq!(field.title, "Ball DPI");
+        assert_eq!(field.qsid, 120);
+        assert_eq!(field.kind, ModuleSettingKind::Integer);
+        assert_eq!(field.width, 2);
+        assert_eq!(field.min, 100);
+        assert_eq!(field.max, 16000);
+    }
+
+    #[test]
+    fn module_setting_parser_normalizes_select_metadata() {
+        let field = EntropyApp::parse_module_setting_field(
+            &serde_json::json!({
+                "title": "Mode",
+                "qsid": 134,
+                "type": "select",
+                "width": 0,
+                "bit": 99,
+                "variants": ["Normal", " Scroll ", ""]
+            }),
+            &[134],
+        )
+        .expect("supported select field should parse");
+
+        assert_eq!(field.kind, ModuleSettingKind::Select);
+        assert_eq!(field.width, 1);
+        assert_eq!(field.bit, 15);
+        assert_eq!(field.variants, vec!["Normal", "Scroll"]);
+        assert_eq!(field.min, 0);
+        assert_eq!(field.max, 1);
+    }
+
+    #[test]
+    fn module_setting_parser_rejects_unsupported_or_invalid_fields() {
+        let unsupported = serde_json::json!({
+            "title": "Mode",
+            "qsid": 134,
+            "type": "select"
+        });
+        let overflowed_qsid = serde_json::json!({
+            "title": "Mode",
+            "qsid": 65536,
+            "type": "select"
+        });
+        let blank_title = serde_json::json!({
+            "title": "  ",
+            "qsid": 134,
+            "type": "select"
+        });
+        let unknown_type = serde_json::json!({
+            "title": "Mode",
+            "qsid": 134,
+            "type": "slider"
+        });
+
+        assert!(EntropyApp::parse_module_setting_field(&unsupported, &[]).is_none());
+        assert!(EntropyApp::parse_module_setting_field(&overflowed_qsid, &[0]).is_none());
+        assert!(EntropyApp::parse_module_setting_field(&blank_title, &[134]).is_none());
+        assert!(EntropyApp::parse_module_setting_field(&unknown_type, &[134]).is_none());
+    }
+
+    #[test]
+    fn duplicate_module_qsid_uses_widest_read_width() {
+        let narrow = EntropyApp::parse_module_setting_field(
+            &serde_json::json!({
+                "title": "Mode",
+                "qsid": 134,
+                "type": "select",
+                "width": 1
+            }),
+            &[134, 135],
+        )
+        .unwrap();
+        let wide = EntropyApp::parse_module_setting_field(
+            &serde_json::json!({
+                "title": "Resolution",
+                "qsid": 134,
+                "type": "integer",
+                "width": 2
+            }),
+            &[134, 135],
+        )
+        .unwrap();
+        let other = EntropyApp::parse_module_setting_field(
+            &serde_json::json!({
+                "title": "Invert",
+                "qsid": 135,
+                "type": "boolean"
+            }),
+            &[134, 135],
+        )
+        .unwrap();
+
+        assert_eq!(
+            EntropyApp::module_setting_widths(&[narrow, wide, other]),
+            std::collections::BTreeMap::from([(134, 2), (135, 1)])
+        );
     }
 }


### PR DESCRIPTION
## EN

### Problem

The module-settings audit still lacked direct parser boundary coverage and a test for duplicate QSID read widths. Current `main` already covers verified writeback success and failure paths, while open PRs #91 and #94 add controller grouping and split-touchpad JSON fixtures. Duplicating those tests here would make this branch overlap unnecessarily.

The parser also converted JSON QSID values with an unchecked `as u16` cast, so values above 65535 could wrap into a supported setting ID.

### Fix

- Reject module-setting QSID values that do not fit in `u16` instead of allowing integer wraparound.
- Extract duplicate-QSID width resolution into a focused helper that always selects the widest required HID read.
- Add parser tests for integer bounds, select metadata normalization, unsupported fields, blank titles, unknown types, and out-of-range QSIDs.
- Add a duplicate-QSID test covering mixed one-byte and two-byte fields.
- Keep grouping and split-device fixture coverage in PRs #91 and #94, and keep existing writeback-path tests on `main`.

### Verification

- `cargo test`: 195 passed.
- `cargo test module_setting`: 11 passed.
- `cargo clippy --all-targets`: passed with existing repository warnings.
- `python3 scripts/check_i18n.py`: passed.
- Scoped `rustfmt --check` and `git diff --check`: passed. Repository-wide `cargo fmt --all -- --check` remains blocked by pre-existing formatting differences in `src/keycode.rs`.
- `TARGET=aarch64-apple-darwin scripts/build_macos_app.sh`: arm64 app, DMG, and ZIP built; architecture and code-signature validation passed.

## RU

### Проблема

В аудите настроек модулей оставались непокрытыми граничные случаи парсера и выбор ширины чтения для повторяющихся QSID. Текущая ветка `main` уже содержит тесты успешной и ошибочной проверенной записи, а открытые PR #91 и #94 добавляют JSON-фикстуры для группировки контроллеров и разделенных touchpad-настроек. Дублирование этих тестов создало бы лишнее пересечение между ветками.

Кроме того, парсер преобразовывал QSID из JSON через непроверенный `as u16`, поэтому значения больше 65535 могли переполниться и превратиться в поддерживаемый идентификатор настройки.

### Исправление

- QSID, не помещающиеся в `u16`, теперь отклоняются без целочисленного переполнения.
- Логика выбора ширины для повторяющихся QSID вынесена в отдельную функцию, которая всегда выбирает самое широкое требуемое HID-чтение.
- Добавлены тесты парсера для границ integer-полей, нормализации select-метаданных, неподдерживаемых полей, пустых заголовков, неизвестных типов и QSID вне диапазона.
- Добавлен тест повторяющегося QSID с одно- и двухбайтовыми полями.
- Покрытие группировки и split-устройств остается в PR #91 и #94, а существующие тесты записи остаются в `main`.

### Проверка

- `cargo test`: прошли 195 тестов.
- `cargo test module_setting`: прошли 11 тестов.
- `cargo clippy --all-targets`: прошел с существующими предупреждениями репозитория.
- `python3 scripts/check_i18n.py`: прошел.
- Scoped `rustfmt --check` и `git diff --check`: прошли. Общий `cargo fmt --all -- --check` по-прежнему блокируется существующими отличиями форматирования в `src/keycode.rs`.
- `TARGET=aarch64-apple-darwin scripts/build_macos_app.sh`: собраны arm64-приложение, DMG и ZIP; архитектура и подпись прошли проверку.
