### PR TITLE
Remove Clippy warnings from test fixtures

### DIFF
--- a/src/keycode_picker.rs
+++ b/src/keycode_picker.rs
@@ -217,10 +217,13 @@ mod tests {
 
     #[test]
     fn rmk_macro_ext_guard_hides_layer_macro_choices_and_explains_why() {
-        let mut picker = KeycodePicker::default();
-        picker.supports_macro_ext_keycodes = false;
-        picker.macro_ext_keycodes_disabled_reason =
-            Some(MacroExtKeycodesDisabledReason::RmkVialMacroExtUnsupported);
+        let picker = KeycodePicker {
+            supports_macro_ext_keycodes: false,
+            macro_ext_keycodes_disabled_reason: Some(
+                MacroExtKeycodesDisabledReason::RmkVialMacroExtUnsupported,
+            ),
+            ..Default::default()
+        };
 
         assert!(picker
             .macro_layer_key_choices(MacroKeyPickKind::Tap)

--- a/src/ui/live_features_settings.rs
+++ b/src/ui/live_features_settings.rs
@@ -357,11 +357,13 @@ mod tests {
         app.layout_options_value = Some(0);
         app.app_settings.layout_sync_enabled = false;
 
-        let mut input = egui::RawInput::default();
-        input.screen_rect = Some(egui::Rect::from_min_size(
-            egui::Pos2::ZERO,
-            egui::vec2(900.0, 700.0),
-        ));
+        let input = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::vec2(900.0, 700.0),
+            )),
+            ..Default::default()
+        };
         let output = ctx.run_ui(input, |ui| {
             app.draw_live_features_settings_page(ui, ui.max_rect());
         });

--- a/src/ui/tap_hold_settings.rs
+++ b/src/ui/tap_hold_settings.rs
@@ -799,8 +799,10 @@ mod tests {
 
     #[test]
     fn tap_hold_rows_hide_unadvertised_qsids() {
-        let mut tap_hold = TapHoldSettingsState::default();
-        tap_hold.supported = true;
+        let mut tap_hold = TapHoldSettingsState {
+            supported: true,
+            ..Default::default()
+        };
         tap_hold.set_qsid_supported(7);
 
         let rows = tap_hold_one_shot_rows(
@@ -822,8 +824,10 @@ mod tests {
 
     #[test]
     fn rmk_rows_use_rmk_behavior_names() {
-        let mut tap_hold = TapHoldSettingsState::default();
-        tap_hold.supported = true;
+        let mut tap_hold = TapHoldSettingsState {
+            supported: true,
+            ..Default::default()
+        };
         for qsid in [18, 19, 26, 27] {
             tap_hold.set_qsid_supported(qsid);
         }
@@ -850,8 +854,10 @@ mod tests {
 
     #[test]
     fn one_shot_rows_follow_advertised_qsids_independently() {
-        let mut one_shot = OneShotSettingsState::default();
-        one_shot.supported = true;
+        let mut one_shot = OneShotSettingsState {
+            supported: true,
+            ..Default::default()
+        };
         one_shot.set_qsid_supported(6);
 
         let rows = tap_hold_one_shot_rows(


### PR DESCRIPTION
### Problem

Five test fixtures initialized a default value and then immediately reassigned one or two fields, producing `clippy::field_reassign_with_default` warnings.

These warnings add noise to the existing Clippy baseline even though the fixtures are meant to exercise otherwise unchanged behavior.

### Fix

- The affected fixtures now set their non-default fields directly with Rust struct update syntax.
- Unspecified fields still use the same `Default` implementations, and fixtures that call setters remain mutable.
- The cleanup is limited to three test-only files that do not overlap current pull requests. Three same-rule warnings in `src/app_state.rs` remain deferred because open PR #83 changes that file.

### Verification

- `cargo test --locked rows -- --test-threads=1` - 11 passed
- `cargo test --locked rmk_macro_ext_guard_hides_layer_macro_choices_and_explains_why -- --test-threads=1` - 1 passed
- `cargo test --locked supported_qmk_live_features_are_described_with_a_static_preset -- --test-threads=1` - 1 passed
- `cargo test --locked -- --test-threads=1` - 437 passed
- `cargo --config build.incremental=false clippy --locked --all-targets --message-format=short` - passed with existing warnings; test-target warnings decreased from 79 to 74
- Scoped `rustfmt --edition 2021 --check` for the three changed Rust files
- `git diff --check origin/main...HEAD`
