### PR TITLE
chore: clear UI Clippy warnings

### DIFF
--- a/src/app_icon.rs
+++ b/src/app_icon.rs
@@ -55,14 +55,12 @@ fn draw_capsule(
     pixel: &mut [f32; 4],
     x: f32,
     y: f32,
-    ax: f32,
-    ay: f32,
-    bx: f32,
-    by: f32,
+    start: (f32, f32),
+    end: (f32, f32),
     radius: f32,
     color: [f32; 4],
 ) {
-    let distance = sd_capsule(x, y, ax, ay, bx, by, radius);
+    let distance = sd_capsule(x, y, start.0, start.1, end.0, end.1, radius);
     let alpha = smooth_alpha(distance, 0.020) * color[3];
     if alpha > 0.0 {
         blend(pixel, [color[0], color[1], color[2], alpha]);
@@ -108,17 +106,15 @@ fn draw_letter_e(pixel: &mut [f32; 4], x: f32, y: f32) {
             pixel,
             x,
             y,
-            ax + 0.030,
-            ay + 0.030,
-            bx + 0.030,
-            by + 0.030,
+            (ax + 0.030, ay + 0.030),
+            (bx + 0.030, by + 0.030),
             radius,
             shadow,
         );
     }
 
     for (ax, ay, bx, by, radius) in strokes {
-        draw_capsule(pixel, x, y, ax, ay, bx, by, radius, cream);
+        draw_capsule(pixel, x, y, (ax, ay), (bx, by), radius, cream);
     }
 }
 

--- a/src/keycode_picker.rs
+++ b/src/keycode_picker.rs
@@ -4,7 +4,7 @@ use crate::keycode::{
     gui_label, gui_mod_name, key_label_font_sizes, keycode_label_with_names_and_layout,
     keycode_tooltip, modifier_label_from_bits, KeyLegendLayout, KeycodeCategory, KEYCODES,
 };
-use crate::popup_state::{PopupKey, PopupState};
+use crate::popup_state::{PopupState, PopupWindow};
 use egui::{Color32, Key, RichText, Vec2};
 
 #[path = "keycode_picker_keyboard.rs"]
