### PR TITLE
Remove redundant Clippy syntax warnings

### DIFF
--- a/src/keycode_picker_basic.rs
+++ b/src/keycode_picker_basic.rs
@@ -322,7 +322,7 @@ impl KeycodePicker {
         ui: &mut egui::Ui,
         is_allowed: impl Fn(u16) -> bool,
     ) -> Option<u16> {
-        if qwerty_picker_grid_keys_for_values(|value| is_allowed(value)).is_empty() {
+        if qwerty_picker_grid_keys_for_values(&is_allowed).is_empty() {
             return None;
         }
 

--- a/src/ui/window_lifecycle.rs
+++ b/src/ui/window_lifecycle.rs
@@ -224,7 +224,6 @@ impl EntropyApp {
                 self.close_to_tray_prompt_open = true;
                 self.close_to_tray_prompt_remember = false;
                 ctx.request_repaint();
-                return;
             }
             CloseToTrayBehavior::Ask | CloseToTrayBehavior::Close | CloseToTrayBehavior::Tray => {
                 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
### Problem

Clippy reports two redundant syntax warnings in otherwise straightforward control flow: a closure that only forwards its argument to an existing predicate, and a terminal `return` at the end of a match arm. Keeping them adds avoidable noise to the warning baseline.

### Fix

- Pass the existing key-picker predicate directly by reference.
- Remove the redundant terminal `return` from the close-window match arm.
- Keep evaluation order and control flow unchanged; no new tests are needed for these syntax-only edits.

### Verification

- `cargo test --locked qwerty_ -- --test-threads=1` - 3 passed
- `cargo test --locked app_lifecycle -- --test-threads=1` - 19 passed
- `cargo test --locked -- --test-threads=1` - 437 passed
- Binary Clippy warnings: 68 → 66
- All-target Clippy warnings: 79 → 77
- Scoped `rustfmt --check`
- `git diff --check`

Related: #17
