### PR TITLE
Verify AppImage packaging tool downloads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,10 @@ jobs:
             libssl-dev \
             libgtk-3-dev
 
+      - name: Test AppImage tool integrity verification
+        if: matrix.kind == 'linux'
+        run: bash scripts/test_verify_sha256.sh
+
       - name: Build
         if: matrix.kind != 'macos'
         run: cargo build --release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,9 @@ jobs:
 
       - name: Test AppImage tool integrity verification
         if: matrix.kind == 'linux'
-        run: bash scripts/test_verify_sha256.sh
+        run: |
+          bash scripts/test_verify_sha256.sh
+          bash scripts/test_build_linux_appimage.sh
 
       - name: Build
         if: matrix.kind != 'macos'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,7 @@ jobs:
         run: |
           bash scripts/test_verify_sha256.sh
           bash scripts/test_build_linux_appimage.sh
+          bash scripts/test_update_appimagetool_pin.sh
 
       - name: Build
         if: matrix.kind != 'macos'

--- a/scripts/appimagetool_pin.sh
+++ b/scripts/appimagetool_pin.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# These constants are consumed by scripts that source this file.
+# shellcheck disable=SC2034
+readonly APPIMAGETOOL_PINNED_URL="https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
+readonly APPIMAGETOOL_PINNED_SHA256="b90f4a8b18967545fda78a445b27680a1642f1ef9488ced28b65398f2be7add2"

--- a/scripts/appimagetool_pin.sh
+++ b/scripts/appimagetool_pin.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-# These constants are consumed by scripts that source this file.
+# These constants are consumed by scripts that source this file. Update them
+# with `bash scripts/update_appimagetool_pin.sh <immutable-release-tag>`.
 # shellcheck disable=SC2034
-readonly APPIMAGETOOL_PINNED_URL="https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
-readonly APPIMAGETOOL_PINNED_SHA256="b90f4a8b18967545fda78a445b27680a1642f1ef9488ced28b65398f2be7add2"
+readonly APPIMAGETOOL_PINNED_RELEASE="12"
+readonly APPIMAGETOOL_PINNED_URL="https://github.com/AppImage/AppImageKit/releases/download/12/appimagetool-x86_64.AppImage"
+readonly APPIMAGETOOL_PINNED_SHA256="d918b4df547b388ef253f3c9e7f6529ca81a885395c31f619d9aaf7030499a13"

--- a/scripts/build_linux_appimage.sh
+++ b/scripts/build_linux_appimage.sh
@@ -10,10 +10,13 @@ fi
 OUT="${2:-$ROOT/dist/release/entropy-${VERSION}-x86_64.AppImage}"
 APPDIR="${APPDIR:-$ROOT/target/appimage/Entropy.AppDir}"
 APPIMAGETOOL="${APPIMAGETOOL:-$ROOT/target/tools/appimagetool-x86_64.AppImage}"
-APPIMAGETOOL_URL="${APPIMAGETOOL_URL:-https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage}"
-APPIMAGETOOL_SHA256="${APPIMAGETOOL_SHA256:-b90f4a8b18967545fda78a445b27680a1642f1ef9488ced28b65398f2be7add2}"
 
 cd "$ROOT"
+# shellcheck disable=SC1091
+source scripts/appimagetool_pin.sh
+APPIMAGETOOL_URL="${APPIMAGETOOL_URL:-$APPIMAGETOOL_PINNED_URL}"
+APPIMAGETOOL_SHA256="${APPIMAGETOOL_SHA256:-$APPIMAGETOOL_PINNED_SHA256}"
+
 cargo build --release --locked
 
 rm -rf "$APPDIR" "$OUT"

--- a/scripts/build_linux_appimage.sh
+++ b/scripts/build_linux_appimage.sh
@@ -11,6 +11,7 @@ OUT="${2:-$ROOT/dist/release/entropy-${VERSION}-x86_64.AppImage}"
 APPDIR="${APPDIR:-$ROOT/target/appimage/Entropy.AppDir}"
 APPIMAGETOOL="${APPIMAGETOOL:-$ROOT/target/tools/appimagetool-x86_64.AppImage}"
 APPIMAGETOOL_URL="${APPIMAGETOOL_URL:-https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage}"
+APPIMAGETOOL_SHA256="${APPIMAGETOOL_SHA256:-b90f4a8b18967545fda78a445b27680a1642f1ef9488ced28b65398f2be7add2}"
 
 cd "$ROOT"
 cargo build --release --locked
