### PR TITLE
Remove Clippy warnings from build and keymap checks

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,9 +13,10 @@ fn main() {
         return;
     }
 
-    if !Path::new(WINDOWS_ICON_PATH).is_file() {
-        panic!("Windows icon file is missing: {WINDOWS_ICON_PATH}");
-    }
+    assert!(
+        Path::new(WINDOWS_ICON_PATH).is_file(),
+        "Windows icon file is missing: {WINDOWS_ICON_PATH}"
+    );
 
     let mut res = winresource::WindowsResource::new();
     if env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("gnu") && env::var_os("WINDRES").is_none()

--- a/src/hid_keymap.rs
+++ b/src/hid_keymap.rs
@@ -174,7 +174,7 @@ impl HidDevice {
         local_offset: usize,
     ) -> Result<Vec<u16>> {
         let (layer_offset, layer_bytes) = keymap_layer_bounds(layer, layers, rows, cols)?;
-        if local_offset >= layer_bytes || local_offset % 2 != 0 {
+        if local_offset >= layer_bytes || !local_offset.is_multiple_of(2) {
             bail!(
                 "invalid keymap layer chunk offset: layer={layer}, local_offset={local_offset}, layer_bytes={layer_bytes}"
             );


### PR DESCRIPTION
### Problem

Clippy reports two direct expression warnings in independent validation paths: a build-script `if` branch that only panics when the Windows icon is missing, and a manual modulo check for VIA keymap byte-offset parity. Both obscure the underlying invariants without adding behavior.

### Fix

- Express the Windows icon precondition with `assert!`, preserving the Windows-only gate and panic message.
- Express the VIA keymap byte-alignment check with `usize::is_multiple_of(2)`, preserving bounds checks, short-circuit order, and request construction.

### Verification

- `cargo test --locked keymap_ -- --test-threads=1` — 1 passed
- `cargo test --locked -- --test-threads=1` — 437 passed
- Binary-target Clippy warnings: 68 → 67
- All-target Clippy warnings: 79 → 78
- Build-script Clippy warnings: 1 → 0
- Scoped `rustfmt --check`
- `git diff --check`

Related: #17
