### PR TITLE
Roll back failed app settings imports

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -506,6 +506,7 @@ failed_to_create_backup_dir = "failed to create backup dir {path}"
 failed_to_serialize_rules = "failed to serialize text expander rules"
 failed_to_serialize = "failed to serialize .entsettings"
 failed_to_write = "failed to write {path}"
+failed_to_restore = "failed to fully restore settings after the import error ({error}): {errors}"
 
 [app_chrome]
 light = "Light"

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -506,6 +506,7 @@ failed_to_create_backup_dir = "не удалось создать папку б�
 failed_to_serialize_rules = "не удалось сериализовать rules Text Expander"
 failed_to_serialize = "не удалось сериализовать .entsettings"
 failed_to_write = "не удалось записать {path}"
+failed_to_restore = "не удалось полностью восстановить настройки после ошибки импорта ({error}): {errors}"
 
 [app_chrome]
 light = "Светлая"

--- a/src/entsettings.rs
+++ b/src/entsettings.rs
@@ -23,6 +23,35 @@ struct EntSettingsTextExpanderRuleFile {
     rules: Vec<crate::text_expander::TextExpansionRule>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+struct EntSettingsStoragePaths {
+    app_settings: PathBuf,
+    primary_rules: PathBuf,
+    extra_rules_dir: PathBuf,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl EntSettingsStoragePaths {
+    fn current() -> Self {
+        Self {
+            app_settings: app_settings_path(),
+            primary_rules: text_expander_rules_path(),
+            extra_rules_dir: text_expander_rules_dir(),
+        }
+    }
+
+    fn extra_rules(&self, file_name: &str) -> PathBuf {
+        self.extra_rules_dir.join(file_name)
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+struct EntSettingsWrite {
+    target: PathBuf,
+    contents: Vec<u8>,
+    original: Option<Vec<u8>>,
+}
+
 impl EntropyApp {
     #[cfg(not(target_arch = "wasm32"))]
     pub(super) fn export_entsettings_dialog(&mut self) {
@@ -88,13 +117,8 @@ impl EntropyApp {
         path: &Path,
     ) -> Result<String> {
         let lang = self.app_settings.language;
-        let data = std::fs::read_to_string(path).with_context(|| {
-            crate::i18n::tr_catalog_format(
-                lang,
-                "entsettings.failed_to_read",
-                &[("path", &path.display().to_string())],
-            )
-        })?;
+        let data =
+            std::fs::read_to_string(path).with_context(|| entsettings_read_error(lang, path))?;
         let bundle: EntSettingsFile = serde_json::from_str(&data).with_context(|| {
             crate::i18n::tr_catalog_format(
                 lang,
@@ -144,34 +168,50 @@ impl EntropyApp {
         }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     fn apply_entsettings(&mut self, ctx: &egui::Context, bundle: EntSettingsFile) -> Result<()> {
+        self.apply_entsettings_with_paths(ctx, bundle, &EntSettingsStoragePaths::current())
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn apply_entsettings_with_paths(
+        &mut self,
+        ctx: &egui::Context,
+        bundle: EntSettingsFile,
+        paths: &EntSettingsStoragePaths,
+    ) -> Result<()> {
         let mut settings = bundle.settings;
         settings.ui_scale = clamp_ui_scale(settings.ui_scale);
         settings.text_expander_rule_files =
             normalize_text_expander_rule_files(&settings.text_expander_rule_files);
+        let language = self.app_settings.language;
 
-        self.app_settings = settings;
-        save_app_settings(&self.app_settings);
-        save_text_expansion_rules(&self.app_settings.text_expansion_rules);
-
+        let mut writes = Vec::with_capacity(2 + bundle.text_expander_extra_files.len());
+        writes.push(prepare_entsettings_write(
+            paths.app_settings.clone(),
+            &settings,
+            language,
+            "entsettings.failed_to_serialize",
+        )?);
+        writes.push(prepare_entsettings_write(
+            paths.primary_rules.clone(),
+            &settings.text_expansion_rules,
+            language,
+            "entsettings.failed_to_serialize_rules",
+        )?);
         for file in &bundle.text_expander_extra_files {
             if let Some(file_name) = normalize_text_expander_rules_file_name(&file.file_name) {
-                let path = text_expander_extra_rules_path(&file_name);
-                let json =
-                    serde_json::to_string_pretty(&file.rules).context(crate::i18n::tr_catalog(
-                        self.app_settings.language,
-                        "entsettings.failed_to_serialize_rules",
-                    ))?;
-                std::fs::write(&path, json).with_context(|| {
-                    crate::i18n::tr_catalog_format(
-                        self.app_settings.language,
-                        "entsettings.failed_to_write",
-                        &[("path", &path.display().to_string())],
-                    )
-                })?;
+                writes.push(prepare_entsettings_write(
+                    paths.extra_rules(&file_name),
+                    &file.rules,
+                    language,
+                    "entsettings.failed_to_serialize_rules",
+                )?);
             }
         }
 
+        write_entsettings_files(&writes, language)?;
+        self.app_settings = settings;
         crate::ui_style::set_accent(self.app_settings.accent_color.color());
         ctx.set_zoom_factor(self.app_settings.ui_scale);
         self.sticky_layout_last_size = None;
@@ -188,6 +228,104 @@ impl EntropyApp {
         ctx.request_repaint();
         Ok(())
     }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn prepare_entsettings_write<T: Serialize>(
+    target: PathBuf,
+    value: &T,
+    language: crate::i18n::Language,
+    serialize_error_key: &'static str,
+) -> Result<EntSettingsWrite> {
+    let contents = serde_json::to_vec_pretty(value)
+        .context(crate::i18n::tr_catalog(language, serialize_error_key))?;
+    let original = match std::fs::read(&target) {
+        Ok(contents) => Some(contents),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => {
+            return Err(error).with_context(|| entsettings_read_error(language, &target));
+        }
+    };
+    Ok(EntSettingsWrite {
+        target,
+        contents,
+        original,
+    })
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn write_entsettings_files(
+    writes: &[EntSettingsWrite],
+    language: crate::i18n::Language,
+) -> Result<()> {
+    for (index, write) in writes.iter().enumerate() {
+        if let Err(error) = std::fs::write(&write.target, &write.contents) {
+            let error =
+                anyhow::Error::new(error).context(entsettings_write_error(language, &write.target));
+            let rollback_errors = rollback_entsettings_writes(&writes[..=index]);
+            return Err(with_entsettings_rollback_errors(
+                error,
+                rollback_errors,
+                language,
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn with_entsettings_rollback_errors(
+    error: anyhow::Error,
+    rollback_errors: Vec<String>,
+    language: crate::i18n::Language,
+) -> anyhow::Error {
+    if rollback_errors.is_empty() {
+        error
+    } else {
+        let original_error = format!("{error:#}");
+        error.context(crate::i18n::tr_catalog_format(
+            language,
+            "entsettings.failed_to_restore",
+            &[
+                ("error", &original_error),
+                ("errors", &rollback_errors.join("; ")),
+            ],
+        ))
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn rollback_entsettings_writes(writes: &[EntSettingsWrite]) -> Vec<String> {
+    let mut errors = Vec::new();
+    for write in writes.iter().rev() {
+        let result = match &write.original {
+            Some(original) => std::fs::write(&write.target, original),
+            None => std::fs::remove_file(&write.target),
+        };
+        if let Err(error) = result {
+            if write.original.is_some() || error.kind() != std::io::ErrorKind::NotFound {
+                errors.push(format!("restore {}: {error}", write.target.display()));
+            }
+        }
+    }
+    errors
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn entsettings_read_error(language: crate::i18n::Language, path: &Path) -> String {
+    crate::i18n::tr_catalog_format(
+        language,
+        "entsettings.failed_to_read",
+        &[("path", &path.display().to_string())],
+    )
+}
+
+fn entsettings_write_error(language: crate::i18n::Language, path: &Path) -> String {
+    crate::i18n::tr_catalog_format(
+        language,
+        "entsettings.failed_to_write",
+        &[("path", &path.display().to_string())],
+    )
 }
 
 fn validate_entsettings_file(
@@ -248,11 +386,141 @@ fn write_entsettings_file(
         language,
         "entsettings.failed_to_serialize",
     ))?;
-    std::fs::write(path, json).with_context(|| {
-        crate::i18n::tr_catalog_format(
-            language,
-            "entsettings.failed_to_write",
-            &[("path", &path.display().to_string())],
-        )
-    })
+    std::fs::write(path, json).with_context(|| entsettings_write_error(language, path))
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+
+    fn test_dir(name: &str) -> PathBuf {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "entropy-entsettings-{name}-{}-{nonce}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn failed_extra_rule_write_leaves_live_and_persisted_settings_unchanged() {
+        let ctx = egui::Context::default();
+        let creation_context = eframe::CreationContext::_new_kittest(ctx.clone());
+        let mut app = EntropyApp::new(&creation_context);
+        app.app_settings.language = crate::i18n::Language::English;
+        let original_ui_scale = app.app_settings.ui_scale;
+        let imported_ui_scale = if original_ui_scale < 1.5 { 1.75 } else { 1.0 };
+        let root = test_dir("late-write-failure");
+        let app_settings = root.join("app_settings.json");
+        let primary_rules = root.join("text_expansion_rules.json");
+        std::fs::write(&app_settings, "old app settings").unwrap();
+        std::fs::write(&primary_rules, "old primary rules").unwrap();
+
+        let mut bundle = app.entsettings_snapshot();
+        bundle.settings.ui_scale = imported_ui_scale;
+        bundle.settings.language = crate::i18n::Language::Russian;
+        bundle.text_expander_extra_files = vec![EntSettingsTextExpanderRuleFile {
+            file_name: "extra.json".to_owned(),
+            rules: vec![crate::text_expander::TextExpansionRule {
+                enabled: true,
+                trigger: "audit".to_owned(),
+                replacement: "atomic".to_owned(),
+            }],
+        }];
+        let paths = EntSettingsStoragePaths {
+            app_settings: app_settings.clone(),
+            primary_rules: primary_rules.clone(),
+            extra_rules_dir: root.join("missing-extra-rules-dir"),
+        };
+
+        let result = app.apply_entsettings_with_paths(&ctx, bundle, &paths);
+
+        assert!(result.is_err());
+        let error = result.unwrap_err().to_string();
+        assert!(error.starts_with("failed to write "));
+        assert!(!error.contains("не удалось записать"));
+        assert_eq!(app.app_settings.ui_scale, original_ui_scale);
+        assert_eq!(
+            std::fs::read_to_string(&app_settings).unwrap(),
+            "old app settings"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&primary_rules).unwrap(),
+            "old primary rules"
+        );
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn rollback_error_message_keeps_the_original_write_failure() {
+        let write_error = anyhow::anyhow!("disk full").context("failed to write settings");
+
+        let error = with_entsettings_rollback_errors(
+            write_error,
+            vec!["restore settings: disk full".to_owned()],
+            crate::i18n::Language::English,
+        );
+        let message = error.to_string();
+
+        assert!(message.contains("failed to write settings: disk full"));
+        assert!(message.contains("restore settings: disk full"));
+    }
+
+    #[test]
+    fn successful_import_commits_all_files_before_updating_live_settings() {
+        let ctx = egui::Context::default();
+        let creation_context = eframe::CreationContext::_new_kittest(ctx.clone());
+        let mut app = EntropyApp::new(&creation_context);
+        let root = test_dir("successful-commit");
+        let extra_rules_dir = root.join("extra-rules");
+        std::fs::create_dir_all(&extra_rules_dir).unwrap();
+        let paths = EntSettingsStoragePaths {
+            app_settings: root.join("app_settings.json"),
+            primary_rules: root.join("text_expansion_rules.json"),
+            extra_rules_dir,
+        };
+        let primary_rules = vec![crate::text_expander::TextExpansionRule {
+            enabled: true,
+            trigger: "primary".to_owned(),
+            replacement: "committed".to_owned(),
+        }];
+        let extra_rules = vec![crate::text_expander::TextExpansionRule {
+            enabled: true,
+            trigger: "extra".to_owned(),
+            replacement: "committed".to_owned(),
+        }];
+        let mut bundle = app.entsettings_snapshot();
+        bundle.settings.ui_scale = 1.75;
+        bundle.settings.text_expansion_rules = primary_rules.clone();
+        bundle.settings.text_expander_rule_files = vec!["extra.json".to_owned()];
+        bundle.text_expander_extra_files = vec![EntSettingsTextExpanderRuleFile {
+            file_name: "extra.json".to_owned(),
+            rules: extra_rules.clone(),
+        }];
+
+        app.apply_entsettings_with_paths(&ctx, bundle, &paths)
+            .unwrap();
+
+        let persisted_settings: AppSettings =
+            serde_json::from_str(&std::fs::read_to_string(&paths.app_settings).unwrap()).unwrap();
+        let persisted_primary_rules: Vec<crate::text_expander::TextExpansionRule> =
+            serde_json::from_str(&std::fs::read_to_string(&paths.primary_rules).unwrap()).unwrap();
+        let persisted_extra_rules: Vec<crate::text_expander::TextExpansionRule> =
+            serde_json::from_str(
+                &std::fs::read_to_string(paths.extra_rules("extra.json")).unwrap(),
+            )
+            .unwrap();
+        let expected_ui_scale = clamp_ui_scale(1.75);
+        assert_eq!(app.app_settings.ui_scale, expected_ui_scale);
+        assert_eq!(persisted_settings.ui_scale, expected_ui_scale);
+        assert_eq!(persisted_primary_rules, primary_rules);
+        assert_eq!(persisted_extra_rules, extra_rules);
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
 }


### PR DESCRIPTION
### Problem

If an `.entsettings` import failed while writing an extra Text Expander rules file, Entropy could leave the app settings and primary rules already replaced while also applying the imported settings to the running app. The auto-backup preserved a recovery copy, but the active files and live state could still disagree after the failed import.

### Fix

- Every settings and rules file is serialized and its previous contents are captured before the first write.
- If any write fails, completed or partially written targets are restored in reverse order and the live settings remain unchanged.
- Import failures stay in the current UI language and report both the originating write error and any restoration failures.
- Live app settings and Text Expander runtime state update only after every persistent write succeeds.

### Verification

- `cargo test entsettings` - 3 passed
- `cargo test --locked -- --test-threads=1` - 440 passed
- `cargo clippy --locked --all-targets` - passed with existing warnings
- `python3 scripts/check_i18n.py`
- `rustfmt --edition 2021 --check src/entsettings.rs`
- `git diff --check`