@@ -253,9 +253,11 @@ mod tests {
     #[test]
     fn pending_modifier_picker_renders_layout_and_list_tabs() {
         let ctx = egui::Context::default();
-        let mut picker = KeycodePicker::default();
-        picker.open = true;
-        picker.vial_quantum_pending_mod = Some(0x0100);
+        let mut picker = KeycodePicker {
+            open: true,
+            vial_quantum_pending_mod: Some(0x0100),
+            ..Default::default()
+        };
 
         let mut render = || {
             let mut input = egui::RawInput::default();
@@ -885,18 +887,17 @@ impl KeycodePicker {
             self.vial_quantum_pending_mod.is_some() || self.vial_quantum_pending_mt.is_some();
         let td_key_pick_open = self.td_key_pick.is_some() || self.td_mod_key_pick.is_some();
 
+        self.popup_state.begin_frame(PopupWindow::Picker, self.open);
         self.popup_state
-            .begin_frame(PopupKey::PickerWindow, self.open);
+            .begin_frame(PopupWindow::MacroKeyPick, macro_key_pick_open);
         self.popup_state
-            .begin_frame(PopupKey::MacroKeyPickWindow, macro_key_pick_open);
+            .begin_frame(PopupWindow::RegularKeyPick, regular_key_pick_open);
         self.popup_state
-            .begin_frame(PopupKey::RegularKeyPickWindow, regular_key_pick_open);
+            .begin_frame(PopupWindow::PickLayer, layer_pick_open);
         self.popup_state
-            .begin_frame(PopupKey::PickLayerWindow, layer_pick_open);
+            .begin_frame(PopupWindow::PendingKeyPick, pending_key_pick_open);
         self.popup_state
-            .begin_frame(PopupKey::PendingKeyPickWindow, pending_key_pick_open);
-        self.popup_state
-            .begin_frame(PopupKey::TdKeyPickWindow, td_key_pick_open);
+            .begin_frame(PopupWindow::TdKeyPick, td_key_pick_open);
 
         if !self.open {
             return;
@@ -923,7 +924,7 @@ impl KeycodePicker {
             crate::ui_style::centered_modal_window(
                 ctx,
                 tr_picker(self.language, "key_picker.pick_key_title"),
-                self.popup_state.id(PopupKey::MacroKeyPickWindow),
+                self.popup_state.id(PopupWindow::MacroKeyPick),
                 &mut pick_open,
                 popup_size,
             )
@@ -1127,7 +1128,7 @@ impl KeycodePicker {
         crate::ui_style::centered_modal_window(
             ctx,
             tr_picker(self.language, "key_picker.title"),
-            self.popup_state.id(PopupKey::PickerWindow),
+            self.popup_state.id(PopupWindow::Picker),
             &mut still_open,
             picker_size,
         )
@@ -1288,7 +1289,7 @@ impl KeycodePicker {
         crate::ui_style::centered_modal_window(
             ctx,
             window_title.as_str(),
-            self.popup_state.id(PopupKey::RegularKeyPickWindow),
+            self.popup_state.id(PopupWindow::RegularKeyPick),
             &mut still_open,
             popup_size,
         )
@@ -1474,7 +1475,7 @@ impl KeycodePicker {
             let _resp_win = crate::ui_style::centered_modal_window(
                 ctx,
                 tr_picker(self.language, "key_picker.pick_layer_title"),
-                self.popup_state.id(PopupKey::PickLayerWindow),
+                self.popup_state.id(PopupWindow::PickLayer),
                 &mut still_open,
                 Vec2::new(300.0, 120.0),
             )
@@ -1578,7 +1579,7 @@ impl KeycodePicker {
             let _resp_win = crate::ui_style::centered_modal_window(
                 ctx,
                 title,
-                self.popup_state.id(PopupKey::PendingKeyPickWindow),
+                self.popup_state.id(PopupWindow::PendingKeyPick),
                 &mut still_open,
                 popup_size,
             )

--- a/src/keycode_picker_basic.rs
+++ b/src/keycode_picker_basic.rs
@@ -9,6 +9,20 @@ struct QwertyPickerGridKey {
     value: u16,
 }
 
+#[derive(Clone, Copy)]
+struct QwertyPickerGridMetrics {
+    cell_w: f32,
+    cell_h: f32,
+    gap: f32,
+}
+
+#[derive(Clone, Copy)]
+struct QwertyPickerGridPosition {
+    row: usize,
+    col: usize,
+    span: usize,
+}
+
 const fn qwerty_picker_grid_key(
     row: usize,
     col: usize,
@@ -168,24 +182,22 @@ impl KeycodePicker {
         &mut self,
         ui: &mut egui::Ui,
         origin: egui::Pos2,
-        cell_w: f32,
-        cell_h: f32,
-        gap: f32,
-        row: usize,
-        col: usize,
-        span: usize,
+        metrics: QwertyPickerGridMetrics,
+        position: QwertyPickerGridPosition,
         label: &str,
         value: u16,
     ) {
-        let x = origin.x + col as f32 * (cell_w + gap);
-        let right_nav_extra_gap = if col >= 16 && matches!(row, 1 | 2) {
+        let x = origin.x + position.col as f32 * (metrics.cell_w + metrics.gap);
+        let right_nav_extra_gap = if position.col >= 16 && matches!(position.row, 1 | 2) {
             14.0
         } else {
             0.0
         };
-        let y = origin.y + row as f32 * (cell_h + gap) + right_nav_extra_gap;
-        let width = span as f32 * cell_w + span.saturating_sub(1) as f32 * gap;
-        let rect = egui::Rect::from_min_size(egui::pos2(x, y), Vec2::new(width, cell_h));
+        let y =
+            origin.y + position.row as f32 * (metrics.cell_h + metrics.gap) + right_nav_extra_gap;
+        let width = position.span as f32 * metrics.cell_w
+            + position.span.saturating_sub(1) as f32 * metrics.gap;
+        let rect = egui::Rect::from_min_size(egui::pos2(x, y), Vec2::new(width, metrics.cell_h));
         let resp = picker_keycap_button_in_rect(ui, rect, label, true, false);
         if resp.clicked() {
             self.assign_keycode_value(value);
@@ -305,12 +317,16 @@ impl KeycodePicker {
             self.basic_key_button_at(
                 ui,
                 origin,
-                cell_w,
-                cell_h,
-                gap,
-                key.row,
-                key.col,
-                key.span,
+                QwertyPickerGridMetrics {
+                    cell_w,
+                    cell_h,
+                    gap,
+                },
+                QwertyPickerGridPosition {
+                    row: key.row,
+                    col: key.col,
+                    span: key.span,
+                },
                 &display_label,
                 assigned_value,
             );

--- a/src/keycode_picker_model.rs
+++ b/src/keycode_picker_model.rs
@@ -298,10 +298,7 @@ fn is_symbol(value: u16) -> bool {
 }
 
 fn is_modifier_or_layer_action(value: u16) -> bool {
-    matches!(
-        value,
-        0x0100..=0x3FFF | 0x4000..=0x4FFF | 0x5000..=0x52FF
-    )
+    matches!(value, 0x0100..=0x52FF)
 }
 
 #[cfg(test)]

--- a/src/keycode_picker_tap_dance_picker.rs
+++ b/src/keycode_picker_tap_dance_picker.rs
@@ -91,7 +91,7 @@ impl KeycodePicker {
         crate::ui_style::centered_modal_window(
             ctx,
             window_title.as_str(),
-            self.popup_state.id(PopupKey::TdKeyPickWindow),
+            self.popup_state.id(PopupWindow::TdKeyPick),
             &mut still_open,
             popup_size,
         )

--- a/src/popup_state.rs
+++ b/src/popup_state.rs
@@ -1,33 +1,33 @@
 use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum PopupKey {
-    PickerWindow,
-    MacroKeyPickWindow,
-    RegularKeyPickWindow,
-    PickLayerWindow,
-    PendingKeyPickWindow,
-    TdKeyPickWindow,
+pub enum PopupWindow {
+    Picker,
+    MacroKeyPick,
+    RegularKeyPick,
+    PickLayer,
+    PendingKeyPick,
+    TdKeyPick,
 }
 
 #[derive(Debug, Default, Clone)]
 pub struct PopupState {
-    epochs: HashMap<PopupKey, u64>,
-    open: HashSet<PopupKey>,
+    epochs: HashMap<PopupWindow, u64>,
+    open: HashSet<PopupWindow>,
 }
 
 impl PopupState {
-    pub fn on_open(&mut self, key: PopupKey) {
+    pub fn on_open(&mut self, key: PopupWindow) {
         if self.open.insert(key) {
             *self.epochs.entry(key).or_insert(0) += 1;
         }
     }
 
-    pub fn on_close(&mut self, key: PopupKey) {
+    pub fn on_close(&mut self, key: PopupWindow) {
         self.open.remove(&key);
     }
 
-    pub fn begin_frame(&mut self, key: PopupKey, is_open: bool) {
+    pub fn begin_frame(&mut self, key: PopupWindow, is_open: bool) {
         if is_open {
             self.on_open(key);
         } else {
@@ -35,7 +35,7 @@ impl PopupState {
         }
     }
 
-    pub fn id(&self, key: PopupKey) -> egui::Id {
+    pub fn id(&self, key: PopupWindow) -> egui::Id {
         egui::Id::new(("popup", key, self.epochs.get(&key).copied().unwrap_or(0)))
     }
 }

--- a/src/ui/bluetooth_settings.rs
+++ b/src/ui/bluetooth_settings.rs
@@ -494,11 +494,13 @@ mod tests {
         assert!(app.hid_device.is_none());
         assert!(app.vial_hid_task_active());
 
-        let mut input = egui::RawInput::default();
-        input.screen_rect = Some(egui::Rect::from_min_size(
-            egui::Pos2::ZERO,
-            egui::vec2(900.0, 700.0),
-        ));
+        let input = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::vec2(900.0, 700.0),
+            )),
+            ..Default::default()
+        };
         let output = ctx.run_ui(input, |ui| {
             app.draw_bluetooth_settings_page(ui, ui.max_rect());
         });

--- a/src/ui/settings_shell.rs
+++ b/src/ui/settings_shell.rs
@@ -230,11 +230,6 @@ impl EntropyApp {
         self.main_menu_tab = MainMenuTab::Settings;
     }
 
-    pub(super) fn open_grave_escape_settings_page(&mut self) {
-        self.settings_tab = SettingsTab::GraveEscape;
-        self.main_menu_tab = MainMenuTab::Settings;
-    }
-
     pub(super) fn can_return_from_settings_page(
         &self,
         ctx: &egui::Context,

--- a/src/ui_style.rs
+++ b/src/ui_style.rs
@@ -450,7 +450,6 @@ pub fn modern_button_with_font(
     resp
 }
 
-#[allow(clippy::too_many_arguments)]
 pub fn modern_text_field_sized(
     ui: &mut Ui,
     id: egui::Id,
@@ -476,7 +475,6 @@ pub fn modern_text_field_sized(
     )
 }
 
-#[allow(clippy::too_many_arguments)]
 pub fn modern_text_field_interactive(
     ui: &mut Ui,
     id: egui::Id,
@@ -501,7 +499,6 @@ pub fn modern_text_field_interactive(
     )
 }
 
-#[allow(clippy::too_many_arguments)]
 fn modern_text_field_impl(
     ui: &mut Ui,
     id: egui::Id,
@@ -986,7 +983,6 @@ pub fn settings_list_row(
     );
 }
 
-#[allow(clippy::too_many_arguments)]
 pub fn settings_list_row_with_tooltip(
     ui: &mut Ui,
     content_width: f32,

--- a/src/ui_style.rs
+++ b/src/ui_style.rs
@@ -450,6 +450,7 @@ pub fn modern_button_with_font(
     resp
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn modern_text_field_sized(
     ui: &mut Ui,
     id: egui::Id,
@@ -475,6 +476,7 @@ pub fn modern_text_field_sized(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn modern_text_field_interactive(
     ui: &mut Ui,
     id: egui::Id,
@@ -499,6 +501,7 @@ pub fn modern_text_field_interactive(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn modern_text_field_impl(
     ui: &mut Ui,
     id: egui::Id,
@@ -983,6 +986,7 @@ pub fn settings_list_row(
     );
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn settings_list_row_with_tooltip(
     ui: &mut Ui,
     content_width: f32,


### PR DESCRIPTION
### Problem

This PR initially added four new `#[allow(clippy::too_many_arguments)]` attributes for established UI helper APIs. Those attributes hid diagnostics rather than resolving them, while a sound parameter-object refactor would affect many existing call sites.

### Fix

- Keep the seven substantive UI and test Clippy fixes in this focused slice.
- Remove the four new allowances; defer the UI API refactor to a separate, reviewable PR.

### Verification / Проверка

- `cargo clippy --locked --all-targets` completes successfully, reporting 62 existing non-blocking warnings, including the four deferred UI-signature diagnostics.
- `cargo test --locked -- --test-threads=1` passed (456 tests) before this documentation-only scope correction; removing lint attributes does not change runtime behavior.
- Scoped `rustfmt --check src/ui_style.rs` and `git diff --check` pass.