### PR TITLE
Remove Clippy warnings from lifecycle conditions

### DIFF
--- a/src/ui/app_lifecycle.rs
+++ b/src/ui/app_lifecycle.rs
@@ -1165,10 +1165,8 @@ impl eframe::App for EntropyApp {
         if let Some((layer, ki, kc)) = self.pending_handed_swap {
             if !ctx.input(|i| i.modifiers.ctrl) {
                 #[cfg(not(target_arch = "wasm32"))]
-                if !self.hid_write_task_active() {
-                    if self.assign_keycode(ctx, layer, ki, kc) {
-                        self.pending_handed_swap = None;
-                    }
+                if !self.hid_write_task_active() && self.assign_keycode(ctx, layer, ki, kc) {
+                    self.pending_handed_swap = None;
                 }
                 #[cfg(target_arch = "wasm32")]
                 {
@@ -1825,14 +1823,12 @@ impl eframe::App for EntropyApp {
             // Consume this attempt. Failed device entries remain different from the
             // synced snapshot and retry after the next edit or picker close.
             self.keycode_picker.tap_dance_dirty = false;
-            if td_save_ok {
-                if self.status_msg.is_empty() || self.status_msg.starts_with("✓") {
-                    self.status_msg = crate::i18n::tr_catalog(
-                        self.app_settings.language,
-                        "status_messages.tap_dance_saved",
-                    )
-                    .into();
-                }
+            if td_save_ok && (self.status_msg.is_empty() || self.status_msg.starts_with("✓")) {
+                self.status_msg = crate::i18n::tr_catalog(
+                    self.app_settings.language,
+                    "status_messages.tap_dance_saved",
+                )
+                .into();
             }
         }
 


### PR DESCRIPTION
### Problem

Two lifecycle branches used nested conditions even though the inner work depended directly on the outer guard.

Clippy therefore reported two `clippy::collapsible_if` warnings, adding noise to the warning baseline without identifying a behavior defect.

### Fix

- The handed-swap path now combines HID-task availability with the existing `assign_keycode` result.
- The Tap Dance save path now combines save success with the existing status-message eligibility check.
- Rust short-circuit evaluation preserves the original call order and state changes; the wasm-specific handed-swap path is unchanged.

Related: #17

### Verification

- `cargo test --locked app_lifecycle -- --test-threads=1` - 19 passed
- `cargo test --locked -- --test-threads=1` - 437 passed
- Binary Clippy warnings decreased from 68 to 66
- All-target Clippy warnings decreased from 79 to 77
- Scoped `rustfmt --edition 2021 --check src/ui/app_lifecycle.rs`
- `git diff --check`