### PR TITLE
fix: clarify inherited key display

### DIFF
--- a/src/ui/layout_image_export.rs
+++ b/src/ui/layout_image_export.rs
@@ -931,26 +931,7 @@ impl EntropyApp {
             let kc = layout.get_keycode(layer_idx, key_idx);
             let (label, dimmed) = match kc {
                 0x0000 => (String::new(), false),
-                0x0001 => {
-                    let fallback = (0..layer_idx)
-                        .rev()
-                        .map(|fallback_layer| layout.get_keycode(fallback_layer, key_idx))
-                        .find(|fallback| !matches!(*fallback, 0x0000 | 0x0001));
-                    match fallback {
-                        Some(fallback_kc) => (
-                            export_keycode_label_with_macro_names(
-                                fallback_kc,
-                                &layout.custom_keycodes,
-                                &self.layer_names,
-                                &self.keycode_picker.macro_names,
-                                &self.keycode_picker.tap_dance_names,
-                                self.app_settings.layout_image_export.key_legend_layout,
-                            ),
-                            true,
-                        ),
-                        None => (String::new(), false),
-                    }
-                }
+                0x0001 => ("▽".to_string(), true),
                 value => (
                     export_keycode_label_with_macro_names(
                         value,
@@ -1111,26 +1092,7 @@ impl EntropyApp {
             let kc = layout.get_keycode(layer_idx, key_idx);
             let (label, dimmed) = match kc {
                 0x0000 => (String::new(), false),
-                0x0001 => {
-                    let fallback = (0..layer_idx)
-                        .rev()
-                        .map(|fallback_layer| layout.get_keycode(fallback_layer, key_idx))
-                        .find(|fallback| !matches!(*fallback, 0x0000 | 0x0001));
-                    match fallback {
-                        Some(fallback_kc) => (
-                            export_keycode_label_with_macro_names(
-                                fallback_kc,
-                                &layout.custom_keycodes,
-                                &self.layer_names,
-                                &self.keycode_picker.macro_names,
-                                &self.keycode_picker.tap_dance_names,
-                                self.app_settings.layout_image_export.key_legend_layout,
-                            ),
-                            true,
-                        ),
-                        None => (String::new(), false),
-                    }
-                }
+                0x0001 => ("▽".to_string(), true),
                 value => (
                     export_keycode_label_with_macro_names(
                         value,
@@ -1444,19 +1406,10 @@ fn draw_encoder_export(
         )
         .replace('\n', " ")
     };
-    let encoder_label = |visual_idx: usize, kc: u16| -> (String, bool) {
+    let encoder_label = |_visual_idx: usize, kc: u16| -> (String, bool) {
         match kc {
             0x0000 => (String::new(), false),
-            0x0001 => {
-                let fallback = (0..layer_idx)
-                    .rev()
-                    .map(|fallback_layer| layout.get_encoder_keycode(fallback_layer, visual_idx))
-                    .find(|fallback| !matches!(*fallback, 0x0000 | 0x0001));
-                match fallback {
-                    Some(fallback_kc) => (encoder_value_label(fallback_kc), true),
-                    None => ("▽".to_string(), false),
-                }
-            }
+            0x0001 => ("▽".to_string(), true),
             value => (encoder_value_label(value), false),
         }
     };
@@ -1575,19 +1528,10 @@ fn write_encoder_svg(
         )
         .replace('\n', " ")
     };
-    let encoder_label = |visual_idx: usize, kc: u16| -> (String, bool) {
+    let encoder_label = |_visual_idx: usize, kc: u16| -> (String, bool) {
         match kc {
             0x0000 => (String::new(), false),
-            0x0001 => {
-                let fallback = (0..layer_idx)
-                    .rev()
-                    .map(|fallback_layer| layout.get_encoder_keycode(fallback_layer, visual_idx))
-                    .find(|fallback| !matches!(*fallback, 0x0000 | 0x0001));
-                match fallback {
-                    Some(fallback_kc) => (encoder_value_label(fallback_kc), true),
-                    None => ("▽".to_string(), false),
-                }
-            }
+            0x0001 => ("▽".to_string(), true),
             value => (encoder_value_label(value), false),
         }
     };

--- a/src/ui/layout_indicator_preview.rs
+++ b/src/ui/layout_indicator_preview.rs
@@ -78,7 +78,10 @@ fn draw_sticky_encoder_arrow(
             center.y + rad.sin() * r,
         ));
     }
-    painter.add(egui::Shape::line(points.clone(), Stroke::new(1.7_f32, color)));
+    painter.add(egui::Shape::line(
+        points.clone(),
+        Stroke::new(1.7_f32, color),
+    ));
     if points.len() >= 2 {
         let end = points[points.len() - 1];
         let prev = points[points.len() - 2];
@@ -425,30 +428,22 @@ impl EntropyApp {
                 continue;
             }
 
-            let label_kc = if is_transparent {
-                (0..key_layer)
-                    .rev()
-                    .map(|fallback_layer| layout.get_keycode(fallback_layer, *ki))
-                    .find(|fallback| !matches!(*fallback, 0x0000 | 0x0001))
-                    .unwrap_or(0x0000)
+            let label = if is_transparent {
+                "▽".to_string()
             } else {
-                kc
-            };
-            if label_kc == 0x0000 {
-                continue;
-            }
-            let label = number_row_shifted_label(
-                keycode_label_with_macro_names(
-                    label_kc,
-                    &layout.custom_keycodes,
-                    layer_names,
-                    macro_names,
-                    tap_dance_names,
+                number_row_shifted_label(
+                    keycode_label_with_macro_names(
+                        kc,
+                        &layout.custom_keycodes,
+                        layer_names,
+                        macro_names,
+                        tap_dance_names,
+                        key_legend_layout,
+                    ),
+                    show_shifted_number_symbols,
                     key_legend_layout,
-                ),
-                show_shifted_number_symbols,
-                key_legend_layout,
-            );
+                )
+            };
             draw_sticky_key_label(
                 &painter,
                 *key_rect,
@@ -471,23 +466,12 @@ impl EntropyApp {
             .replace('\n', " ")
         };
         let label_for = |encoder_target: Option<(usize, u16)>| -> (String, bool) {
-            let Some((visual_idx, kc)) = encoder_target else {
+            let Some((_visual_idx, kc)) = encoder_target else {
                 return (String::new(), false);
             };
             let (label, dimmed) = match kc {
                 0x0000 => (String::new(), false),
-                0x0001 => {
-                    let fallback = (0..layer)
-                        .rev()
-                        .map(|fallback_layer| {
-                            layout.get_encoder_keycode(fallback_layer, visual_idx)
-                        })
-                        .find(|fallback| !matches!(*fallback, 0x0000 | 0x0001));
-                    match fallback {
-                        Some(fallback_kc) => (encoder_value_label(fallback_kc), true),
-                        None => ("▽".to_string(), false),
-                    }
-                }
+                0x0001 => ("▽".to_string(), true),
                 value => (encoder_value_label(value), false),
             };
             (sticky_compact_label(&label, 9), dimmed)
@@ -662,26 +646,7 @@ impl EntropyApp {
                         .unwrap_or(layer);
                     let kc = layout.get_keycode(press_layer, press_ki);
                     if kc == 0x0001 {
-                        let fallback_kc = (0..press_layer)
-                            .rev()
-                            .map(|fallback_layer| layout.get_keycode(fallback_layer, press_ki))
-                            .find(|fallback| !matches!(*fallback, 0x0000 | 0x0001))
-                            .unwrap_or(0x0000);
-                        if fallback_kc == 0x0000 {
-                            ("▽".to_string(), false)
-                        } else {
-                            (
-                                keycode_label_with_macro_names(
-                                    fallback_kc,
-                                    &layout.custom_keycodes,
-                                    layer_names,
-                                    macro_names,
-                                    tap_dance_names,
-                                    key_legend_layout,
-                                ),
-                                true,
-                            )
-                        }
+                        ("▽".to_string(), true)
                     } else if kc == 0x0000 {
                         (String::new(), false)
                     } else {

--- a/src/ui/layout_keyboard.rs
+++ b/src/ui/layout_keyboard.rs
@@ -762,26 +762,7 @@ impl EntropyApp {
                 let (press_label, press_dimmed) = {
                     let kc = layout.get_keycode(layer, press_ki);
                     if kc == 0x0001 {
-                        let fallback_kc = (0..layer)
-                            .rev()
-                            .map(|l| layout.get_keycode(l, press_ki))
-                            .find(|&k| !matches!(k, 0x0000 | 0x0001))
-                            .unwrap_or(0x0000);
-                        if fallback_kc == 0x0000 {
-                            ("▽".to_string(), false)
-                        } else {
-                            (
-                                keycode_label_with_macro_names(
-                                    fallback_kc,
-                                    &layout.custom_keycodes,
-                                    &self.layer_names,
-                                    &self.keycode_picker.macro_names,
-                                    &self.keycode_picker.tap_dance_names,
-                                    self.app_settings.key_legend_layout,
-                                ),
-                                true,
-                            )
-                        }
+                        ("▽".to_string(), true)
                     } else if kc == 0x0000 {
                         (String::new(), false)
                     } else {

--- a/src/ui/layout_keyboard.rs
+++ b/src/ui/layout_keyboard.rs
@@ -340,36 +340,7 @@ impl EntropyApp {
             if kc == 0x0001 {
                 paint_layout_keycap(painter, draw_rect, key.rotation, bg, key_border_stroke);
                 if !is_hovering {
-                    let fallback_kc = (0..layer)
-                        .rev()
-                        .map(|l| layout.get_keycode(l, *ki))
-                        .find(|&k| k != 0x0001)
-                        .unwrap_or(0x0000);
-                    let label = if fallback_kc == 0x0000 || fallback_kc == 0x0001 {
-                        String::new()
-                    } else {
-                        keycode_label_with_macro_names(
-                            fallback_kc,
-                            &layout.custom_keycodes,
-                            &self.layer_names,
-                            &self.keycode_picker.macro_names,
-                            &self.keycode_picker.tap_dance_names,
-                            self.app_settings.key_legend_layout,
-                        )
-                    };
-                    let label = inherited_key_label_or_marker(label);
-                    let label = number_row_shifted_label(
-                        label,
-                        self.app_settings.show_shifted_number_symbols,
-                        self.app_settings.key_legend_layout,
-                    );
-                    draw_key_label_dimmed(
-                        painter,
-                        draw_rect,
-                        &label,
-                        dark,
-                        key.rotation.to_radians(),
-                    );
+                    draw_key_label_dimmed(painter, draw_rect, "▽", dark, key.rotation.to_radians());
                 }
             } else if kc == 0x0000 {
                 paint_layout_keycap(painter, draw_rect, key.rotation, bg, key_border_stroke);
@@ -413,21 +384,10 @@ impl EntropyApp {
             )
             .replace('\n', " ")
         };
-        let encoder_label = |layer_idx: usize, visual_idx: usize, kc: u16| -> (String, bool) {
+        let encoder_label = |_layer_idx: usize, _visual_idx: usize, kc: u16| -> (String, bool) {
             match kc {
                 0x0000 => (String::new(), false),
-                0x0001 => {
-                    let fallback = (0..layer_idx)
-                        .rev()
-                        .map(|fallback_layer| {
-                            layout.get_encoder_keycode(fallback_layer, visual_idx)
-                        })
-                        .find(|fallback| !matches!(*fallback, 0x0000 | 0x0001));
-                    match fallback {
-                        Some(fallback_kc) => (encoder_value_label(fallback_kc), true),
-                        None => ("▽".to_string(), false),
-                    }
-                }
+                0x0001 => ("▽".to_string(), true),
                 value => (encoder_value_label(value), false),
             }
         };

--- a/src/ui/layout_shared.rs
+++ b/src/ui/layout_shared.rs
@@ -534,14 +534,6 @@ pub(crate) fn inherited_key_label_color(dark: bool) -> Color32 {
     }
 }
 
-pub(crate) fn inherited_key_label_or_marker(label: String) -> String {
-    if label.is_empty() {
-        "▽".to_owned()
-    } else {
-        label
-    }
-}
-
 pub(crate) fn draw_key_label_dimmed(
     painter: &egui::Painter,
     rect: egui::Rect,
@@ -656,11 +648,5 @@ mod tests {
                 "inherited label should be dim but readable for dark={dark}, got {contrast}"
             );
         }
-    }
-
-    #[test]
-    fn inherited_key_without_effective_label_keeps_transparent_marker() {
-        assert_eq!(inherited_key_label_or_marker(String::new()), "▽");
-        assert_eq!(inherited_key_label_or_marker("A".to_owned()), "A");
     }
 }


### PR DESCRIPTION
### Problem

https://t.me/c/1464748383/37027/132146

`Inherit` (`KC_TRNS`) was rendered as the keycode from a lower-numbered layer in several UI and layout-export views. This suggested that the displayed key would always run, even though firmware resolution instead follows the active layer stack.

### Fix

- Render every `Inherit` assignment as a dimmed `▽` marker instead of resolving and displaying a lower-layer keycode.
- Apply the marker consistently to keyboard keys, encoder rotation and press assignments, Sticky Layout preview, and PNG/SVG/PDF layout exports.
- Keep `None` behavior unchanged; this PR only corrects the representation of `Inherit`.

### Verification

- `cargo test --bin entropy -- --quiet`: 321 passed.
- Scoped `rustfmt --check` and `git diff --check`: passed.
