### PR TITLE
chore: remove unused app storage helpers

### DIFF
--- a/src/app_storage.rs
+++ b/src/app_storage.rs
@@ -513,13 +513,6 @@ pub(super) fn save_combo_colors(colors: &[u32], device_name: &str) {
     }
 }
 
-pub(super) fn combo_display_name(combo_names: &[String], idx: usize) -> String {
-    match combo_names.get(idx) {
-        Some(name) if !name.trim().is_empty() => name.clone(),
-        _ => format!("C{}", idx),
-    }
-}
-
 pub(super) fn key_override_names_path(device_name: &str) -> std::path::PathBuf {
     let dir = dirs::config_dir()
         .unwrap_or_else(|| std::path::PathBuf::from("."))
@@ -547,13 +540,6 @@ pub(super) fn save_key_override_names(names: &[String], device_name: &str) {
         } else {
             log::info!("save_key_override_names ok → {:?}", path);
         }
-    }
-}
-
-pub(super) fn key_override_display_name(key_override_names: &[String], idx: usize) -> String {
-    match key_override_names.get(idx) {
-        Some(name) if !name.trim().is_empty() => name.clone(),
-        _ => format!("KO{}", idx),
     }
 }
 


### PR DESCRIPTION
### Problem

Two unused app-storage display-name helpers produce dead_code warnings in each compiled target.
### Fix

Remove the unreachable combo and key-override display-name helpers. No persisted data, UI text, or runtime behavior changes.

### Verification

- cargo clippy --locked --all-targets completed successfully; the targeted app_storage dead_code diagnostics are zero.
- cargo test --locked -- --test-threads=1 passed (456 tests).
- Scoped rustfmt --check src/app_storage.rs and git diff --check passed.