### PR TITLE
Detect settings migration fields structurally

### DIFF
--- a/src/app_storage.rs
+++ b/src/app_storage.rs
@@ -266,6 +266,33 @@ pub(super) fn open_path_in_system_editor(path: &std::path::Path) -> bool {
     }
 }
 
+fn parse_app_settings_fields(
+    settings_data: Option<&str>,
+) -> Option<serde_json::Map<String, serde_json::Value>> {
+    settings_data.and_then(|data| {
+        serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(data).ok()
+    })
+}
+
+fn apply_app_settings_migrations(settings: &mut AppSettings, settings_data: Option<&str>) {
+    let settings_fields = parse_app_settings_fields(settings_data);
+    let has_close_behavior = settings_fields
+        .as_ref()
+        .is_some_and(|fields| fields.contains_key("close_to_tray_behavior"));
+    if !has_close_behavior && settings.minimize_to_tray_on_close {
+        settings.close_to_tray_behavior = CloseToTrayBehavior::Tray;
+    }
+    settings.minimize_to_tray_on_close =
+        matches!(settings.close_to_tray_behavior, CloseToTrayBehavior::Tray);
+
+    let has_layout_image_export = settings_fields
+        .as_ref()
+        .is_some_and(|fields| fields.contains_key("layout_image_export"));
+    if !has_layout_image_export {
+        settings.layout_image_export.key_legend_layout = settings.key_legend_layout;
+    }
+}
+
 pub(super) fn load_app_settings() -> AppSettings {
     migrate_legacy_text_expander_rules_file();
     let path = app_settings_path();
@@ -288,21 +315,7 @@ pub(super) fn load_app_settings() -> AppSettings {
     settings.text_expander_rule_files =
         normalize_text_expander_rule_files(&settings.text_expander_rule_files);
 
-    let has_close_behavior = settings_data
-        .as_deref()
-        .is_some_and(|data| data.contains("close_to_tray_behavior"));
-    if !has_close_behavior && settings.minimize_to_tray_on_close {
-        settings.close_to_tray_behavior = CloseToTrayBehavior::Tray;
-    }
-    settings.minimize_to_tray_on_close =
-        matches!(settings.close_to_tray_behavior, CloseToTrayBehavior::Tray);
-
-    let has_layout_image_export = settings_data
-        .as_deref()
-        .is_some_and(|data| data.contains("layout_image_export"));
-    if !has_layout_image_export {
-        settings.layout_image_export.key_legend_layout = settings.key_legend_layout;
-    }
+    apply_app_settings_migrations(&mut settings, settings_data.as_deref());
     settings.typing_trainer = settings.typing_trainer.normalized();
     normalize_typing_trainer_history(&mut settings.typing_trainer_history);
 
@@ -688,6 +701,63 @@ mod tests {
             std::process::id(),
             nonce
         ))
+    }
+
+    #[test]
+    fn app_settings_migrations_use_top_level_json_keys() {
+        let mut settings = AppSettings {
+            minimize_to_tray_on_close: true,
+            ..AppSettings::default()
+        };
+        apply_app_settings_migrations(
+            &mut settings,
+            Some(r#"{"nested":{"close_to_tray_behavior":"ask"}}"#),
+        );
+        assert_eq!(settings.close_to_tray_behavior, CloseToTrayBehavior::Tray);
+        assert!(settings.minimize_to_tray_on_close);
+
+        let mut settings = AppSettings {
+            minimize_to_tray_on_close: true,
+            ..AppSettings::default()
+        };
+        apply_app_settings_migrations(&mut settings, Some(r#"{"close_to_tray_behavior":"ask"}"#));
+        assert_eq!(settings.close_to_tray_behavior, CloseToTrayBehavior::Ask);
+        assert!(!settings.minimize_to_tray_on_close);
+
+        let mut settings = AppSettings {
+            key_legend_layout: KeyLegendLayout::Russian,
+            ..AppSettings::default()
+        };
+        apply_app_settings_migrations(
+            &mut settings,
+            Some(r#"{"text_expansion_rules":[{"replacement":"layout_image_export"}]}"#),
+        );
+        assert_eq!(
+            settings.layout_image_export.key_legend_layout,
+            KeyLegendLayout::Russian
+        );
+
+        let mut settings = AppSettings {
+            key_legend_layout: KeyLegendLayout::Russian,
+            ..AppSettings::default()
+        };
+        apply_app_settings_migrations(&mut settings, Some(r#"{"layout_image_export":{}}"#));
+        assert_eq!(
+            settings.layout_image_export.key_legend_layout,
+            KeyLegendLayout::English
+        );
+
+        let mut settings = AppSettings {
+            minimize_to_tray_on_close: true,
+            key_legend_layout: KeyLegendLayout::Russian,
+            ..AppSettings::default()
+        };
+        apply_app_settings_migrations(&mut settings, Some("not json"));
+        assert_eq!(settings.close_to_tray_behavior, CloseToTrayBehavior::Tray);
+        assert_eq!(
+            settings.layout_image_export.key_legend_layout,
+            KeyLegendLayout::Russian
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Problem

App settings migrations searched the raw JSON text to decide whether newer top-level fields were present.
A same-named key nested in another object, or literal text inside Text Expander content, could suppress a required migration and leave close-to-tray behavior or exported legend layout on legacy/default values.

### Fix

Migrations now inspect the parsed top-level JSON fields once and use exact keys for both compatibility decisions. Nested keys and string content no longer impersonate persisted fields, while real top-level fields preserve user choices and invalid legacy JSON retains the existing fallback behavior.

Regression tests exercise the resulting migration behavior for nested names, literal content, real top-level fields, and invalid JSON.

Related: #109

### Verification

- `cargo test app_storage --locked` - 7 passed
- `cargo test --locked -- --test-threads=1` - 438 passed
- Both affected Vial timing tests passed individually
- `cargo clippy --locked --all-targets` - passed with existing warnings
- Scoped `rustfmt --edition 2021 --check` for `src/app_storage.rs`
- `git diff --check origin/main`
- The default parallel suite still fails only the two pre-existing Vial timing tests; their deadline-based wait replacement is tracked separately.