@@ -60,8 +61,15 @@ cat > "$APPDIR/entropy.svg" <<'EOF'
 EOF
 
 if [[ ! -x "$APPIMAGETOOL" ]]; then
-  curl -fsSL "$APPIMAGETOOL_URL" -o "$APPIMAGETOOL"
-  chmod 0755 "$APPIMAGETOOL"
+  APPIMAGETOOL_DOWNLOAD="$(mktemp "${APPIMAGETOOL}.download.XXXXXX")"
+  trap 'rm -f "$APPIMAGETOOL_DOWNLOAD"' EXIT
+  curl -fsSL "$APPIMAGETOOL_URL" -o "$APPIMAGETOOL_DOWNLOAD"
+  "$ROOT/scripts/verify_sha256.sh" "$APPIMAGETOOL_DOWNLOAD" "$APPIMAGETOOL_SHA256"
+  chmod 0755 "$APPIMAGETOOL_DOWNLOAD"
+  mv "$APPIMAGETOOL_DOWNLOAD" "$APPIMAGETOOL"
+  trap - EXIT
+else
+  "$ROOT/scripts/verify_sha256.sh" "$APPIMAGETOOL" "$APPIMAGETOOL_SHA256"
 fi
 
 ARCH=x86_64 APPIMAGE_EXTRACT_AND_RUN=1 "$APPIMAGETOOL" "$APPDIR" "$OUT"

--- a/scripts/test_build_linux_appimage.sh
+++ b/scripts/test_build_linux_appimage.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD="$ROOT/scripts/build_linux_appimage.sh"
+VERIFY="$ROOT/scripts/verify_sha256.sh"
+# shellcheck disable=SC1091
+source "$ROOT/scripts/appimagetool_pin.sh"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+hash_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+PINNED_TOOL="$TMP_DIR/pinned-appimagetool"
+curl --connect-timeout 30 --max-time 300 -fsSL \
+  "$APPIMAGETOOL_PINNED_URL" \
+  -o "$PINNED_TOOL"
+"$VERIFY" "$PINNED_TOOL" "$APPIMAGETOOL_PINNED_SHA256"
+
+STUB_BIN="$TMP_DIR/bin"
+mkdir -p "$STUB_BIN"
+
+cat > "$STUB_BIN/cargo" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+cat > "$STUB_BIN/install" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+destination="${!#}"
+mkdir -p "$(dirname "$destination")"
+: > "$destination"
+chmod 0755 "$destination"
+EOF
+
+cat > "$STUB_BIN/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+output=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "-o" ]]; then
+    output="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+[[ -n "$output" ]]
+printf 'called\n' > "$APPIMAGETOOL_CURL_MARKER"
+cp "$APPIMAGETOOL_FIXTURE" "$output"
+EOF
+
+chmod 0755 "$STUB_BIN/cargo" "$STUB_BIN/install" "$STUB_BIN/curl"
+
+TRUSTED_TOOL="$TMP_DIR/trusted-tool"
+cat > "$TRUSTED_TOOL" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'ran\n' > "$APPIMAGETOOL_RUN_MARKER"
+: > "$2"
+EOF
+chmod 0755 "$TRUSTED_TOOL"
+TRUSTED_SHA256="$(hash_file "$TRUSTED_TOOL")"
+
+CORRUPT_TOOL="$TMP_DIR/corrupt-tool"
+printf 'corrupt\n' > "$CORRUPT_TOOL"
+
+run_build() {
+  local scenario="$1"
+  local fixture="$2"
+  local tool="$scenario/appimagetool"
+  local output="$scenario/entropy.AppImage"
+
+  mkdir -p "$scenario"
+  PATH="$STUB_BIN:$PATH" \
+    APPDIR="$scenario/Entropy.AppDir" \
+    APPIMAGETOOL="$tool" \
+    APPIMAGETOOL_URL="https://example.invalid/appimagetool" \
+    APPIMAGETOOL_SHA256="$TRUSTED_SHA256" \
+    APPIMAGETOOL_FIXTURE="$fixture" \
+    APPIMAGETOOL_CURL_MARKER="$scenario/curl-called" \
+    APPIMAGETOOL_RUN_MARKER="$scenario/tool-ran" \
+    "$BUILD" vtest "$output"
+}
+
+FRESH_VALID="$TMP_DIR/fresh-valid"
+run_build "$FRESH_VALID" "$TRUSTED_TOOL"
+[[ -x "$FRESH_VALID/appimagetool" ]]
+[[ -f "$FRESH_VALID/curl-called" ]]
+[[ -f "$FRESH_VALID/tool-ran" ]]
+[[ -f "$FRESH_VALID/entropy.AppImage" ]]
+
+FRESH_CORRUPT="$TMP_DIR/fresh-corrupt"
+mkdir -p "$FRESH_CORRUPT"
+if run_build "$FRESH_CORRUPT" "$CORRUPT_TOOL" 2> "$FRESH_CORRUPT/stderr"; then
+  echo "Expected a corrupt download to fail" >&2
+  exit 1
+fi
+[[ "$(<"$FRESH_CORRUPT/stderr")" == *"SHA-256 mismatch"* ]]
+[[ ! -e "$FRESH_CORRUPT/appimagetool" ]]
+[[ ! -e "$FRESH_CORRUPT/tool-ran" ]]
+if compgen -G "$FRESH_CORRUPT/appimagetool.download.*" >/dev/null; then
+  echo "Corrupt download temporary file was not cleaned up" >&2
+  exit 1
+fi
+
+CACHED_VALID="$TMP_DIR/cached-valid"
+mkdir -p "$CACHED_VALID"
+cp "$TRUSTED_TOOL" "$CACHED_VALID/appimagetool"
+run_build "$CACHED_VALID" "$CORRUPT_TOOL"
+[[ ! -e "$CACHED_VALID/curl-called" ]]
+[[ -f "$CACHED_VALID/tool-ran" ]]
+[[ -f "$CACHED_VALID/entropy.AppImage" ]]
+
+CACHED_CORRUPT="$TMP_DIR/cached-corrupt"
+mkdir -p "$CACHED_CORRUPT"
+cp "$CORRUPT_TOOL" "$CACHED_CORRUPT/appimagetool"
+chmod 0755 "$CACHED_CORRUPT/appimagetool"
+if run_build "$CACHED_CORRUPT" "$TRUSTED_TOOL" 2> "$CACHED_CORRUPT/stderr"; then
+  echo "Expected a corrupt cached tool to fail" >&2
+  exit 1
+fi
+[[ "$(<"$CACHED_CORRUPT/stderr")" == *"SHA-256 mismatch"* ]]
+[[ ! -e "$CACHED_CORRUPT/curl-called" ]]
+[[ ! -e "$CACHED_CORRUPT/tool-ran" ]]
+
+echo "AppImage tool integration tests passed"

