### PR TITLE
Remove Clippy warnings from enum defaults

### DIFF
--- a/src/keycode_picker_model.rs
+++ b/src/keycode_picker_model.rs
@@ -9,9 +9,10 @@ pub enum BasicPickerLayout {
     Norman,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum PickerViewMode {
     Layout,
+    #[default]
     List,
 }
 
@@ -34,12 +35,6 @@ impl PickerViewMode {
             PickerViewMode::Layout => "key_picker.view_layout",
             PickerViewMode::List => "key_picker.view_list",
         }
-    }
-}
-
-impl Default for PickerViewMode {
-    fn default() -> Self {
-        Self::List
     }
 }
 

--- a/src/typing_trainer_words.rs
+++ b/src/typing_trainer_words.rs
@@ -1,6 +1,7 @@
-#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum TypingTrainerLanguage {
+    #[default]
     English,
     Russian,
 }
@@ -16,12 +17,6 @@ impl TypingTrainerLanguage {
             Self::English => "en",
             Self::Russian => "ru",
         }
-    }
-}
-
-impl Default for TypingTrainerLanguage {
-    fn default() -> Self {
-        Self::English
     }
 }
 
@@ -55,6 +50,10 @@ mod tests {
 
     #[test]
     fn typing_trainer_language_packs_are_large_enough() {
+        assert_eq!(
+            TypingTrainerLanguage::default(),
+            TypingTrainerLanguage::English
+        );
         for language in TYPING_TRAINER_LANGUAGES {
             assert!(word_count(language) >= 300);
         }


### PR DESCRIPTION
### Problem

`PickerViewMode` and `TypingTrainerLanguage` manually implemented `Default` even though each enum has one static default.

Clippy therefore reported two `clippy::derivable_impls` warnings, adding noise to the warning baseline without identifying a behavior defect.

### Fix

- Both enums now derive `Default` and explicitly mark their existing defaults: `List` and `English`.
- The redundant manual implementations are removed without changing variant order, serialization, or initial behavior.
- The typing-trainer test now asserts the English default; the existing key-picker test continues to assert the List default.

Related: #17

### Verification

- `cargo test --locked picker_view_mode_defaults_to_list_and_can_switch_to_layout -- --test-threads=1` - 1 passed
- `cargo test --locked typing_trainer_language_packs_are_large_enough -- --test-threads=1` - 1 passed
- `cargo test --locked -- --test-threads=1` - 437 passed
- Scoped `rustfmt --edition 2021 --check` for both changed Rust files
- `git diff --check`
- Clippy binary warnings decreased from 68 to 66; test-target warnings decreased from 79 to 77, with both targeted warnings removed