### PR TITLE
Avoid firmware version probe connection stalls

### DIFF
--- a/src/hid.rs
+++ b/src/hid.rs
@@ -900,6 +900,22 @@ fn write_output_report_local(
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+fn is_optional_firmware_version_request(data: &[u8]) -> bool {
+    data.starts_with(&[CMD_VIA_GET_KEYBOARD_VALUE, VIA_FIRMWARE_VERSION])
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn usb_send_max_attempts(transport: HidTransport, data: &[u8]) -> usize {
+    // Runtime firmware metadata has a Vial-definition fallback, so an
+    // unsupported probe must not hold up the whole connection retry budget.
+    if transport.is_bluetooth() || is_optional_firmware_version_request(data) {
+        1
+    } else {
+        VIAL_GUI_USB_RETRIES
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 fn usb_send_local(
     device: &hidapi::HidDevice,
     transport: HidTransport,
@@ -928,11 +944,7 @@ fn usb_send_local(
         VIAL_GUI_READ_TIMEOUT_MS
     };
 
-    let max_retries = if transport.is_bluetooth() {
-        1
-    } else {
-        VIAL_GUI_USB_RETRIES
-    };
+    let max_retries = usb_send_max_attempts(transport, data);
 
     let mut last_error: Option<anyhow::Error> = None;
     for attempt in 0..max_retries {
@@ -1402,9 +1414,14 @@ fn response_matches_command(command: &[u8], resp: &[u8; MSG_LEN]) -> bool {
         CMD_VIA_CUSTOM_GET_VALUE if command.get(1) == Some(&ERGOHAVEN_CUSTOM_NAMESPACE) => {
             command.len() >= 3 && resp[0] == cmd && resp[1..3] == command[1..3]
         }
-        CMD_VIA_GET_KEYBOARD_VALUE | CMD_VIA_LIGHTING_GET_VALUE => {
-            command.len() >= 2 && resp[0] == cmd && resp[1] == command[1]
+        CMD_VIA_GET_KEYBOARD_VALUE => {
+            command.len() >= 2
+                && ((resp[0] == cmd && resp[1] == command[1])
+                    || (is_optional_firmware_version_request(command)
+                        && resp[0] == u8::MAX
+                        && resp[1] == VIA_FIRMWARE_VERSION))
         }
+        CMD_VIA_LIGHTING_GET_VALUE => command.len() >= 2 && resp[0] == cmd && resp[1] == command[1],
         CMD_VIA_GET_KEYCODE => command.len() >= 4 && resp[0] == cmd && resp[1..4] == command[1..4],
         CMD_VIA_SET_KEYBOARD_VALUE
         | CMD_VIA_SET_KEYCODE
@@ -1969,6 +1986,59 @@ mod tests {
             HidWriteFraming::LinuxBluetoothUnnumbered,
         )
         .is_err());
+    }
+
+    #[test]
+    fn optional_firmware_version_probe_uses_one_usb_attempt() {
+        let command = [CMD_VIA_GET_KEYBOARD_VALUE, VIA_FIRMWARE_VERSION];
+
+        assert_eq!(usb_send_max_attempts(HidTransport::Usb, &command), 1);
+    }
+
+    #[test]
+    fn mandatory_usb_request_keeps_full_retry_budget() {
+        let command = [CMD_VIA_GET_PROTOCOL_VERSION];
+
+        assert_eq!(
+            usb_send_max_attempts(HidTransport::Usb, &command),
+            VIAL_GUI_USB_RETRIES
+        );
+    }
+
+    #[test]
+    fn firmware_version_probe_accepts_successful_response() {
+        let command = [CMD_VIA_GET_KEYBOARD_VALUE, VIA_FIRMWARE_VERSION];
+        let mut response = [0u8; MSG_LEN];
+        response[..6].copy_from_slice(&[
+            CMD_VIA_GET_KEYBOARD_VALUE,
+            VIA_FIRMWARE_VERSION,
+            0,
+            4,
+            0,
+            5,
+        ]);
+
+        assert!(response_matches_command(&command, &response));
+    }
+
+    #[test]
+    fn firmware_version_probe_accepts_matching_unhandled_response() {
+        let command = [CMD_VIA_GET_KEYBOARD_VALUE, VIA_FIRMWARE_VERSION];
+        let mut response = [0u8; MSG_LEN];
+        response[0] = u8::MAX;
+        response[1] = VIA_FIRMWARE_VERSION;
+
+        assert!(response_matches_command(&command, &response));
+    }
+
+    #[test]
+    fn firmware_version_probe_rejects_unhandled_response_for_another_value() {
+        let command = [CMD_VIA_GET_KEYBOARD_VALUE, VIA_FIRMWARE_VERSION];
+        let mut response = [0u8; MSG_LEN];
+        response[0] = u8::MAX;
+        response[1] = VIA_SWITCH_MATRIX_STATE;
+
+        assert!(!response_matches_command(&command, &response));
     }
 
     fn qmk_settings_command(subcommand: u8, qsid: u16) -> [u8; MSG_LEN] {


### PR DESCRIPTION
### Problem

Addresses #104 

Since v0.2.8, keyboards that do not support VIA's optional firmware-version query could leave Entropy stuck at "Reading firmware version..." instead of continuing with the device definition. The optional query inherited the full USB retry budget, so an unsupported response or silence could delay connection for many seconds.

### Fix

The firmware-version probe now fails fast without changing the retry budget for mandatory HID commands. A matching VIA "unsupported" response is accepted as terminal, allowing the existing Vial-definition version fallback to continue the connection, while valid runtime firmware versions are still preserved.

### Verification

- `cargo test firmware_version_probe` - 4 passed
- `cargo test hid::tests` - 27 passed
- `cargo test --locked -- --test-threads=1` - 442 passed
- `cargo clippy --locked --all-targets` - no errors; 81 existing warnings
- `rustfmt --check src/hid.rs`
- `git diff --check`

The two timing-sensitive Vial worker failures from the default-parallel full suite also reproduce on unchanged `origin/main`; each passes individually and the serial full suite passes.