### PR TITLE
Simplify layout geometry helpers

### DIFF
--- a/src/ui/layout_chrome.rs
+++ b/src/ui/layout_chrome.rs
@@ -6,12 +6,15 @@ impl EntropyApp {
         ui: &mut egui::Ui,
         layout: &KeyboardLayout,
         ctx: &egui::Context,
-        top_base_y: f32,
-        main_tabs_h: f32,
-        layer_bar_h: f32,
-        top_reserved_h: f32,
-        viewport: egui::Rect,
+        geometry: LayoutChromeGeometry,
     ) -> bool {
+        let LayoutChromeGeometry {
+            top_base_y,
+            main_tabs_h,
+            layer_bar_h,
+            top_reserved_h,
+            viewport,
+        } = geometry;
         let typing_trainer_page = self.main_menu_tab == MainMenuTab::Advanced
             && self.settings_tab == SettingsTab::TypingTrainer;
         if typing_trainer_page {

--- a/src/ui/layout_shared.rs
+++ b/src/ui/layout_shared.rs
@@ -10,6 +10,15 @@ pub(crate) struct LayoutGeometry {
     pub(crate) layout_h: f32,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) struct LayoutChromeGeometry {
+    pub(crate) top_base_y: f32,
+    pub(crate) main_tabs_h: f32,
+    pub(crate) layer_bar_h: f32,
+    pub(crate) top_reserved_h: f32,
+    pub(crate) viewport: egui::Rect,
+}
+
 pub(crate) fn responsive_layout_max_scale(ctx: &egui::Context, viewport: egui::Rect) -> f32 {
     let native_scale = ctx
         .native_pixels_per_point()
@@ -143,22 +152,6 @@ pub(crate) fn layout_geometry_with_reserved_and_filter(
         padding: LAYOUT_KEY_PADDING,
         layout_h,
     }
-}
-
-pub(crate) fn layout_keycap_rect(
-    offset_x: f32,
-    offset_y: f32,
-    unit: f32,
-    padding: f32,
-    x: f32,
-    y: f32,
-    w: f32,
-    h: f32,
-) -> egui::Rect {
-    egui::Rect::from_min_size(
-        egui::pos2(offset_x + x * unit + padding, offset_y + y * unit + padding),
-        Vec2::new(w * unit - padding * 2.0, h * unit - padding * 2.0),
-    )
 }
 
 pub(crate) fn rotate_layout_point(

--- a/src/ui/layout_view.rs
+++ b/src/ui/layout_view.rs
@@ -94,11 +94,13 @@ impl EntropyApp {
             ui,
             layout,
             ctx,
-            top_base_y,
-            main_tabs_h,
-            layer_bar_h,
-            top_reserved_h,
-            viewport,
+            LayoutChromeGeometry {
+                top_base_y,
+                main_tabs_h,
+                layer_bar_h,
+                top_reserved_h,
+                viewport,
+            },
         ) {
             return;
         }


### PR DESCRIPTION
### Problem

Layout chrome rendering passed five same-typed geometry values as separate arguments, producing a `clippy::too_many_arguments` warning and leaving room for accidental value swaps. An unused keycap rectangle helper also produced both dead-code and argument-count warnings.

### Fix

- Grouped the chrome geometry values in `LayoutChromeGeometry` and destructured them inside the renderer without changing any values or control flow.
- Removed the unused `layout_keycap_rect` helper after confirming it had no callers.

### Verification

- `rustfmt --edition 2021 src/ui/layout_chrome.rs src/ui/layout_shared.rs src/ui/layout_view.rs`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features --message-format short`: binary warnings `68 -> 65`; test warnings `79 -> 76`
- `cargo test --all-features -- --test-threads=1`: 437 passed
- The default parallel test run exposed two existing Vial background-task timing flakes; both passed independently and in the full single-threaded suite.