### PR TITLE
Require confirmation before starting Vial unlock

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -268,6 +268,10 @@ return_to_layout_hint = "Right-click or Esc to return to layout"
 
 [unlock]
 highlighted_keys_hint = "Press and hold the highlighted keys"
+start_hint = "Unlocking is required for this action"
+safety_warning = "Keyboard input pauses after Start. Keep Entropy open.\nReconnect the keyboard if interrupted."
+start = "Start"
+cancel = "Cancel"
 
 [universal_symbols_setup]
 open_privacy_settings = "Open Privacy Settings"

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -268,6 +268,10 @@ return_to_layout_hint = "ПКМ или Esc — вернуться к раскл�
 
 [unlock]
 highlighted_keys_hint = "Нажмите и удерживайте подсвеченные клавиши"
+start_hint = "Для этого действия требуется разблокировка"
+safety_warning = "После запуска ввод с клавиатуры приостановится. Не закрывайте Entropy.\nПри сбое переподключите клавиатуру."
+start = "Начать"
+cancel = "Отмена"
 
 [universal_symbols_setup]
 open_privacy_settings = "Открыть настройки приватности"

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -257,35 +257,34 @@ impl EntropyApp {
         }
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn cancel_vial_unlock(&mut self, suppress_macro_auto_unlock: bool) {
-        if let Some(hid) = &self.hid_device {
-            match hid.lock() {
-                Ok(()) => {
-                    self.vial_unlocked = Some(false);
-                    self.status_msg = crate::i18n::tr_catalog(
-                        self.app_settings.language,
-                        "status_messages.device_unlock_cancelled",
-                    )
-                    .into();
-                }
-                Err(e) => {
-                    self.status_msg = crate::i18n::tr_catalog_format(
-                        self.app_settings.language,
-                        "status_messages.cancel_unlock_failed",
-                        &[("error", &e.to_string())],
-                    );
-                }
-            }
+        // Vial does not define a command that clears `vial_unlock_in_progress`.
+        // CMD_VIAL_LOCK only changes the unlocked flag, so pretending to cancel
+        // after UNLOCK_START would leave normal keyboard input suspended until
+        // the device is reconnected. Cancellation is therefore safe only while
+        // this is still the preflight prompt.
+        if self.vial_unlock_polling {
+            log::warn!("Ignored Vial unlock cancellation after UNLOCK_START");
+            self.status_msg = crate::i18n::tr_catalog(
+                self.app_settings.language,
+                "status_messages.finish_unlock_before_closing",
+            )
+            .into();
+            return;
         }
+
+        log::info!("Vial unlock prompt dismissed before UNLOCK_START");
+        self.status_msg = crate::i18n::tr_catalog(
+            self.app_settings.language,
+            "status_messages.device_unlock_cancelled",
+        )
+        .into();
         self.unlock_open = false;
         self.vial_unlock_polling = false;
         self.vial_unlock_last_poll = None;
         self.pending_layout_indicator_open_after_unlock = false;
         self.vial_unlock_counter = 0;
         self.vial_unlock_best = 50;
-        self.matrix_tester_unlock_prompted = false;
-        self.matrix_tester_lock_checked = false;
         if suppress_macro_auto_unlock {
             self.macro_auto_unlock_cancelled = true;
         }

--- a/src/ui/window_lifecycle.rs
+++ b/src/ui/window_lifecycle.rs
@@ -5,8 +5,8 @@ use super::*;
 #[cfg(target_os = "macos")]
 use objc::{msg_send, sel, sel_impl};
 
-fn should_keep_vial_unlock_visible(unlock_open: bool, unlock_polling: bool) -> bool {
-    unlock_open || unlock_polling
+fn should_keep_vial_unlock_visible(unlock_polling: bool) -> bool {
+    unlock_polling
 }
 
 impl EntropyApp {
@@ -184,7 +184,11 @@ impl EntropyApp {
         #[cfg(not(target_arch = "wasm32"))]
         self.flush_pending_qmk_setting_writes();
 
-        if should_keep_vial_unlock_visible(self.unlock_open, self.vial_unlock_polling) {
+        if self.unlock_open && !self.vial_unlock_polling {
+            self.cancel_vial_unlock(true);
+        }
+
+        if should_keep_vial_unlock_visible(self.vial_unlock_polling) {
             ctx.send_viewport_cmd(egui::ViewportCommand::CancelClose);
             self.keep_vial_unlock_visible(ctx);
             return;
@@ -236,7 +240,11 @@ impl EntropyApp {
     }
 
     pub(super) fn minimize_window_to_tray(&mut self, ctx: &egui::Context) {
-        if should_keep_vial_unlock_visible(self.unlock_open, self.vial_unlock_polling) {
+        if self.unlock_open && !self.vial_unlock_polling {
+            self.cancel_vial_unlock(true);
+        }
+
+        if should_keep_vial_unlock_visible(self.vial_unlock_polling) {
             self.keep_vial_unlock_visible(ctx);
             return;
         }
@@ -759,7 +767,7 @@ impl EntropyApp {
 
     #[cfg(any(target_os = "windows", target_os = "macos"))]
     pub(super) fn handle_tray_quit_request(&mut self, ctx: &egui::Context) {
-        if should_keep_vial_unlock_visible(self.unlock_open, self.vial_unlock_polling)
+        if should_keep_vial_unlock_visible(self.vial_unlock_polling)
             && TRAY_QUIT_REQUESTED.swap(false, std::sync::atomic::Ordering::Relaxed)
         {
             self.keep_vial_unlock_visible(ctx);
@@ -1028,11 +1036,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn active_vial_unlock_blocks_close_and_tray_actions() {
-        assert!(should_keep_vial_unlock_visible(true, false));
-        assert!(should_keep_vial_unlock_visible(false, true));
-        assert!(should_keep_vial_unlock_visible(true, true));
-        assert!(!should_keep_vial_unlock_visible(false, false));
+    fn only_started_vial_unlock_blocks_close_and_tray_actions() {
+        assert!(should_keep_vial_unlock_visible(true));
+        assert!(!should_keep_vial_unlock_visible(false));
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/src/vial/unlock.rs
+++ b/src/vial/unlock.rs
@@ -4,6 +4,15 @@ use super::*;
 
 const VIAL_UNLOCK_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(200);
 const VIAL_UNLOCK_PROGRESS_ANIMATION_TIME: f32 = 0.16;
+const VIAL_UNLOCK_LAYOUT_TOP_RESERVED_H: f32 = 156.0;
+
+fn should_start_vial_unlock(
+    unlock_open: bool,
+    unlock_polling: bool,
+    start_requested: bool,
+) -> bool {
+    unlock_open && !unlock_polling && start_requested
+}
 
 impl EntropyApp {
     pub(super) fn stop_vial_unlock_with_status(&mut self, status: impl Into<String>) {
@@ -96,23 +105,6 @@ impl EntropyApp {
     pub(super) fn draw_vial_unlock_overlay(&mut self, ctx: &egui::Context) {
         // Vial unlock modal
         if self.unlock_open && self.firmware == FirmwareProtocol::Vial {
-            // Start unlock through the serialized HID worker so Bluetooth
-            // round-trips never block the UI thread.
-            #[cfg(not(target_arch = "wasm32"))]
-            if !self.vial_unlock_polling {
-                match self.start_vial_unlock(ctx) {
-                    VialHidTaskStart::Started | VialHidTaskStart::Busy => {}
-                    VialHidTaskStart::NoDevice => {
-                        self.stop_vial_unlock_with_status(crate::i18n::tr_catalog(
-                            self.app_settings.language,
-                            "status_messages.unlock_cancelled_disconnected",
-                        ));
-                        return;
-                    }
-                }
-                ctx.request_repaint_after(std::time::Duration::from_millis(16));
-            }
-
             // Match Vial's polling cadence. Vial QMK resets the unlock counter whenever
             // UNLOCK_POLL arrives before its internal ~100ms timer has elapsed, even if the
             // correct keys are held. Polling too fast makes progress stick near zero.
@@ -145,6 +137,10 @@ impl EntropyApp {
             let counter = self.vial_unlock_counter;
             let total = self.vial_unlock_total;
             let layout_options_value = self.layout_options_value;
+            let waiting_for_start = !self.vial_unlock_polling;
+            let mut start_requested = false;
+            let mut cancel_requested =
+                waiting_for_start && ctx.input(|input| input.key_pressed(egui::Key::Escape));
 
             egui::Area::new(egui::Id::new("unlock_overlay"))
                 .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
@@ -178,6 +174,11 @@ impl EntropyApp {
                     } else {
                         Color32::from_rgb(230, 230, 233)
                     };
+                    ui.interact(
+                        screen,
+                        egui::Id::new("unlock_overlay_blocker"),
+                        egui::Sense::click_and_drag(),
+                    );
                     ui.painter().rect_filled(screen, 0.0, screen_bg);
 
                     let center_x = screen.center().x;
@@ -195,53 +196,107 @@ impl EntropyApp {
                         title_color,
                     );
 
+                    let subtitle_key = if waiting_for_start {
+                        "unlock.start_hint"
+                    } else {
+                        "unlock.highlighted_keys_hint"
+                    };
                     ui.painter().text(
                         egui::pos2(center_x, top_y + 30.0),
                         egui::Align2::CENTER_CENTER,
-                        crate::i18n::tr_catalog(
-                            self.app_settings.language,
-                            "unlock.highlighted_keys_hint",
-                        ),
+                        crate::i18n::tr_catalog(self.app_settings.language, subtitle_key),
                         FontId::proportional(14.0),
                         subtitle_color,
                     );
 
-                    // Progress bar
-                    let target_progress = if total > 0 {
-                        1.0 - (counter as f32 / total as f32)
+                    ui.painter().text(
+                        egui::pos2(center_x, top_y + 52.0),
+                        egui::Align2::CENTER_CENTER,
+                        crate::i18n::tr_catalog(
+                            self.app_settings.language,
+                            "unlock.safety_warning",
+                        ),
+                        FontId::proportional(12.0),
+                        subtitle_color,
+                    );
+
+                    if waiting_for_start {
+                        let controls_rect = egui::Rect::from_center_size(
+                            egui::pos2(center_x, top_y + 84.0),
+                            egui::vec2(320.0, 40.0),
+                        );
+                        crate::ui_style::allocate_ui_at_rect(ui, controls_rect, |ui| {
+                            ui.horizontal_centered(|ui| {
+                                if crate::ui_style::modern_button(
+                                    ui,
+                                    crate::i18n::tr_catalog(
+                                        self.app_settings.language,
+                                        "unlock.cancel",
+                                    ),
+                                    egui::vec2(120.0, 34.0),
+                                    true,
+                                )
+                                .clicked()
+                                {
+                                    cancel_requested = true;
+                                }
+                                ui.add_space(12.0);
+                                if crate::ui_style::modern_button(
+                                    ui,
+                                    crate::i18n::tr_catalog(
+                                        self.app_settings.language,
+                                        "unlock.start",
+                                    ),
+                                    egui::vec2(120.0, 34.0),
+                                    true,
+                                )
+                                .clicked()
+                                {
+                                    start_requested = true;
+                                }
+                            });
+                        });
                     } else {
-                        0.0
-                    };
-                    let progress = ui.ctx().animate_value_with_time(
-                        egui::Id::new(("vial_unlock_progress", self.vial_unlock_animation_nonce)),
-                        target_progress.clamp(0.0, 1.0),
-                        VIAL_UNLOCK_PROGRESS_ANIMATION_TIME,
-                    );
-                    let bar_w = 300.0f32;
-                    let bar_h = 12.0f32;
-                    let bar_y = top_y + 55.0;
-                    let bar_rect = egui::Rect::from_min_size(
-                        egui::pos2(center_x - bar_w / 2.0, bar_y),
-                        egui::Vec2::new(bar_w, bar_h),
-                    );
-                    ui.painter().rect(
-                        bar_rect,
-                        4.0,
-                        bar_bg,
-                        egui::Stroke::NONE,
-                        egui::StrokeKind::Inside,
-                    );
-                    let fill_rect = egui::Rect::from_min_size(
-                        bar_rect.min,
-                        egui::Vec2::new(bar_w * progress, bar_h),
-                    );
-                    ui.painter().rect(
-                        fill_rect,
-                        4.0,
-                        app_accent(),
-                        egui::Stroke::NONE,
-                        egui::StrokeKind::Inside,
-                    );
+                        // Progress bar
+                        let target_progress = if total > 0 {
+                            1.0 - (counter as f32 / total as f32)
+                        } else {
+                            0.0
+                        };
+                        let progress = ui.ctx().animate_value_with_time(
+                            egui::Id::new((
+                                "vial_unlock_progress",
+                                self.vial_unlock_animation_nonce,
+                            )),
+                            target_progress.clamp(0.0, 1.0),
+                            VIAL_UNLOCK_PROGRESS_ANIMATION_TIME,
+                        );
+                        let bar_w = 300.0f32;
+                        let bar_h = 12.0f32;
+                        let bar_y = top_y + 78.0;
+                        let bar_rect = egui::Rect::from_min_size(
+                            egui::pos2(center_x - bar_w / 2.0, bar_y),
+                            egui::Vec2::new(bar_w, bar_h),
+                        );
+                        ui.painter().rect(
+                            bar_rect,
+                            4.0,
+                            bar_bg,
+                            egui::Stroke::NONE,
+                            egui::StrokeKind::Inside,
+                        );
+                        let fill_rect = egui::Rect::from_min_size(
+                            bar_rect.min,
+                            egui::Vec2::new(bar_w * progress, bar_h),
+                        );
+                        ui.painter().rect(
+                            fill_rect,
+                            4.0,
+                            app_accent(),
+                            egui::Stroke::NONE,
+                            egui::StrokeKind::Inside,
+                        );
+                    }
 
                     // Draw layout keys with highlighted unlock keys. Always compute geometry
                     // against the fullscreen unlock overlay: `last_layout_geometry` belongs to
@@ -267,7 +322,7 @@ impl EntropyApp {
                             layout,
                             screen,
                             clamp_ui_scale(self.app_settings.ui_scale),
-                            LAYOUT_TOP_RESERVED_H,
+                            VIAL_UNLOCK_LAYOUT_TOP_RESERVED_H,
                             LAYOUT_BOTTOM_RESERVED_H,
                             LAYOUT_FIT_MARGIN,
                             None,
@@ -302,6 +357,130 @@ impl EntropyApp {
                         }
                     }
                 });
+
+            if cancel_requested {
+                self.cancel_vial_unlock(true);
+                ctx.request_repaint();
+                return;
+            }
+
+            #[cfg(not(target_arch = "wasm32"))]
+            if should_start_vial_unlock(self.unlock_open, self.vial_unlock_polling, start_requested)
+            {
+                // Mark the protocol active immediately. This closes the small
+                // window where UNLOCK_START could already be in flight while
+                // the UI still offered an unsafe cancellation.
+                match self.start_vial_unlock(ctx) {
+                    VialHidTaskStart::Started => {
+                        self.vial_unlock_polling = true;
+                        self.vial_unlock_counter = self.vial_unlock_total.max(1);
+                        self.vial_unlock_best = self.vial_unlock_counter;
+                        self.vial_unlock_last_poll = Some(std::time::Instant::now());
+                    }
+                    VialHidTaskStart::Busy => {}
+                    VialHidTaskStart::NoDevice => {
+                        self.stop_vial_unlock_with_status(crate::i18n::tr_catalog(
+                            self.app_settings.language,
+                            "status_messages.unlock_cancelled_disconnected",
+                        ));
+                    }
+                }
+                ctx.request_repaint_after(std::time::Duration::from_millis(16));
+            }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unlock_waits_for_explicit_start_request() {
+        assert!(!should_start_vial_unlock(true, false, false));
+        assert!(should_start_vial_unlock(true, false, true));
+        assert!(!should_start_vial_unlock(false, false, true));
+        assert!(!should_start_vial_unlock(true, true, true));
+    }
+
+    #[test]
+    fn showing_unlock_overlay_does_not_start_the_protocol() {
+        let ctx = egui::Context::default();
+        let creation_context = eframe::CreationContext::_new_kittest(ctx.clone());
+        let mut app = EntropyApp::new(&creation_context);
+        let (hid_device, recorder) = crate::hid::HidDevice::test_device();
+        app.hid_device = Some(hid_device);
+        app.firmware = FirmwareProtocol::Vial;
+        app.unlock_open = true;
+
+        let _ = ctx.run_ui(egui::RawInput::default(), |_ui| {
+            app.draw_vial_unlock_overlay(&ctx);
+        });
+
+        assert!(app.unlock_open);
+        assert!(!app.vial_unlock_polling);
+        assert!(recorder.requests().is_empty());
+    }
+
+    #[test]
+    fn escape_cancels_unlock_before_the_protocol_starts() {
+        let ctx = egui::Context::default();
+        let creation_context = eframe::CreationContext::_new_kittest(ctx.clone());
+        let mut app = EntropyApp::new(&creation_context);
+        let (hid_device, recorder) = crate::hid::HidDevice::test_device();
+        app.hid_device = Some(hid_device);
+        app.firmware = FirmwareProtocol::Vial;
+        app.unlock_open = true;
+        let mut input = egui::RawInput::default();
+        input.events.push(egui::Event::Key {
+            key: egui::Key::Escape,
+            physical_key: None,
+            pressed: true,
+            repeat: false,
+            modifiers: egui::Modifiers::NONE,
+        });
+
+        let _ = ctx.run_ui(input, |_ui| {
+            app.draw_vial_unlock_overlay(&ctx);
+        });
+
+        assert!(!app.unlock_open);
+        assert!(!app.vial_unlock_polling);
+        assert!(recorder.requests().is_empty());
+    }
+
+    #[test]
+    fn cancelling_preflight_does_not_send_a_vial_command() {
+        let ctx = egui::Context::default();
+        let creation_context = eframe::CreationContext::_new_kittest(ctx);
+        let mut app = EntropyApp::new(&creation_context);
+        let (hid_device, recorder) = crate::hid::HidDevice::test_device();
+        app.hid_device = Some(hid_device);
+        app.unlock_open = true;
+
+        app.cancel_vial_unlock(true);
+
+        assert!(!app.unlock_open);
+        assert!(!app.vial_unlock_polling);
+        assert!(app.macro_auto_unlock_cancelled);
+        assert!(recorder.requests().is_empty());
+    }
+
+    #[test]
+    fn cancellation_is_ignored_after_unlock_start() {
+        let ctx = egui::Context::default();
+        let creation_context = eframe::CreationContext::_new_kittest(ctx);
+        let mut app = EntropyApp::new(&creation_context);
+        let (hid_device, recorder) = crate::hid::HidDevice::test_device();
+        app.hid_device = Some(hid_device);
+        app.unlock_open = true;
+        app.vial_unlock_polling = true;
+
+        app.cancel_vial_unlock(true);
+
+        assert!(app.unlock_open);
+        assert!(app.vial_unlock_polling);
+        assert!(!app.macro_auto_unlock_cancelled);
+        assert!(recorder.requests().is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Addresses https://t.me/c/1464748383/37027/132198

- restore a preflight screen before sending `CMD_VIAL_UNLOCK_START`
- allow Cancel, Escape, window close, and tray minimization while the prompt is still safe to dismiss
- stop using `CMD_VIAL_LOCK` as a fake cancellation after unlock has started, because it does not clear the firmware unlock-in-progress state
- warn that keyboard input pauses during unlock and that the keyboard must be reconnected if the process is interrupted
- add regression coverage proving that merely showing the overlay or cancelling it sends no Vial HID command

## Reported reproduction

On Windows 11 25H2 with HPD v2 and K03 Pro, opening Config could lead into the unlock flow unexpectedly.

Once `UNLOCK_START` was sent, normal keyboard input stopped, Entropy could not safely close, and force-terminating Entropy left the keyboard unavailable until USB reconnection.

The Config dropdown navigation regression is already fixed on `main`.
This PR addresses the remaining unsafe behavior: displaying an unlock request must not start the firmware protocol without explicit confirmation.

## Protocol constraint

Vial has no command that cancels an active unlock session. After Start, Entropy must continue polling until unlock completes; force-terminating the process during that interval can still require a physical reconnect.

The new preflight prevents that state from being entered accidentally and explains the limitation before Start.

## Validation

- `cargo test`: 394 passed
- `python3 scripts/check_i18n.py`
- `git diff --check`