### PR TITLE
Harden optional HID disconnect handling

### DIFF
--- a/src/hid.rs
+++ b/src/hid.rs
@@ -208,6 +208,7 @@ impl TestHidRecorder {
 #[derive(Clone, Copy)]
 pub(crate) enum TestHidFault {
     Disconnect,
+    Timeout,
     WorkerPanic,
 }
 
@@ -397,19 +398,33 @@ impl Drop for HidProxy {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub fn is_disconnect_error_message(message: &str) -> bool {
+pub fn is_transport_disconnect_error_message(message: &str) -> bool {
     let message = message.to_ascii_lowercase();
     message.contains("disconnected")
-        || message.contains("device did not respond")
-        || message.contains("hid helper timed out")
-        || message.contains("failed to write hid helper request")
-        || message.contains("failed to flush hid helper request")
-        || message.contains("hid write failed")
-        || message.contains("hid read failed")
         || message.contains("broken pipe")
         || message.contains("pipe is being closed")
         || message.contains("the device is not connected")
         || message.contains("org.bluez.error.notconnected")
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn is_transport_disconnect_error(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .any(|cause| is_transport_disconnect_error_message(&cause.to_string()))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn is_disconnect_error_message(message: &str) -> bool {
+    is_transport_disconnect_error_message(message) || {
+        let message = message.to_ascii_lowercase();
+        message.contains("device did not respond")
+            || message.contains("hid helper timed out")
+            || message.contains("failed to write hid helper request")
+            || message.contains("failed to flush hid helper request")
+            || message.contains("hid write failed")
+            || message.contains("hid read failed")
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -809,6 +824,7 @@ impl HidDevice {
                 if let Some((_, fault)) = fault {
                     match fault {
                         TestHidFault::Disconnect => bail!("HID device disconnected"),
+                        TestHidFault::Timeout => bail!("HID timeout — device did not respond"),
                         TestHidFault::WorkerPanic => panic!("test HID worker stopped"),
                     }
                 }

--- a/src/ui/device_connect_task.rs
+++ b/src/ui/device_connect_task.rs
@@ -338,6 +338,33 @@ fn has_firmware_layer_names(names: &[String]) -> bool {
         .any(|(index, name)| !is_default_layer_name(index, name))
 }
 
+fn rmk_native_capabilities(
+    dev_conn: &crate::hid::HidDevice,
+) -> anyhow::Result<crate::rmk_native::RmkNativeCapabilities> {
+    match dev_conn.get_rmk_native_capabilities() {
+        Ok(capabilities) => Ok(capabilities),
+        Err(error) if crate::hid::is_transport_disconnect_error(&error) => Err(error),
+        Err(error) => {
+            log::debug!("RMK native capabilities unavailable: {error:#}");
+            Ok(crate::rmk_native::RmkNativeCapabilities::default())
+        }
+    }
+}
+
+fn firmware_layer_name(
+    dev_conn: &crate::hid::HidDevice,
+    qsid: u16,
+) -> anyhow::Result<Option<String>> {
+    match dev_conn.get_qmk_setting_string(qsid) {
+        Ok(name) => Ok(Some(name)),
+        Err(error) if crate::hid::is_transport_disconnect_error(&error) => Err(error),
+        Err(error) => {
+            log::warn!("get_qmk_setting_string(layer name qsid {qsid}): {error}");
+            Ok(None)
+        }
+    }
+}
+
 fn layer_name_sync_updates(
     names: &[String],
     current_names: &[Option<String>],
@@ -918,12 +945,10 @@ impl EntropyApp {
                     }
                 }
 
-                let rmk_native_capabilities = dev_conn
-                    .get_rmk_native_capabilities()
-                    .unwrap_or_else(|error| {
-                        log::debug!("RMK native key-action capability unavailable: {error:#}");
-                        crate::rmk_native::RmkNativeCapabilities::default()
-                    });
+                let rmk_native_capabilities =
+                    rmk_native_capabilities(&dev_conn).map_err(|error| {
+                        format!("RMK native key-action capability read failed: {error:#}")
+                    })?;
                 let supports_rmk_native_key_actions = rmk_native_capabilities.key_actions;
                 let supports_universal_symbols = rmk_native_capabilities.universal_symbols;
                 let supports_universal_russian_letters = rmk_native_capabilities.russian_letters;
@@ -961,16 +986,15 @@ impl EntropyApp {
                         if !has_qmk_setting(qsid) {
                             continue;
                         }
-                        match dev_conn.get_qmk_setting_string(qsid) {
-                            Ok(name) => {
-                                *current_firmware_name = Some(name.clone());
-                                if !name.is_empty() {
-                                    layout.layer_names[layer] = name;
-                                    layer_names_from_firmware[layer] = true;
-                                }
-                            }
-                            Err(e) => {
-                                log::warn!("get_qmk_setting_string(layer name qsid {qsid}): {e}")
+                        if let Some(name) =
+                            firmware_layer_name(&dev_conn, qsid).map_err(|error| {
+                                format!("Layer name read failed for qsid {qsid}: {error:#}")
+                            })?
+                        {
+                            *current_firmware_name = Some(name.clone());
+                            if !name.is_empty() {
+                                layout.layer_names[layer] = name;
+                                layer_names_from_firmware[layer] = true;
                             }
                         }
                     }
@@ -1398,6 +1422,65 @@ mod tests {
     fn reported_layer_count_is_never_zero() {
         assert_eq!(normalize_reported_layer_count(0), 1);
         assert_eq!(normalize_reported_layer_count(4), 4);
+    }
+
+    #[test]
+    fn disconnect_after_initial_keymap_read_fails_rmk_capability_probe() {
+        let (device, _) = crate::hid::HidDevice::test_device_with_fault_after_requests(Some((
+            1,
+            crate::hid::TestHidFault::Disconnect,
+        )));
+
+        device.get_keymap_buffer(1, 1, 1).unwrap();
+        let error = rmk_native_capabilities(&device).unwrap_err();
+
+        assert!(
+            crate::hid::is_transport_disconnect_error(&error),
+            "{error:#}"
+        );
+    }
+
+    #[test]
+    fn disconnect_after_initial_keymap_read_fails_layer_name_probe() {
+        let (device, _) = crate::hid::HidDevice::test_device_with_fault_after_requests(Some((
+            1,
+            crate::hid::TestHidFault::Disconnect,
+        )));
+
+        device.get_keymap_buffer(1, 1, 1).unwrap();
+        let error = firmware_layer_name(&device, 200).unwrap_err();
+
+        assert!(
+            crate::hid::is_transport_disconnect_error(&error),
+            "{error:#}"
+        );
+    }
+
+    #[test]
+    fn timeout_after_initial_keymap_read_keeps_rmk_capability_probe_optional() {
+        let (device, _) = crate::hid::HidDevice::test_device_with_fault_after_requests(Some((
+            1,
+            crate::hid::TestHidFault::Timeout,
+        )));
+
+        device.get_keymap_buffer(1, 1, 1).unwrap();
+
+        assert_eq!(
+            rmk_native_capabilities(&device).unwrap(),
+            crate::rmk_native::RmkNativeCapabilities::default()
+        );
+    }
+
+    #[test]
+    fn timeout_after_initial_keymap_read_keeps_layer_name_probe_optional() {
+        let (device, _) = crate::hid::HidDevice::test_device_with_fault_after_requests(Some((
+            1,
+            crate::hid::TestHidFault::Timeout,
+        )));
+
+        device.get_keymap_buffer(1, 1, 1).unwrap();
+
+        assert_eq!(firmware_layer_name(&device, 200).unwrap(), None);
     }
 
     #[test]


### PR DESCRIPTION
### Problem

After the initial keymap read, RMK capability and firmware layer-name reads are optional only while the HID transport remains connected. A confirmed transport loss must end connection setup, while timeouts and unsupported optional requests should keep their existing fallback behavior.

### Fix

- Separate explicit transport-loss signals from the broader reconnect classifier without changing reconnect behavior.
- Propagate only transport disconnects from optional RMK capability and firmware layer-name reads.
- Cover disconnect and timeout paths after the initial keymap request.

### Verification

- Test-first timeout regressions failed with the broad classifier and passed with the transport-only predicate.
- `cargo test --locked -- --test-threads=1` - 460 passed.
- `cargo check --locked` - passed with no errors.
- Scoped `rustfmt --check` and `git diff --check` passed.