### PR TITLE
Avoid shell parsing for Windows update URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,6 +1430,7 @@ dependencies = [
  "serde_json",
  "tray-icon",
  "ureq",
+ "url",
  "wasm-bindgen-futures",
  "web-sys",
  "windows 0.56.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ ab_glyph = "0.2"
 image = { version = "0.25", default-features = false, features = ["png"] }
 postcard = "1"
 rmk-types = { git = "https://github.com/ergohaven/rmk.git", rev = "99cdcd542600eb1a439675455997fe7cf3928600", default-features = false }
+url = "2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rfd = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ hidapi = "2.6"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 tray-icon = "0.22"
-windows-sys = { version = "0.60", features = ["Win32_Foundation", "Win32_Globalization", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_WindowsAndMessaging"] }
+windows-sys = { version = "0.60", features = ["Win32_Foundation", "Win32_Globalization", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 windows = { version = "0.56", features = ["Foundation", "Media_Control", "Win32_Media_Audio_Endpoints", "Win32_System_Com_StructuredStorage"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src/app_update.rs
+++ b/src/app_update.rs
@@ -1,5 +1,6 @@
 const GITHUB_LATEST_RELEASE_API: &str =
     "https://api.github.com/repos/ergohaven/entropy/releases/latest";
+const GITHUB_RELEASE_ROOT: &str = "https://github.com/ergohaven/entropy/releases/";
 
 #[derive(Clone, Debug)]
 pub(crate) struct UpdateAsset {
@@ -123,13 +124,31 @@ pub(crate) fn update_available(state: &UpdateCheckState) -> bool {
 }
 
 pub(crate) fn open_url_in_browser(url: &str) -> bool {
+    if !is_trusted_release_url(url) {
+        log::warn!("Refusing to open an untrusted update URL");
+        return false;
+    }
+
     #[cfg(target_os = "windows")]
     {
-        return std::process::Command::new("cmd")
-            .args(["/C", "start", "", url])
-            .status()
-            .map(|status| status.success())
-            .unwrap_or(false);
+        use windows_sys::Win32::UI::Shell::ShellExecuteW;
+        use windows_sys::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
+
+        let url = url
+            .encode_utf16()
+            .chain(std::iter::once(0))
+            .collect::<Vec<_>>();
+        let result = unsafe {
+            ShellExecuteW(
+                std::ptr::null_mut(),
+                std::ptr::null(),
+                url.as_ptr(),
+                std::ptr::null(),
+                std::ptr::null(),
+                SW_SHOWNORMAL,
+            )
+        };
+        return result as usize > 32;
     }
     #[cfg(target_os = "macos")]
     {
@@ -152,6 +171,15 @@ pub(crate) fn open_url_in_browser(url: &str) -> bool {
         let _ = url;
         false
     }
+}
+
+fn is_trusted_release_url(url: &str) -> bool {
+    let Some(path) = url.strip_prefix(GITHUB_RELEASE_ROOT) else {
+        return false;
+    };
+    path.strip_prefix("tag/")
+        .or_else(|| path.strip_prefix("download/"))
+        .is_some_and(|remainder| !remainder.is_empty())
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -243,6 +271,36 @@ fn normalized_arch_label() -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn trusts_entropy_release_urls() {
+        assert!(is_trusted_release_url(
+            "https://github.com/ergohaven/entropy/releases/tag/v0.3.0"
+        ));
+        assert!(is_trusted_release_url(
+            "https://github.com/ergohaven/entropy/releases/download/v0.3.0/Entropy-Windows-x86_64.exe"
+        ));
+    }
+
+    #[test]
+    fn rejects_untrusted_update_urls() {
+        for url in [
+            "http://github.com/ergohaven/entropy/releases/tag/v0.3.0",
+            "https://github.com.evil.invalid/ergohaven/entropy/releases/tag/v0.3.0",
+            "https://github.com/ergohaven/another-repo/releases/tag/v0.3.0",
+            "https://github.com/ergohaven/entropy/issues",
+            "file:///C:/Windows/System32/calc.exe",
+            "https://github.com/ergohaven/entropy/releases/tag/",
+            "https://github.com/ergohaven/entropy/releases/download/",
+        ] {
+            assert!(!is_trusted_release_url(url), "{url}");
+        }
+    }
+
+    #[test]
+    fn refuses_untrusted_url_before_launch() {
+        assert!(!open_url_in_browser("file:///C:/Windows/System32/calc.exe"));
+    }
 
     #[cfg(not(target_arch = "wasm32"))]
     #[test]

--- a/src/app_update.rs
+++ b/src/app_update.rs
@@ -1,6 +1,5 @@
 const GITHUB_LATEST_RELEASE_API: &str =
     "https://api.github.com/repos/ergohaven/entropy/releases/latest";
-const GITHUB_RELEASE_ROOT: &str = "https://github.com/ergohaven/entropy/releases/";
 
 #[derive(Clone, Debug)]
 pub(crate) struct UpdateAsset {
@@ -124,11 +123,19 @@ pub(crate) fn update_available(state: &UpdateCheckState) -> bool {
 }
 
 pub(crate) fn open_url_in_browser(url: &str) -> bool {
+    open_trusted_release_url(url, launch_url_in_browser)
+}
+
+fn open_trusted_release_url(url: &str, launch: impl FnOnce(&str) -> bool) -> bool {
     if !is_trusted_release_url(url) {
         log::warn!("Refusing to open an untrusted update URL");
         return false;
     }
 
+    launch(url)
+}
+
+fn launch_url_in_browser(url: &str) -> bool {
     #[cfg(target_os = "windows")]
     {
         use windows_sys::Win32::UI::Shell::ShellExecuteW;
@@ -174,12 +181,30 @@ pub(crate) fn open_url_in_browser(url: &str) -> bool {
 }
 
 fn is_trusted_release_url(url: &str) -> bool {
-    let Some(path) = url.strip_prefix(GITHUB_RELEASE_ROOT) else {
+    let Ok(url) = url::Url::parse(url) else {
         return false;
     };
-    path.strip_prefix("tag/")
-        .or_else(|| path.strip_prefix("download/"))
-        .is_some_and(|remainder| !remainder.is_empty())
+    if url.scheme() != "https"
+        || url.host_str() != Some("github.com")
+        || url.port().is_some()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return false;
+    }
+
+    let Some(segments) = url.path_segments() else {
+        return false;
+    };
+    match segments.collect::<Vec<_>>().as_slice() {
+        ["ergohaven", "entropy", "releases", "tag", tag] => !tag.is_empty(),
+        ["ergohaven", "entropy", "releases", "download", tag, asset] => {
+            !tag.is_empty() && !asset.is_empty()
+        }
+        _ => false,
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -280,6 +305,9 @@ mod tests {
         assert!(is_trusted_release_url(
             "https://github.com/ergohaven/entropy/releases/download/v0.3.0/Entropy-Windows-x86_64.exe"
         ));
+        assert!(is_trusted_release_url(
+            "https://github.com/ergohaven/entropy/releases/tag/release%2Fv0.3.0"
+        ));
     }
 
     #[test]
@@ -292,14 +320,40 @@ mod tests {
             "file:///C:/Windows/System32/calc.exe",
             "https://github.com/ergohaven/entropy/releases/tag/",
             "https://github.com/ergohaven/entropy/releases/download/",
+            "https://github.com/ergohaven/entropy/releases/tag/v0.3.0/extra",
+            "https://github.com/ergohaven/entropy/releases/download/v0.3.0/nested/Entropy.exe",
+            "https://github.com/ergohaven/entropy/releases/tag/v0.3.0?source=update",
+            "https://github.com/ergohaven/entropy/releases/download/../../../../attacker/repo/releases/download/v1/payload.exe",
+            "https://github.com/ergohaven/entropy/releases/download/%2e%2e/%2e%2e/%2e%2e/%2e%2e/attacker/repo/releases/download/v1/payload.exe",
+            "https://github.com/ergohaven/entropy/releases/download/..\\..\\..\\../attacker/repo/releases/download/v1/payload.exe",
         ] {
             assert!(!is_trusted_release_url(url), "{url}");
         }
     }
 
     #[test]
-    fn refuses_untrusted_url_before_launch() {
-        assert!(!open_url_in_browser("file:///C:/Windows/System32/calc.exe"));
+    fn refuses_untrusted_url_without_launching() {
+        let mut launched = false;
+        assert!(!open_trusted_release_url(
+            "file:///C:/Windows/System32/calc.exe",
+            |_| {
+                launched = true;
+                true
+            }
+        ));
+        assert!(!launched);
+    }
+
+    #[test]
+    fn forwards_trusted_url_to_launcher() {
+        let trusted_url = "https://github.com/ergohaven/entropy/releases/tag/v0.3.0";
+        let mut launched_url = None;
+
+        assert!(open_trusted_release_url(trusted_url, |url| {
+            launched_url = Some(url.to_owned());
+            true
+        }));
+        assert_eq!(launched_url.as_deref(), Some(trusted_url));
     }
 
     #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
### Problem

On Windows, update links were opened through `cmd /C start`, so URL text received from the GitHub API was reparsed by a command shell. A tampered link could exploit shell syntax or appear to stay under the Entropy release prefix while browser normalization navigated elsewhere.

### Fix

Entropy now parses and normalizes update URLs, accepts only HTTPS release pages and assets under `github.com/ergohaven/entropy`, and rejects alternate schemes, hosts, repositories, traversal segments, unexpected path shapes, queries, and fragments. Windows launches the validated URL directly with `ShellExecuteW`; macOS and Linux retain their native launch commands behind the same trust policy.

### Verification

- `cargo test app_update::tests` - 7 passed
- `cargo test --locked -- --test-threads=1` - 441 passed
- `cargo check --locked` - passed with existing warnings
- `cargo clippy --locked --all-targets` - passed with existing warnings
- `rustfmt --check src/app_update.rs`
- `git diff --check`
- The Windows Rust target is not installed locally, so the `ShellExecuteW` branch was not compiled or exercised here. GitHub Windows CI is the platform compilation gate.
