### PR TITLE
Keep Matrix Tester HID reads off the UI thread

### DIFF
--- a/src/ui/key_assignment.rs
+++ b/src/ui/key_assignment.rs
@@ -377,9 +377,9 @@ impl EntropyApp {
 
     #[cfg(not(target_arch = "wasm32"))]
     pub(super) fn undo(&mut self, ctx: &egui::Context) {
-        if self.vial_hid_background_layer_active() {
+        if self.vial_hid_nonblocking_read_active() {
             self.pending_layout_undo = true;
-            self.deferred_device_load.defer_background_for_user_input();
+            self.defer_background_layer_for_user_input_if_active();
             ctx.request_repaint_after(std::time::Duration::from_millis(16));
             return;
         }
@@ -389,7 +389,7 @@ impl EntropyApp {
     #[cfg(not(target_arch = "wasm32"))]
     pub(super) fn maybe_start_pending_layout_undo(&mut self, ctx: &egui::Context) {
         if !self.pending_layout_undo
-            || self.vial_hid_background_layer_active()
+            || self.vial_hid_nonblocking_read_active()
             || self.hid_user_action_busy()
         {
             return;

--- a/src/ui/layer_operations.rs
+++ b/src/ui/layer_operations.rs
@@ -789,14 +789,14 @@ impl EntropyApp {
         action_key: &'static str,
         undo_behavior: LayerUndoBehavior,
     ) {
-        if self.vial_hid_background_layer_active() {
+        if self.vial_hid_nonblocking_read_active() {
             self.pending_layer_write = Some(PendingLayerWrite {
                 layer,
                 desired,
                 action_key,
                 undo_behavior,
             });
-            self.deferred_device_load.defer_background_for_user_input();
+            self.defer_background_layer_for_user_input_if_active();
             return;
         }
 
@@ -983,7 +983,7 @@ impl EntropyApp {
     #[cfg(not(target_arch = "wasm32"))]
     pub(super) fn maybe_start_pending_layer_write(&mut self) {
         if self.pending_layer_write.is_none()
-            || self.vial_hid_background_layer_active()
+            || self.vial_hid_nonblocking_read_active()
             || self.hid_user_action_busy()
         {
             return;

--- a/src/ui/layout_settings_dropdown.rs
+++ b/src/ui/layout_settings_dropdown.rs
@@ -31,10 +31,10 @@ fn vial_lock_menu_state(
 
 fn vial_lock_control_idle(
     user_action_busy: bool,
-    background_layer_active: bool,
+    nonblocking_read_active: bool,
     is_unlocked: bool,
 ) -> bool {
-    !user_action_busy && (!is_unlocked || !background_layer_active)
+    !user_action_busy && (!is_unlocked || !nonblocking_read_active)
 }
 
 impl EntropyApp {
@@ -105,7 +105,7 @@ impl EntropyApp {
             #[cfg(not(target_arch = "wasm32"))]
             let vial_hid_idle = vial_lock_control_idle(
                 self.hid_user_action_busy(),
-                self.vial_hid_background_layer_active(),
+                self.vial_hid_nonblocking_read_active(),
                 is_unlocked,
             );
             #[cfg(target_arch = "wasm32")]
@@ -633,7 +633,7 @@ mod tests {
     }
 
     #[test]
-    fn background_layer_keeps_unlock_available_but_not_unqueued_lock() {
+    fn nonblocking_read_keeps_unlock_available_but_not_unqueued_lock() {
         assert!(vial_lock_control_idle(false, true, false));
         assert!(!vial_lock_control_idle(false, true, true));
     }

--- a/src/ui/matrix_tester.rs
+++ b/src/ui/matrix_tester.rs
@@ -84,51 +84,20 @@ impl EntropyApp {
         if self.is_vial_locked() {
             return;
         }
+        if self.vial_hid_task_active() {
+            return;
+        }
         let now = std::time::Instant::now();
         let poll_interval = self.matrix_tester_poll_interval();
 
-        if matrix_tester_poll_mode_for_transport(self.matrix_tester_uses_bluetooth_transport())
-            == MatrixTesterPollMode::Background
-        {
-            if now.duration_since(self.matrix_tester_last_poll) >= poll_interval {
-                match self.start_vial_matrix_poll(ctx, rows, cols, remember_ever_pressed) {
-                    VialHidTaskStart::Started => {
-                        self.matrix_tester_last_poll = now;
-                    }
-                    VialHidTaskStart::Busy | VialHidTaskStart::NoDevice => {}
-                }
-            }
-            ctx.request_repaint_after(poll_interval);
-            return;
-        }
-
-        let Some(hid) = &self.hid_device else {
-            return;
-        };
-
         if now.duration_since(self.matrix_tester_last_poll) >= poll_interval {
-            self.matrix_tester_last_poll = now;
-            let poll_result = hid.get_switch_matrix_with_rmk_byte_order(
-                rows,
-                cols,
-                self.matrix_tester_rmk_byte_order,
-            );
-            match poll_result {
-                Ok(pressed) => {
-                    self.finish_matrix_tester_poll(pressed, remember_ever_pressed);
+            match self.start_vial_matrix_poll(ctx, rows, cols, remember_ever_pressed) {
+                VialHidTaskStart::Started => {
+                    self.matrix_tester_last_poll = now;
+                    return;
                 }
-                Err(e) => {
-                    log::warn!("Matrix poll error: {e}");
-                    if crate::hid::is_disconnect_error(&e) {
-                        if !self.begin_bluetooth_reconnect(e.to_string()) {
-                            self.clear_connected_keyboard_state("Device disconnected");
-                        }
-                        return;
-                    }
-                    self.matrix_tester_lock_checked = false;
-                    self.matrix_tester_last_lock_check =
-                        std::time::Instant::now() - MATRIX_TESTER_LOCK_CHECK_INTERVAL;
-                }
+                VialHidTaskStart::Busy => {}
+                VialHidTaskStart::NoDevice => return,
             }
         }
         ctx.request_repaint_after(poll_interval);
@@ -407,26 +376,9 @@ fn matrix_tester_poll_interval_for_target(
     if bluetooth && !target_is_macos {
         MATRIX_TESTER_BLUETOOTH_POLL_INTERVAL
     } else {
-        // macOS already keeps a 16 ms visible Bluetooth repaint cadence and
-        // serializes Vial HID operations. Avoid holding fast BLE matrix
-        // round-trips to an 80 ms request cadence.
+        // Keep USB and macOS Bluetooth reads at the visible 16 ms cadence.
+        // Other desktop Bluetooth transports use a paced request interval.
         MATRIX_TESTER_POLL_INTERVAL
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum MatrixTesterPollMode {
-    Inline,
-    Background,
-}
-
-fn matrix_tester_poll_mode_for_transport(bluetooth: bool) -> MatrixTesterPollMode {
-    // BLE Vial round-trips can block on every desktop OS. Keep them on the
-    // serialized background HID worker so live tools remain responsive.
-    if bluetooth {
-        MatrixTesterPollMode::Background
-    } else {
-        MatrixTesterPollMode::Inline
     }
 }
 
@@ -463,18 +415,47 @@ mod tests {
     }
 
     #[test]
-    fn bluetooth_matrix_polling_uses_the_background_hid_worker_on_every_desktop() {
-        assert_eq!(
-            matrix_tester_poll_mode_for_transport(true),
-            MatrixTesterPollMode::Background
-        );
-    }
+    #[cfg(not(target_arch = "wasm32"))]
+    fn usb_matrix_polling_starts_a_background_hid_task() {
+        let ctx = egui::Context::default();
+        let creation_context = eframe::CreationContext::_new_kittest(ctx.clone());
+        let mut app = EntropyApp::new(&creation_context);
+        let (hid, recorder) = crate::hid::HidDevice::test_device();
+        app.device_manager
+            .replace_devices(vec![crate::device::Device {
+                name: "Test USB keyboard".to_owned(),
+                vendor_id: 0xE126,
+                product_id: 0x0074,
+                manufacturer: "Ergohaven".to_owned(),
+                serial_number: "TEST-USB".to_owned(),
+                bus_type: "USB".to_owned(),
+                path: "test-usb".to_owned(),
+                firmware: FirmwareProtocol::Vial,
+            }]);
+        app.selected_device = Some(0);
+        app.firmware = FirmwareProtocol::Vial;
+        app.hid_device = Some(hid);
+        app.matrix_tester_last_poll = std::time::Instant::now() - MATRIX_TESTER_POLL_INTERVAL;
 
-    #[test]
-    fn usb_matrix_polling_stays_inline() {
-        assert_eq!(
-            matrix_tester_poll_mode_for_transport(false),
-            MatrixTesterPollMode::Inline
-        );
+        app.poll_switch_matrix_state(&ctx, 1, 1, false);
+
+        assert!(app.vial_hid_task_active());
+        assert!(app.hid_device.is_none());
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while std::time::Instant::now() < deadline {
+            app.poll_vial_hid_task(&ctx);
+            if !app.vial_hid_task_active() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+
+        assert!(!app.vial_hid_task_active());
+        assert!(app.hid_device.is_some());
+        assert_eq!(app.matrix_tester_pressed, vec![false]);
+        let requests = recorder.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(&requests[0][..2], &[0x02, 0x03]);
     }
 }

--- a/src/ui/vial_hid_task.rs
+++ b/src/ui/vial_hid_task.rs
@@ -42,6 +42,17 @@ pub(super) enum VialHidOperation {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+impl VialHidOperation {
+    fn is_background_layer(&self) -> bool {
+        matches!(self, Self::Deferred(request) if request.is_background_layer())
+    }
+
+    fn is_nonblocking_read(&self) -> bool {
+        matches!(self, Self::Matrix { .. }) || self.is_background_layer()
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 enum VialHidOutcome {
     UnlockStarted {
         unlocked: bool,
@@ -207,17 +218,28 @@ impl EntropyApp {
 
     #[cfg(not(target_arch = "wasm32"))]
     pub(super) fn vial_hid_background_layer_active(&self) -> bool {
-        self.vial_hid_task.as_ref().is_some_and(|task| {
-            matches!(
-                &task.operation,
-                VialHidOperation::Deferred(request) if request.is_background_layer()
-            )
-        })
+        self.vial_hid_task
+            .as_ref()
+            .is_some_and(|task| task.operation.is_background_layer())
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(super) fn vial_hid_nonblocking_read_active(&self) -> bool {
+        self.vial_hid_task
+            .as_ref()
+            .is_some_and(|task| task.operation.is_nonblocking_read())
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(super) fn defer_background_layer_for_user_input_if_active(&mut self) {
+        if self.vial_hid_background_layer_active() {
+            self.deferred_device_load.defer_background_for_user_input();
+        }
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     pub(super) fn vial_hid_task_blocks_user_action(&self) -> bool {
-        self.vial_hid_task.is_some() && !self.vial_hid_background_layer_active()
+        self.vial_hid_task.is_some() && !self.vial_hid_nonblocking_read_active()
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -682,7 +704,8 @@ mod tests {
     }
 
     fn poll_until_vial_hid_idle(app: &mut EntropyApp, ctx: &egui::Context) {
-        for _ in 0..100 {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while std::time::Instant::now() < deadline {
             app.poll_vial_hid_task(ctx);
             if !app.vial_hid_task_active() {
                 return;
@@ -866,7 +889,8 @@ mod tests {
         assert!(app.pending_layout_undo);
         assert_eq!(app.undo_stack.len(), 1);
 
-        for _ in 0..100 {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while std::time::Instant::now() < deadline {
             app.poll_vial_hid_task(&ctx);
             app.maybe_start_pending_layout_undo(&ctx);
             if !app.vial_hid_task_active() && !app.pending_layout_undo {
@@ -933,7 +957,8 @@ mod tests {
         assert!(app.pending_layer_write.is_some());
         assert_eq!(app.layout.as_ref().unwrap().get_keycode(0, 0), 0x0004);
 
-        for _ in 0..100 {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while std::time::Instant::now() < deadline {
             app.poll_vial_hid_task(&ctx);
             app.maybe_start_pending_layer_write();
             app.poll_layer_write(&ctx);
@@ -960,6 +985,111 @@ mod tests {
         let requests = recorder.requests();
         assert_eq!(requests.len(), 3);
         assert_eq!(requests[0][0], 0x12);
+        assert_eq!(requests[1][0], 0x05);
+        assert_eq!(requests[2][0], 0x04);
+    }
+
+    #[test]
+    fn matrix_read_does_not_disable_user_actions_and_queued_undo_runs_next() {
+        let ctx = egui::Context::default();
+        let creation_context = eframe::CreationContext::_new_kittest(ctx.clone());
+        let mut app = EntropyApp::new(&creation_context);
+        let (hid, recorder) = crate::hid::HidDevice::test_device();
+        app.layout = Some(single_key_layout(0x0004));
+        app.undo_stack.push(UndoAction::Key {
+            layer: 0,
+            key_idx: 0,
+            old_kc: 0,
+        });
+        app.hid_device = Some(hid);
+
+        assert_eq!(
+            app.start_vial_matrix_poll(&ctx, 1, 1, false),
+            VialHidTaskStart::Started
+        );
+        assert!(!app.hid_user_action_busy());
+
+        app.undo(&ctx);
+
+        assert!(app.pending_layout_undo);
+        assert_eq!(app.undo_stack.len(), 1);
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while std::time::Instant::now() < deadline {
+            app.poll_vial_hid_task(&ctx);
+            app.maybe_start_pending_layout_undo(&ctx);
+            if !app.vial_hid_task_active() && !app.pending_layout_undo {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+
+        assert!(!app.pending_layout_undo);
+        assert!(!app.vial_hid_task_active());
+        assert!(app.undo_stack.is_empty());
+        assert_eq!(app.layout.as_ref().unwrap().get_keycode(0, 0), 0);
+        let requests = recorder.requests();
+        assert_eq!(requests.len(), 3);
+        assert_eq!(&requests[0][..2], &[0x02, 0x03]);
+        assert_eq!(requests[1][0], 0x05);
+        assert_eq!(requests[2][0], 0x04);
+    }
+
+    #[test]
+    fn matrix_read_queues_layer_operation_and_runs_it_next() {
+        let ctx = egui::Context::default();
+        let creation_context = eframe::CreationContext::_new_kittest(ctx.clone());
+        let mut app = EntropyApp::new(&creation_context);
+        let (hid, recorder) = crate::hid::HidDevice::test_device();
+        app.layout = Some(single_key_layout(0x0004));
+        app.hid_device = Some(hid);
+
+        assert_eq!(
+            app.start_vial_matrix_poll(&ctx, 1, 1, false),
+            VialHidTaskStart::Started
+        );
+        assert!(!app.hid_user_action_busy());
+
+        app.apply_layer_snapshot(
+            0,
+            LayerSnapshot {
+                keycodes: vec![0],
+                encoder_keycodes: Vec::new(),
+            },
+            "layer_actions.fill_none",
+        );
+
+        assert!(app.pending_layer_write.is_some());
+        assert_eq!(app.layout.as_ref().unwrap().get_keycode(0, 0), 0x0004);
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while std::time::Instant::now() < deadline {
+            app.poll_vial_hid_task(&ctx);
+            app.maybe_start_pending_layer_write();
+            app.poll_layer_write(&ctx);
+            if !app.vial_hid_task_active()
+                && app.pending_layer_write.is_none()
+                && app.layer_write_task.is_none()
+            {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+
+        assert!(app.pending_layer_write.is_none());
+        assert!(app.layer_write_task.is_none());
+        assert_eq!(app.layout.as_ref().unwrap().get_keycode(0, 0), 0);
+        assert!(matches!(
+            app.undo_stack.last(),
+            Some(UndoAction::Layer {
+                layer: 0,
+                old: LayerSnapshot { keycodes, .. },
+                requires_firmware: true,
+            }) if keycodes == &[0x0004]
+        ));
+        let requests = recorder.requests();
+        assert_eq!(requests.len(), 3);
+        assert_eq!(&requests[0][..2], &[0x02, 0x03]);
         assert_eq!(requests[1][0], 0x05);
         assert_eq!(requests[2][0], 0x04);
     }


### PR DESCRIPTION
### Problem

Matrix Tester polled USB keyboards directly from the UI thread at a 16 ms cadence. A slow HID round-trip could therefore make the app hitch while the tester was open, even though Bluetooth matrix reads already used the serialized background worker.

Moving all matrix reads to that worker also required a narrower interaction policy: ordinary editing should stay available during read-only polling, while HID-backed undo, whole-layer writes, and unlocked-device lock actions must still wait for the current read to release the device.

### Fix

- USB and Bluetooth matrix reads now run through the shared background Vial HID worker, with HID ownership restored before the next operation.
- Matrix and deferred background reads no longer disable ordinary editing; undo and whole-layer actions queue and run after the read completes.
- Lock actions remain disabled when an unlocked keyboard has an active unqueued read.
- Matrix polling avoids redundant repaint wakeups while work is active and does not repaint when no device is available.
- Regression tests cover the USB matrix command, HID restoration, nonblocking editing, queued undo and layer writes, and deadline-based async test waits.

### Verification

- `cargo test matrix_tester --locked` - 4 passed
- `cargo test vial_hid_task --locked` - 12 passed
- `cargo test --locked` - 438 passed with the normal parallel runner
- `cargo clippy --locked --all-targets` - passed with existing warnings
- `python3 scripts/check_i18n.py`
- Scoped `rustfmt --edition 2021 --check` for all five changed Rust files
- `git diff --check origin/main`
