### PR TITLE
Remove Clippy warnings from settings renderers

### DIFF
--- a/src/ui/app_settings.rs
+++ b/src/ui/app_settings.rs
@@ -35,15 +35,7 @@ impl EntropyApp {
                     ui.set_clip_rect(list.viewport);
                     ui.set_min_size(list.content_rect.size());
                     ui.spacing_mut().item_spacing.y = 0.0;
-                    self.draw_app_settings_editor_content(
-                        ui,
-                        list.first_visible_row..list.last_visible_row,
-                        list.row_content_width,
-                        list.row_height,
-                        metrics,
-                        dark,
-                        list.suppress_tooltips,
-                    );
+                    self.draw_app_settings_editor_content(ui, &list, metrics, dark);
                 });
 
                 if list.has_scrollbar {
@@ -102,15 +94,16 @@ impl EntropyApp {
     fn draw_app_settings_editor_content(
         &mut self,
         ui: &mut egui::Ui,
-        row_range: std::ops::Range<usize>,
-        content_width: f32,
-        row_height: f32,
+        list: &AdaptiveSettingsListViewport,
         metrics: crate::ui_style::ResponsiveMetrics,
         dark: bool,
-        suppress_tooltips: bool,
     ) {
         use crate::i18n::Key as TrKey;
 
+        let row_range = list.first_visible_row..list.last_visible_row;
+        let content_width = list.row_content_width;
+        let row_height = list.row_height;
+        let suppress_tooltips = list.suppress_tooltips;
         let lang = self.app_settings.language;
         let switch_width = metrics.value(46.0);
         let switch_size = metrics.size(46.0, 24.0);

--- a/src/ui/auto_shift_settings.rs
+++ b/src/ui/auto_shift_settings.rs
@@ -97,15 +97,7 @@ impl EntropyApp {
             ui.set_min_size(list.content_rect.size());
             ui.spacing_mut().item_spacing.y = 0.0;
             for row_idx in list.first_visible_row..list.last_visible_row {
-                self.draw_auto_shift_row(
-                    ui,
-                    row_idx,
-                    list.row_content_width,
-                    list.row_height,
-                    field_width,
-                    dark,
-                    list.suppress_tooltips,
-                );
+                self.draw_auto_shift_row(ui, row_idx, &list, field_width, dark);
             }
         });
 
@@ -124,12 +116,13 @@ impl EntropyApp {
         &mut self,
         ui: &mut egui::Ui,
         row_idx: usize,
-        content_width: f32,
-        row_height: f32,
+        list: &AdaptiveSettingsListViewport,
         field_width: f32,
         _dark: bool,
-        suppress_tooltips: bool,
     ) {
+        let content_width = list.row_content_width;
+        let row_height = list.row_height;
+        let suppress_tooltips = list.suppress_tooltips;
         let row = match row_idx {
             0 => (
                 crate::i18n::tr_catalog(self.app_settings.language, "common.enable"),


### PR DESCRIPTION
### Problem

The App Settings and Auto Shift render helpers accepted viewport geometry and tooltip state as separate arguments even though each call site had already calculated one `AdaptiveSettingsListViewport`.

Clippy therefore reported two `clippy::too_many_arguments` warnings, adding noise to the warning baseline without identifying a behavior defect.

### Fix

- Pass the existing adaptive viewport to each render helper by shared reference.
- Read the same visible row range, content width, row height, and tooltip-suppression state from that viewport inside the helper.
- Keep clipping, row iteration, scrollbar handling, and tooltip behavior unchanged.

### Verification

- `cargo test --locked app_settings -- --test-threads=1` - 5 passed
- `cargo test --locked -- --test-threads=1` - 437 passed
- Binary Clippy warnings decreased from 68 to 66
- All-target Clippy warnings decreased from 79 to 77
- Scoped `rustfmt --edition 2021 --check` for both changed Rust files
- `git diff --check`

Related: #17