### PR TITLE
chore: remove unused device helpers

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -174,6 +174,12 @@ impl DeviceManager {
         devices
     }
 
+    #[cfg(all(not(target_os = "macos"), not(target_arch = "wasm32")))]
+    pub fn scan(&mut self) {
+        self.devices = Self::scan_devices();
+        log::info!("Found {} Vial device(s)", self.devices.len());
+    }
+
     pub fn replace_devices(&mut self, devices: Vec<Device>) {
         self.devices = devices;
         log::info!("Found {} Vial device(s)", self.devices.len());

--- a/src/device.rs
+++ b/src/device.rs
@@ -174,15 +174,6 @@ impl DeviceManager {
         devices
     }
 
-    pub fn scan(&mut self) {
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            self.devices = Self::scan_devices();
-        }
-
-        log::info!("Found {} Vial device(s)", self.devices.len());
-    }
-
     pub fn replace_devices(&mut self, devices: Vec<Device>) {
         self.devices = devices;
         log::info!("Found {} Vial device(s)", self.devices.len());

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -445,10 +445,6 @@ impl KeyboardLayout {
             .unwrap_or(0)
     }
 
-    pub fn set_keycode(&mut self, layer: usize, key_idx: usize, keycode: u16) {
-        self.set_key_binding(layer, key_idx, KeyBinding::Vial(keycode));
-    }
-
     pub fn set_key_binding(&mut self, layer: usize, key_idx: usize, binding: KeyBinding) {
         while self.layers.len() <= layer {
             self.layers

--- a/src/qmk_hid_host.rs
+++ b/src/qmk_hid_host.rs
@@ -690,10 +690,6 @@ fn current_media_info() -> Option<(String, String)> {
 }
 
 #[cfg(not(target_os = "windows"))]
-fn command_stdout(program: &str, args: &[&str]) -> Option<String> {
-    command_stdout_timeout(program, args, Duration::from_secs(10))
-}
-
 #[cfg(target_os = "macos")]
 fn macos_automation_stdout(args: &[&str]) -> Option<String> {
     command_stdout_timeout("osascript", args, MACOS_AUTOMATION_COMMAND_TIMEOUT)

--- a/src/qmk_hid_host.rs
+++ b/src/qmk_hid_host.rs
@@ -696,6 +696,12 @@ fn macos_automation_stdout(args: &[&str]) -> Option<String> {
 }
 
 #[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "linux")]
+fn command_stdout(program: &str, args: &[&str]) -> Option<String> {
+    command_stdout_timeout(program, args, Duration::from_secs(10))
+}
+
+#[cfg(not(target_os = "windows"))]
 fn command_stdout_timeout(program: &str, args: &[&str], timeout: Duration) -> Option<String> {
     use std::io::Read;
 

--- a/src/ui/device_connect_apply.rs
+++ b/src/ui/device_connect_apply.rs
@@ -696,11 +696,6 @@ impl EntropyApp {
         }
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
-    fn sync_layer_names_to_firmware(&self) {
-        let _ = self.write_layer_names_to_firmware(&self.layer_names);
-    }
-
     /// Write `names` to firmware (qsid 200 + layer), one layer at a time so a
     /// single failing SET does not abort the rest. Skips names that already
     /// match. Returns the indices of layers whose write did not land, so callers

--- a/src/ui/key_assignment.rs
+++ b/src/ui/key_assignment.rs
@@ -388,14 +388,6 @@ impl EntropyApp {
         }
     }
 
-    /// Reload all keycodes from device in background.
-    #[cfg(not(target_arch = "wasm32"))]
-    pub(super) fn load_from_device(&mut self) {
-        if let Some(idx) = self.selected_device {
-            self.start_connect(idx);
-        }
-    }
-
     #[cfg(not(target_arch = "wasm32"))]
     pub(super) fn undo(&mut self, ctx: &egui::Context) {
         if self.vial_hid_background_layer_active() {


### PR DESCRIPTION
### Problem

**EN:** Three unreachable helpers plus two helpers unused only on macOS produce ten dead_code warning occurrences across the two compiled app targets.

**RU:** Три недостижимых вспомогательных метода и два метода, неиспользуемых только на macOS, создают десять предупреждений dead_code в двух собранных целях приложения.

### Fix

**EN:** Remove the three unreachable helpers. Keep DeviceManager::scan on Linux and Windows, and the QMK command helper on Linux, where those builds require them; exclude both from macOS where they have no callers.

**RU:** Удалены три недостижимых вспомогательных метода. DeviceManager::scan сохранен для Linux и Windows, а вспомогательный QMK command — для Linux, где они нужны сборкам; оба исключены из macOS, где у них нет вызовов.

### Verification

- cargo clippy --locked --all-targets completed successfully; the targeted macOS dead_code diagnostics are zero.
- cargo test --locked -- --test-threads=1 passed (456 tests).
- Scoped rustfmt --check and git diff --check passed.
- Linux, Windows, and macOS CI are rerunning after the platform-specific correction.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)