### PR TITLE
Fail device loads when HID disconnects

### DIFF
--- a/src/ui/device_connect_task.rs
+++ b/src/ui/device_connect_task.rs
@@ -323,6 +323,24 @@ fn normalize_reported_layer_count(reported_layer_count: usize) -> usize {
     reported_layer_count.max(1)
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+fn read_initial_keymap_buffer(
+    hid: &crate::hid::HidDevice,
+    layer_count: usize,
+    rows: usize,
+    cols: usize,
+    staged_bluetooth_load: bool,
+) -> Result<Vec<u16>, String> {
+    hid.get_keymap_buffer(layer_count, rows, cols)
+        .map_err(|error| {
+            if staged_bluetooth_load {
+                format!("Initial Bluetooth layer read failed: {error:#}")
+            } else {
+                format!("Initial keymap read failed: {error:#}")
+            }
+        })
+}
+
 fn is_default_layer_name(index: usize, name: &str) -> bool {
     let trimmed = name.trim();
     trimmed.is_empty()
@@ -896,27 +914,24 @@ impl EntropyApp {
                 } else {
                     layer_count
                 };
-                match dev_conn.get_keymap_buffer(initial_layer_count, layout.rows, layout.cols) {
-                    Ok(buf) => {
-                        for layer in 0..initial_layer_count {
-                            for (ki, key) in layout.keys.iter().enumerate() {
-                                let idx = layer * layout.rows * layout.cols
-                                    + key.row as usize * layout.cols
-                                    + key.col as usize;
-                                if let Some(&kc) = buf.get(idx) {
-                                    layout.layers[layer][ki] = kc.into();
-                                }
-                            }
+                let buf = read_initial_keymap_buffer(
+                    &dev_conn,
+                    initial_layer_count,
+                    layout.rows,
+                    layout.cols,
+                    staged_bluetooth_load,
+                )?;
+                for layer in 0..initial_layer_count {
+                    for (ki, key) in layout.keys.iter().enumerate() {
+                        let idx = layer * layout.rows * layout.cols
+                            + key.row as usize * layout.cols
+                            + key.col as usize;
+                        if let Some(&kc) = buf.get(idx) {
+                            layout.layers[layer][ki] = kc.into();
                         }
-                        log::info!("Keymap loaded from buffer");
-                    }
-                    Err(e) => {
-                        if staged_bluetooth_load {
-                            return Err(format!("Initial Bluetooth layer read failed: {e:#}"));
-                        }
-                        log::warn!("get_keymap_buffer failed: {e}");
                     }
                 }
+                log::info!("Keymap loaded from buffer");
 
                 let supports_rmk_native_key_actions = dev_conn
                     .get_rmk_native_capabilities()
@@ -1390,6 +1405,37 @@ mod tests {
     fn reported_layer_count_is_never_zero() {
         assert_eq!(normalize_reported_layer_count(0), 1);
         assert_eq!(normalize_reported_layer_count(4), 4);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn initial_usb_keymap_disconnect_fails_the_connection_read() {
+        let (hid, recorder) = crate::hid::HidDevice::test_device_with_fault_after_requests(Some((
+            0,
+            crate::hid::TestHidFault::Disconnect,
+        )));
+
+        let error = read_initial_keymap_buffer(&hid, 1, 2, 3, false)
+            .expect_err("a mandatory USB keymap read must not fall back to zero-filled layers");
+
+        assert!(error.contains("Initial keymap read failed"));
+        assert_eq!(recorder.requests().len(), 1);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn initial_bluetooth_keymap_disconnect_fails_the_connection_read() {
+        let (hid, recorder) = crate::hid::HidDevice::test_device_with_fault_after_requests(Some((
+            0,
+            crate::hid::TestHidFault::Disconnect,
+        )));
+
+        let error = read_initial_keymap_buffer(&hid, 1, 2, 3, true).expect_err(
+            "a mandatory Bluetooth keymap read must not fall back to zero-filled layers",
+        );
+
+        assert!(error.contains("Initial Bluetooth layer read failed"));
+        assert_eq!(recorder.requests().len(), 1);
     }
 
     #[test]

--- a/src/ui/device_deferred_load.rs
+++ b/src/ui/device_deferred_load.rs
@@ -110,6 +110,21 @@ fn event_defers_automatic_background_load(event: &egui::Event) -> bool {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+fn optional_hid_read_or_default<T: Default>(
+    result: anyhow::Result<T>,
+    context: impl std::fmt::Display,
+) -> anyhow::Result<T> {
+    match result {
+        Ok(value) => Ok(value),
+        Err(error) if crate::hid::is_disconnect_error(&error) => Err(error),
+        Err(error) => {
+            log::warn!("{context}: {error}");
+            Ok(T::default())
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 pub(super) fn run_deferred_load(
     hid: &crate::hid::HidDevice,
     request: &DeferredLoadRequest,
@@ -129,28 +144,20 @@ pub(super) fn run_deferred_load(
             };
             let mut encoders = Vec::with_capacity(context.encoder_count);
             for encoder in 0..context.encoder_count {
-                encoders.push(
-                    hid.get_encoder(*layer as u8, encoder as u8)
-                        .unwrap_or_else(|error| {
-                            log::warn!(
-                                "get_encoder(layer={layer}, idx={encoder}) during staged load: {error}"
-                            );
-                            (0, 0)
-                        }),
-                );
+                encoders.push(optional_hid_read_or_default(
+                    hid.get_encoder(*layer as u8, encoder as u8),
+                    format_args!("get_encoder(layer={layer}, idx={encoder}) during staged load"),
+                )?);
             }
             let qsid = 200 + *layer as u16;
             let firmware_name = if context.supported_qmk_settings.contains(&qsid) {
-                match hid.get_qmk_setting_string(qsid) {
-                    Ok(name) if !name.trim().is_empty() => Some(name),
-                    Ok(_) => None,
-                    Err(error) => {
-                        log::warn!(
-                            "get_qmk_setting_string(layer name qsid {qsid}) during staged load: {error}"
-                        );
-                        None
-                    }
-                }
+                let name = optional_hid_read_or_default(
+                    hid.get_qmk_setting_string(qsid),
+                    format_args!(
+                        "get_qmk_setting_string(layer name qsid {qsid}) during staged load"
+                    ),
+                )?;
+                (!name.trim().is_empty()).then_some(name)
             } else {
                 None
             };
@@ -188,14 +195,12 @@ pub(super) fn run_deferred_load(
                     )
                 }
                 BackgroundLayerStep::Encoder { encoder_index } => {
-                    let keycodes = hid
-                        .get_encoder(*layer as u8, encoder_index as u8)
-                        .unwrap_or_else(|error| {
-                            log::warn!(
-                                "get_encoder(layer={layer}, idx={encoder_index}) during background load: {error}"
-                            );
-                            (0, 0)
-                        });
+                    let keycodes = optional_hid_read_or_default(
+                        hid.get_encoder(*layer as u8, encoder_index as u8),
+                        format_args!(
+                            "get_encoder(layer={layer}, idx={encoder_index}) during background load"
+                        ),
+                    )?;
                     BackgroundLayerStepResult::Encoder {
                         encoder_index,
                         keycodes,
@@ -203,16 +208,13 @@ pub(super) fn run_deferred_load(
                 }
                 BackgroundLayerStep::FirmwareName => {
                     let qsid = 200 + *layer as u16;
-                    let firmware_name = match hid.get_qmk_setting_string(qsid) {
-                        Ok(name) if !name.trim().is_empty() => Some(name),
-                        Ok(_) => None,
-                        Err(error) => {
-                            log::warn!(
-                                "get_qmk_setting_string(layer name qsid {qsid}) during background load: {error}"
-                            );
-                            None
-                        }
-                    };
+                    let name = optional_hid_read_or_default(
+                        hid.get_qmk_setting_string(qsid),
+                        format_args!(
+                            "get_qmk_setting_string(layer name qsid {qsid}) during background load"
+                        ),
+                    )?;
+                    let firmware_name = (!name.trim().is_empty()).then_some(name);
                     BackgroundLayerStepResult::FirmwareName(firmware_name)
                 }
             };
@@ -1532,16 +1534,16 @@ mod tests {
         assert_eq!(&requests[0][1..3], &[0x00, 0x18]);
     }
 
-    #[test]
-    fn deferred_dynamic_reader_propagates_disconnect_without_filling_default_entries() {
+    fn assert_deferred_disconnect(
+        request: DeferredLoadRequest,
+        successful_requests_before_fault: usize,
+        expected_requests: usize,
+        expected_failed_request_prefix: &[u8],
+    ) {
         let (hid, recorder) = crate::hid::HidDevice::test_device_with_fault_after_requests(Some((
-            0,
+            successful_requests_before_fault,
             crate::hid::TestHidFault::Disconnect,
         )));
-        let request = DeferredLoadRequest::Section {
-            section: DeferredLoadSection::Combos,
-            context: std::sync::Arc::new(context()),
-        };
 
         let error = match run_deferred_load(&hid, &request) {
             Ok(_) => panic!("disconnect must fail the deferred load"),
@@ -1549,7 +1551,93 @@ mod tests {
         };
 
         assert!(crate::hid::is_disconnect_error(&error));
-        assert_eq!(recorder.requests().len(), 1);
+        let requests = recorder.requests();
+        assert_eq!(requests.len(), expected_requests);
+        assert!(requests
+            .last()
+            .is_some_and(|request| request.starts_with(expected_failed_request_prefix)));
+    }
+
+    #[test]
+    fn deferred_dynamic_reader_propagates_disconnect_without_filling_default_entries() {
+        assert_deferred_disconnect(
+            DeferredLoadRequest::Section {
+                section: DeferredLoadSection::Combos,
+                context: std::sync::Arc::new(context()),
+            },
+            0,
+            1,
+            &[0xFE, 0x0D, 0x03, 0],
+        );
+    }
+
+    #[test]
+    fn optional_hid_read_preserves_non_disconnect_fallbacks() {
+        let value: (u16, u16) = optional_hid_read_or_default(
+            Err(anyhow::anyhow!("optional feature response was unavailable")),
+            "test optional read",
+        )
+        .unwrap();
+
+        assert_eq!(value, (0, 0));
+    }
+
+    #[test]
+    fn deferred_layer_encoder_disconnect_fails_the_layer_load() {
+        let mut context = context();
+        context.encoder_count = 1;
+        assert_deferred_disconnect(
+            DeferredLoadRequest::Layer {
+                layer: 2,
+                context: std::sync::Arc::new(context),
+            },
+            1,
+            2,
+            &[0xFE, 0x03, 2, 0],
+        );
+    }
+
+    #[test]
+    fn deferred_layer_name_disconnect_fails_the_layer_load() {
+        let mut context = context();
+        context.supported_qmk_settings = std::sync::Arc::new(vec![202]);
+        assert_deferred_disconnect(
+            DeferredLoadRequest::Layer {
+                layer: 2,
+                context: std::sync::Arc::new(context),
+            },
+            1,
+            2,
+            &[0xFE, 0x0A, 202, 0],
+        );
+    }
+
+    #[test]
+    fn background_encoder_disconnect_fails_the_layer_step() {
+        assert_deferred_disconnect(
+            DeferredLoadRequest::BackgroundLayerStep {
+                layer: 2,
+                step: BackgroundLayerStep::Encoder { encoder_index: 0 },
+                context: std::sync::Arc::new(context()),
+            },
+            0,
+            1,
+            &[0xFE, 0x03, 2, 0],
+        );
+    }
+
+    #[test]
+    fn background_layer_name_disconnect_fails_the_layer_step() {
+        assert_deferred_disconnect(
+            DeferredLoadRequest::BackgroundLayerStep {
+                layer: 2,
+                step: BackgroundLayerStep::FirmwareName,
+                context: std::sync::Arc::new(context()),
+            },
+            0,
+            1,
+            &[0xFE, 0x0A, 202, 0],
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Problem

When the mandatory initial USB keymap read failed, Entropy logged the error and
continued with zero-filled layers. During deferred loading, a real disconnect
while reading encoders or firmware layer names was also treated like an
unsupported optional feature, so a lost device could appear successfully
loaded with defaults.

### Fix

- Mandatory initial keymap reads now fail the USB or staged Bluetooth
  connection instead of accepting zero-filled layers.
- Deferred encoder and firmware-layer-name reads now propagate recognized
  disconnects through the existing reconnect path.
- Non-disconnect errors for optional features retain the existing default
  fallback behavior.
- Fault-injection tests verify the exact HID command that failed, covering both
  direct and background layer loading.

### Verification

- `cargo test device_deferred_load` - 29 passed.
- `cargo test device_connect_task` - 23 passed.
- `cargo test -- --test-threads=1` - 444 passed.
- Scoped `rustfmt --check` for both changed files passed.
- `git diff --check` passed.
- The ordinary parallel suite still has two pre-existing timing-sensitive
  failures in `vial_hid_task`; the untouched `origin/main` worktree reproduces
  them, and the serial full suite is green.