--- a/scripts/test_update_appimagetool_pin.sh
+++ b/scripts/test_update_appimagetool_pin.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UPDATE="$ROOT/scripts/update_appimagetool_pin.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+hash_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+PIN_FILE="$TMP_DIR/appimagetool_pin.sh"
+cat > "$PIN_FILE" <<'EOF'
+readonly APPIMAGETOOL_PINNED_RELEASE="11"
+readonly APPIMAGETOOL_PINNED_URL="https://github.com/AppImage/AppImageKit/releases/download/11/appimagetool-x86_64.AppImage"
+readonly APPIMAGETOOL_PINNED_SHA256="0000000000000000000000000000000000000000000000000000000000000000"
+EOF
+cp "$PIN_FILE" "$TMP_DIR/original_pin.sh"
+
+FIXTURE="$TMP_DIR/appimagetool-x86_64.AppImage"
+printf 'trusted AppImageTool release\n' > "$FIXTURE"
+EXPECTED_SHA256="$(hash_file "$FIXTURE")"
+
+STUB_BIN="$TMP_DIR/bin"
+mkdir -p "$STUB_BIN"
+cat > "$STUB_BIN/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+output=""
+for ((index = 1; index <= $#; index += 1)); do
+  if [[ "${!index}" == "--output" ]]; then
+    next_index=$((index + 1))
+    output="${!next_index}"
+    break
+  fi
+done
+
+[[ -n "$output" ]]
+printf '%s\n' "$*" > "$APPIMAGETOOL_UPDATE_CURL_ARGS"
+cp "$APPIMAGETOOL_UPDATE_FIXTURE" "$output"
+EOF
+chmod 0755 "$STUB_BIN/curl"
+
+PATH="$STUB_BIN:$PATH" \
+  APPIMAGETOOL_PIN_FILE="$PIN_FILE" \
+  APPIMAGETOOL_UPDATE_FIXTURE="$FIXTURE" \
+  APPIMAGETOOL_UPDATE_CURL_ARGS="$TMP_DIR/curl-args" \
+  bash "$UPDATE" 12
+
+# shellcheck disable=SC1090
+source "$PIN_FILE"
+[[ "$APPIMAGETOOL_PINNED_RELEASE" == "12" ]]
+[[ "$APPIMAGETOOL_PINNED_URL" == "https://github.com/AppImage/AppImageKit/releases/download/12/appimagetool-x86_64.AppImage" ]]
+[[ "$APPIMAGETOOL_PINNED_SHA256" == "$EXPECTED_SHA256" ]]
+[[ "$(<"$TMP_DIR/curl-args")" == *"/releases/download/12/appimagetool-x86_64.AppImage"* ]]
+
+cp "$PIN_FILE" "$TMP_DIR/updated_pin.sh"
+
+if PATH="$STUB_BIN:$PATH" APPIMAGETOOL_PIN_FILE="$PIN_FILE" bash "$UPDATE" continuous; then
+  echo "Expected the mutable continuous tag to be rejected" >&2
+  exit 1
+fi
+cmp -s "$PIN_FILE" "$TMP_DIR/updated_pin.sh"
+
+if PATH="$STUB_BIN:$PATH" APPIMAGETOOL_PIN_FILE="$PIN_FILE" bash "$UPDATE" '12/../continuous'; then
+  echo "Expected an unsafe release tag to be rejected" >&2
+  exit 1
+fi
+
+cmp -s "$PIN_FILE" "$TMP_DIR/updated_pin.sh"
+
+echo "AppImageTool pin update tests passed"

--- a/scripts/test_verify_sha256.sh
+++ b/scripts/test_verify_sha256.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERIFY="$ROOT/scripts/verify_sha256.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+FIXTURE="$TMP_DIR/trusted-tool"
+STDERR_FILE="$TMP_DIR/stderr"
+printf 'trusted\n' > "$FIXTURE"
+
+"$VERIFY" \
+  "$FIXTURE" \
+  "7bd39a7cbcf687fd60f819645b8bcaf731a9f19cb102484a7b84530516d7e8b8"
+
+if "$VERIFY" "$FIXTURE" "$(printf '0%.0s' {1..64})" 2> "$STDERR_FILE"; then
+  echo "Expected a checksum mismatch to fail" >&2
+  exit 1
+fi
+if [[ "$(<"$STDERR_FILE")" != *"SHA-256 mismatch"* ]]; then
+  echo "Checksum mismatch did not report the expected error" >&2
+  exit 1
+fi
+
+if "$VERIFY" "$FIXTURE" "not-a-checksum" 2> "$STDERR_FILE"; then
+  echo "Expected a malformed checksum to fail" >&2
+  exit 1
+fi
+if [[ "$(<"$STDERR_FILE")" != *"64 lowercase hexadecimal characters"* ]]; then
+  echo "Malformed checksum did not report the expected error" >&2
+  exit 1
+fi
+
+echo "SHA-256 verification tests passed"

--- a/scripts/update_appimagetool_pin.sh
+++ b/scripts/update_appimagetool_pin.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PIN_FILE="${APPIMAGETOOL_PIN_FILE:-$ROOT/scripts/appimagetool_pin.sh}"
+RELEASE="${1:-}"
+ASSET="appimagetool-x86_64.AppImage"
+
+if [[ -z "$RELEASE" ]]; then
+  echo "Usage: bash $0 <immutable-release-tag>" >&2
+  exit 2
+fi
+
+if [[ "$RELEASE" == "continuous" || ! "$RELEASE" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+  echo "Release tag must be immutable and contain only letters, digits, dots, underscores, or hyphens" >&2
+  exit 2
+fi
+
+if [[ ! -f "$PIN_FILE" ]]; then
+  echo "Cannot update missing pin file: $PIN_FILE" >&2
+  exit 1
+fi
+
+URL="https://github.com/AppImage/AppImageKit/releases/download/$RELEASE/$ASSET"
+DOWNLOAD="$(mktemp)"
+PIN_TMP="$(mktemp "${PIN_FILE}.tmp.XXXXXX")"
+trap 'rm -f "$DOWNLOAD" "$PIN_TMP"' EXIT
+
+curl --fail --location --retry 3 --silent --show-error "$URL" --output "$DOWNLOAD"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  SHA256="$(sha256sum "$DOWNLOAD" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  SHA256="$(shasum -a 256 "$DOWNLOAD" | awk '{print $1}')"
+else
+  echo "No SHA-256 utility found (expected sha256sum or shasum)" >&2
+  exit 1
+fi
+
+if ! awk \
+  -v release="$RELEASE" \
+  -v url="$URL" \
+  -v sha256="$SHA256" \
+  '
+    /^readonly APPIMAGETOOL_PINNED_RELEASE=/ {
+      print "readonly APPIMAGETOOL_PINNED_RELEASE=\"" release "\""
+      found_release = 1
+      next
+    }
+    /^readonly APPIMAGETOOL_PINNED_URL=/ {
+      print "readonly APPIMAGETOOL_PINNED_URL=\"" url "\""
+      found_url = 1
+      next
+    }
+    /^readonly APPIMAGETOOL_PINNED_SHA256=/ {
+      print "readonly APPIMAGETOOL_PINNED_SHA256=\"" sha256 "\""
+      found_sha256 = 1
+      next
+    }
+    { print }
+    END { exit !(found_release && found_url && found_sha256) }
+  ' "$PIN_FILE" > "$PIN_TMP"; then
+  echo "Pin file does not contain all expected AppImageTool constants: $PIN_FILE" >&2
+  exit 1
+fi
+
+mv "$PIN_TMP" "$PIN_FILE"
+chmod 0644 "$PIN_FILE"
+trap - EXIT
+rm -f "$DOWNLOAD"
+
+echo "Pinned AppImageTool release $RELEASE ($SHA256)"

--- a/scripts/verify_sha256.sh
+++ b/scripts/verify_sha256.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <file> <expected-sha256>" >&2
+  exit 2
+fi
+
+FILE="$1"
+EXPECTED_SHA256="$2"
+
+if [[ ! -f "$FILE" ]]; then
+  echo "Cannot verify missing file: $FILE" >&2
+  exit 1
+fi
+
+if [[ ! "$EXPECTED_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "Expected SHA-256 must be 64 lowercase hexadecimal characters" >&2
+  exit 2
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+  CHECKSUM_OUTPUT="$(sha256sum "$FILE")"
+elif command -v shasum >/dev/null 2>&1; then
+  CHECKSUM_OUTPUT="$(shasum -a 256 "$FILE")"
+else
+  echo "No SHA-256 utility found (expected sha256sum or shasum)" >&2
+  exit 1
+fi
+
+ACTUAL_SHA256="${CHECKSUM_OUTPUT%% *}"
+if [[ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]]; then
+  echo "SHA-256 mismatch for $FILE" >&2
+  echo "Expected: $EXPECTED_SHA256" >&2
+  echo "Actual:   $ACTUAL_SHA256" >&2
+  exit 1
+fi


### PR DESCRIPTION
### Problem

Linux release packaging downloaded and executed AppImageKit's `appimagetool` without verifying its contents.
A corrupted or replaced upstream download, or a stale cached executable, could therefore be trusted as release tooling and alter the produced AppImage.

The upstream x86_64 tool is published under a rolling `continuous` asset, so a fixed digest also needs to be exercised before a release tag rather than failing for the first time during release packaging.

### Fix

- The current AppImageKit asset URL and SHA-256 digest now share one reviewed pin.
- Fresh downloads are staged in a temporary file, verified before becoming executable, and moved into the cache only after validation.
- Existing cached tools are re-verified before every use.
- Linux CI verifies the live pinned asset and exercises valid and corrupt fresh-download and cached-tool paths, including cleanup and proof that mismatched tools never execute.

### Verification

- `bash scripts/test_verify_sha256.sh`
- `bash scripts/test_build_linux_appimage.sh`
- `bash -n scripts/appimagetool_pin.sh scripts/build_linux_appimage.sh scripts/verify_sha256.sh scripts/test_verify_sha256.sh scripts/test_build_linux_appimage.sh`
- `shellcheck scripts/appimagetool_pin.sh scripts/build_linux_appimage.sh scripts/verify_sha256.sh scripts/test_verify_sha256.sh scripts/test_build_linux_appimage.sh`
- `actionlint .github/workflows/build.yml`
- Ruby YAML parse of `.github/workflows/build.yml`
- Live AppImageKit asset matched the pinned SHA-256 digest
- `git diff --check origin/main...HEAD`