### PR TITLE
Add GUI chords to Mod-Tap

### DIFF
--- a/src/keycode.rs
+++ b/src/keycode.rs
@@ -92,7 +92,7 @@ fn osm_mod_short_name(bits: u16) -> String {
     }
 }
 
-fn osm_mod_full_name(bits: u16) -> String {
+fn modifier_full_name_from_bits(bits: u16) -> String {
     let right = bits & 0x10 != 0;
     let side = if right { "Right" } else { "Left" };
     let gui = gui_mod_name();
@@ -965,13 +965,9 @@ pub fn keycode_tooltip(value: u16, custom: &[CustomKeycode], layer_names: &[Stri
             0x03 => "Ctrl+Shift".into(),
             0x05 => "Ctrl+Alt".into(),
             0x06 => "Shift+Alt".into(),
-            0x09 => format!("Ctrl+{}", gui_mod_name()),
-            0x0A => format!("Shift+{}", gui_mod_name()),
             _ => "modifier".into(),
         }
     };
-    let side = |v: u16| if v & 0x10 != 0 { "Right " } else { "Left " };
-
     // ── KC_NO / KC_TRNS ──────────────────────────────────────────────────────
     if value == 0x0000 {
         return "No key — this key does nothing".to_string();
@@ -984,7 +980,7 @@ pub fn keycode_tooltip(value: u16, custom: &[CustomKeycode], layer_names: &[Stri
     }
     // ── One-shot mod: 0x52A0..=0x52BF (Vial protocol v6) ─────────────────────
     if let Some(bits) = osm_mod_bits(value) {
-        let full_name = osm_mod_full_name(bits);
+        let full_name = modifier_full_name_from_bits(bits);
         return format!("One-Shot {full_name} — applies {full_name} to the next keypress only");
     }
 
@@ -1032,10 +1028,8 @@ pub fn keycode_tooltip(value: u16, custom: &[CustomKeycode], layer_names: &[Stri
         let kc_str = find_keycode(kc)
             .map(simple_key_name)
             .unwrap_or_else(|| format!("0x{:02X}", kc));
-        let right = (value >> 12) & 0x1 != 0;
-        let m = mod_name(mods, right);
-        let side_str = side(mods);
-        return format!("Mod Tap — tap for {}, hold for {}{}", kc_str, side_str, m);
+        let m = modifier_full_name_from_bits(mods);
+        return format!("Mod Tap — tap for {}, hold for {}", kc_str, m);
     }
 
     // ── Modifier+key combos 0x0100..0x1FFF ──────────────────────────────────

--- a/src/keycode.rs
+++ b/src/keycode.rs
@@ -95,24 +95,28 @@ fn osm_mod_short_name(bits: u16) -> String {
 fn osm_mod_full_name(bits: u16) -> String {
     let right = bits & 0x10 != 0;
     let side = if right { "Right" } else { "Left" };
+    format!("{side} {}", modifier_name_from_bits(bits))
+}
+
+pub fn modifier_name_from_bits(mods: u16) -> String {
     let gui = gui_mod_name();
-    match bits & 0x0F {
-        0x01 => format!("{side} Ctrl"),
-        0x02 => format!("{side} Shift"),
-        0x04 => format!("{side} Alt"),
-        0x08 => format!("{side} {gui}"),
-        0x03 => format!("{side} Ctrl+Shift"),
-        0x05 => format!("{side} Ctrl+Alt"),
-        0x09 => format!("{side} Ctrl+{gui}"),
-        0x0B => format!("{side} Ctrl+Shift+{gui}"),
-        0x06 => format!("{side} Shift+Alt"),
-        0x0A => format!("{side} Shift+{gui}"),
-        0x0E => format!("{side} Shift+Alt+{gui}"),
-        0x0D => format!("{side} Ctrl+Alt+{gui}"),
-        0x0C => format!("{side} Alt+{gui}"),
-        0x07 => format!("{side} Meh (Ctrl+Shift+Alt)"),
-        0x0F => format!("{side} Hyper (Ctrl+Shift+Alt+{gui})"),
-        _ => "modifier".to_string(),
+    match mods & 0x0F {
+        0x01 => "Ctrl".into(),
+        0x02 => "Shift".into(),
+        0x04 => "Alt".into(),
+        0x08 => gui.into(),
+        0x03 => "Ctrl+Shift".into(),
+        0x05 => "Ctrl+Alt".into(),
+        0x06 => "Shift+Alt".into(),
+        0x07 => "Meh (Ctrl+Shift+Alt)".into(),
+        0x09 => format!("Ctrl+{gui}"),
+        0x0A => format!("Shift+{gui}"),
+        0x0B => format!("Ctrl+Shift+{gui}"),
+        0x0C => format!("Alt+{gui}"),
+        0x0D => format!("Ctrl+Alt+{gui}"),
+        0x0E => format!("Shift+Alt+{gui}"),
+        0x0F => format!("Hyper (Ctrl+Shift+Alt+{gui})"),
+        _ => "modifier".into(),
     }
 }
 
@@ -954,20 +958,6 @@ pub fn keycode_tooltip(value: u16, custom: &[CustomKeycode], layer_names: &[Stri
             _ => format!("layer {}", n),
         }
     };
-    let mod_name = |m: u16, _right: bool| -> String {
-        match m & 0x0F {
-            0x01 => "Ctrl".into(),
-            0x02 => "Shift".into(),
-            0x04 => "Alt".into(),
-            0x08 => gui_mod_name().into(),
-            0x07 => "Meh (Ctrl+Shift+Alt)".into(),
-            0x0F => format!("Hyper (Ctrl+Shift+Alt+{})", gui_mod_name()),
-            0x03 => "Ctrl+Shift".into(),
-            0x05 => "Ctrl+Alt".into(),
-            0x06 => "Shift+Alt".into(),
-            _ => "modifier".into(),
-        }
-    };
     let side = |v: u16| if v & 0x10 != 0 { "Right " } else { "Left " };
 
     // ── KC_NO / KC_TRNS ──────────────────────────────────────────────────────
@@ -996,7 +986,7 @@ pub fn keycode_tooltip(value: u16, custom: &[CustomKeycode], layer_names: &[Stri
             3 => format!("TG({}) — toggle {} on/off", sub & 0x1F, layer_display(sub & 0x1F)),
             4 => format!("OSL({}) — activate {} for next keypress only", sub & 0x1F, layer_display(sub & 0x1F)),
             5 => {
-                let m = mod_name(sub & 0x1F, sub >= 0x10);
+                let m = modifier_name_from_bits(sub);
                 format!("One-Shot {} — activates {} for the very next keypress only", m, m)
             }
             6 => format!("TT({}) — tap to toggle {}, hold to activate while held", sub & 0x1F, layer_display(sub & 0x1F)),
@@ -1009,7 +999,7 @@ pub fn keycode_tooltip(value: u16, custom: &[CustomKeycode], layer_names: &[Stri
     if (0x5000..0x5200).contains(&value) {
         let layer = (value >> 4) & 0xF;
         let mods = value & 0xF;
-        let m = mod_name(mods, false);
+        let m = modifier_name_from_bits(mods);
         return format!("LM({}, {}) — activate {} with {} held while key is pressed", layer, m, layer_display(layer), m);
     }
 
@@ -1027,11 +1017,10 @@ pub fn keycode_tooltip(value: u16, custom: &[CustomKeycode], layer_names: &[Stri
     if value & 0xE000 == 0x2000 {
         let kc = value & 0xFF;
         let mods = (value >> 8) & 0x1F;
-        let right = (value >> 12) & 0x1 != 0;
         let kc_str = find_keycode(kc)
             .map(simple_key_name)
             .unwrap_or_else(|| format!("0x{:02X}", kc));
-        let m = mod_name(mods, right);
+        let m = modifier_name_from_bits(mods);
         let side_str = side(mods);
         return format!("Mod Tap — tap for {}, hold for {}{}", kc_str, side_str, m);
     }
@@ -1300,5 +1289,18 @@ mod tests {
     #[test]
     fn macos_gui_legends_use_cmd_text() {
         assert_eq!(gui_name_for_target_os("macos"), "Cmd");
+    }
+
+    #[test]
+    fn mod_tap_tooltips_decode_gui_chords() {
+        for (value, modifier) in [(0x2904, "Ctrl"), (0x2A04, "Shift")] {
+            let tooltip = keycode_tooltip(value, &[], &[]);
+
+            assert!(tooltip.contains("tap for A"), "{tooltip}");
+            assert!(
+                tooltip.contains(&format!("hold for Left {modifier}+{}", gui_mod_name())),
+                "{tooltip}"
+            );
+        }
     }
 }

--- a/src/keycode.rs
+++ b/src/keycode.rs
@@ -95,28 +95,24 @@ fn osm_mod_short_name(bits: u16) -> String {
 fn osm_mod_full_name(bits: u16) -> String {
     let right = bits & 0x10 != 0;
     let side = if right { "Right" } else { "Left" };
-    format!("{side} {}", modifier_name_from_bits(bits))
-}
-
-pub fn modifier_name_from_bits(mods: u16) -> String {
     let gui = gui_mod_name();
-    match mods & 0x0F {
-        0x01 => "Ctrl".into(),
-        0x02 => "Shift".into(),
-        0x04 => "Alt".into(),
-        0x08 => gui.into(),
-        0x03 => "Ctrl+Shift".into(),
-        0x05 => "Ctrl+Alt".into(),
-        0x06 => "Shift+Alt".into(),
-        0x07 => "Meh (Ctrl+Shift+Alt)".into(),
-        0x09 => format!("Ctrl+{gui}"),
-        0x0A => format!("Shift+{gui}"),
-        0x0B => format!("Ctrl+Shift+{gui}"),
-        0x0C => format!("Alt+{gui}"),
-        0x0D => format!("Ctrl+Alt+{gui}"),
-        0x0E => format!("Shift+Alt+{gui}"),
-        0x0F => format!("Hyper (Ctrl+Shift+Alt+{gui})"),
-        _ => "modifier".into(),
+    match bits & 0x0F {
+        0x01 => format!("{side} Ctrl"),
+        0x02 => format!("{side} Shift"),
+        0x04 => format!("{side} Alt"),
+        0x08 => format!("{side} {gui}"),
+        0x03 => format!("{side} Ctrl+Shift"),
+        0x05 => format!("{side} Ctrl+Alt"),
+        0x09 => format!("{side} Ctrl+{gui}"),
+        0x0B => format!("{side} Ctrl+Shift+{gui}"),
+        0x06 => format!("{side} Shift+Alt"),
+        0x0A => format!("{side} Shift+{gui}"),
+        0x0E => format!("{side} Shift+Alt+{gui}"),
+        0x0D => format!("{side} Ctrl+Alt+{gui}"),
+        0x0C => format!("{side} Alt+{gui}"),
+        0x07 => format!("{side} Meh (Ctrl+Shift+Alt)"),
+        0x0F => format!("{side} Hyper (Ctrl+Shift+Alt+{gui})"),
+        _ => "modifier".to_string(),
     }
 }
 
@@ -958,6 +954,22 @@ pub fn keycode_tooltip(value: u16, custom: &[CustomKeycode], layer_names: &[Stri
             _ => format!("layer {}", n),
         }
     };
+    let mod_name = |m: u16, _right: bool| -> String {
+        match m & 0x0F {
+            0x01 => "Ctrl".into(),
+            0x02 => "Shift".into(),
+            0x04 => "Alt".into(),
+            0x08 => gui_mod_name().into(),
+            0x07 => "Meh (Ctrl+Shift+Alt)".into(),
+            0x0F => format!("Hyper (Ctrl+Shift+Alt+{})", gui_mod_name()),
+            0x03 => "Ctrl+Shift".into(),
+            0x05 => "Ctrl+Alt".into(),
+            0x06 => "Shift+Alt".into(),
+            0x09 => format!("Ctrl+{}", gui_mod_name()),
+            0x0A => format!("Shift+{}", gui_mod_name()),
+            _ => "modifier".into(),
+        }
+    };
     let side = |v: u16| if v & 0x10 != 0 { "Right " } else { "Left " };
 
     // ── KC_NO / KC_TRNS ──────────────────────────────────────────────────────
@@ -986,7 +998,7 @@ pub fn keycode_tooltip(value: u16, custom: &[CustomKeycode], layer_names: &[Stri
             3 => format!("TG({}) — toggle {} on/off", sub & 0x1F, layer_display(sub & 0x1F)),
             4 => format!("OSL({}) — activate {} for next keypress only", sub & 0x1F, layer_display(sub & 0x1F)),
             5 => {
-                let m = modifier_name_from_bits(sub);
+                let m = mod_name(sub & 0x1F, sub >= 0x10);
                 format!("One-Shot {} — activates {} for the very next keypress only", m, m)
             }
             6 => format!("TT({}) — tap to toggle {}, hold to activate while held", sub & 0x1F, layer_display(sub & 0x1F)),
@@ -999,7 +1011,7 @@ pub fn keycode_tooltip(value: u16, custom: &[CustomKeycode], layer_names: &[Stri
     if (0x5000..0x5200).contains(&value) {
         let layer = (value >> 4) & 0xF;
         let mods = value & 0xF;
-        let m = modifier_name_from_bits(mods);
+        let m = mod_name(mods, false);
         return format!("LM({}, {}) — activate {} with {} held while key is pressed", layer, m, layer_display(layer), m);
     }
 
@@ -1020,7 +1032,8 @@ pub fn keycode_tooltip(value: u16, custom: &[CustomKeycode], layer_names: &[Stri
         let kc_str = find_keycode(kc)
             .map(simple_key_name)
             .unwrap_or_else(|| format!("0x{:02X}", kc));
-        let m = modifier_name_from_bits(mods);
+        let right = (value >> 12) & 0x1 != 0;
+        let m = mod_name(mods, right);
         let side_str = side(mods);
         return format!("Mod Tap — tap for {}, hold for {}{}", kc_str, side_str, m);
     }

--- a/src/keycode_picker.rs
+++ b/src/keycode_picker.rs
@@ -557,6 +557,16 @@ mod tests {
 
         assert_eq!(picker.selected_tab, KeycodeTab::Modifiers);
     }
+
+    #[test]
+    fn gui_chord_mod_tap_retarget_preserves_held_modifiers() {
+        for (base, tap_key, expected) in [(0x2900, 0x0005, 0x2905), (0x2A00, 0x0006, 0x2A06)] {
+            let mut picker = KeycodePicker::default();
+            picker.finish_quantum_pending_key(base, tap_key, true);
+
+            assert_eq!(picker.result, Some(expected.into()));
+        }
+    }
 }
 
 fn show_universal_symbol_section(

--- a/src/keycode_picker_tabs.rs
+++ b/src/keycode_picker_tabs.rs
@@ -411,10 +411,22 @@ impl KeycodePicker {
                 "Ctrl+Alt".into(),
             ),
             (
+                picker_mod_tap_label(0x2900),
+                0x2900,
+                None,
+                format!("Ctrl+{lgui}"),
+            ),
+            (
                 picker_mod_tap_label(0x2600),
                 0x2600,
                 None,
                 "Shift+Alt (LSA)".into(),
+            ),
+            (
+                picker_mod_tap_label(0x2A00),
+                0x2A00,
+                None,
+                format!("Shift+{lgui}"),
             ),
             (
                 picker_mod_tap_label(0x2700),
@@ -506,6 +518,16 @@ mod tests {
         assert_eq!(shift_gui.right_value, Some(0x52BA));
         assert_eq!(shift_gui.label, "OSM\nS+GUI");
         assert_eq!(shift_gui.mod_name, "Shift+GUI");
+    }
+
+    #[test]
+    fn mod_tap_choices_include_gui_chords() {
+        for (base, modifier) in [(0x2900, "Ctrl"), (0x2A00, "Shift")] {
+            assert_eq!(
+                picker_mod_tap_label(base),
+                format!("Hold {modifier}+{}/key", crate::keycode::gui_sym())
+            );
+        }
     }
 
     #[test]

--- a/src/keycode_picker_tabs.rs
+++ b/src/keycode_picker_tabs.rs
@@ -10,17 +10,72 @@ struct OneShotModifierChoice {
 
 fn mod_tap_choices(lgui: &str) -> Vec<(String, u16, Option<u16>, String)> {
     vec![
-        (picker_mod_tap_label(0x2100), 0x2100, Some(0x3100), "Ctrl".into()),
-        (picker_mod_tap_label(0x2200), 0x2200, Some(0x3200), "Shift".into()),
-        (picker_mod_tap_label(0x2400), 0x2400, Some(0x3400), "Alt".into()),
-        (picker_mod_tap_label(0x2800), 0x2800, Some(0x3800), lgui.to_string()),
-        (picker_mod_tap_label(0x2300), 0x2300, None, "Ctrl+Shift".into()),
-        (picker_mod_tap_label(0x2500), 0x2500, None, "Ctrl+Alt".into()),
-        (picker_mod_tap_label(0x2900), 0x2900, None, format!("Ctrl+{lgui}")),
-        (picker_mod_tap_label(0x2600), 0x2600, None, "Shift+Alt (LSA)".into()),
-        (picker_mod_tap_label(0x2700), 0x2700, None, "Meh (Ctrl+Shift+Alt)".into()),
-        (picker_mod_tap_label(0x2A00), 0x2A00, None, format!("Shift+{lgui}")),
-        (picker_mod_tap_label(0x2F00), 0x2F00, None, format!("Hyper (Ctrl+Shift+Alt+{})", gui_mod_name())),
+        (
+            picker_mod_tap_label(0x2100),
+            0x2100,
+            Some(0x3100),
+            "Ctrl".into(),
+        ),
+        (
+            picker_mod_tap_label(0x2200),
+            0x2200,
+            Some(0x3200),
+            "Shift".into(),
+        ),
+        (
+            picker_mod_tap_label(0x2400),
+            0x2400,
+            Some(0x3400),
+            "Alt".into(),
+        ),
+        (
+            picker_mod_tap_label(0x2800),
+            0x2800,
+            Some(0x3800),
+            lgui.to_string(),
+        ),
+        (
+            picker_mod_tap_label(0x2300),
+            0x2300,
+            None,
+            "Ctrl+Shift".into(),
+        ),
+        (
+            picker_mod_tap_label(0x2500),
+            0x2500,
+            None,
+            "Ctrl+Alt".into(),
+        ),
+        (
+            picker_mod_tap_label(0x2900),
+            0x2900,
+            None,
+            format!("Ctrl+{lgui}"),
+        ),
+        (
+            picker_mod_tap_label(0x2600),
+            0x2600,
+            None,
+            "Shift+Alt (LSA)".into(),
+        ),
+        (
+            picker_mod_tap_label(0x2700),
+            0x2700,
+            None,
+            "Meh (Ctrl+Shift+Alt)".into(),
+        ),
+        (
+            picker_mod_tap_label(0x2A00),
+            0x2A00,
+            None,
+            format!("Shift+{lgui}"),
+        ),
+        (
+            picker_mod_tap_label(0x2F00),
+            0x2F00,
+            None,
+            format!("Hyper (Ctrl+Shift+Alt+{})", gui_mod_name()),
+        ),
     ]
 }
 
@@ -483,7 +538,10 @@ mod tests {
                 label,
                 &format!("Hold {modifier}+{}/key", crate::keycode::gui_sym())
             );
-            assert_eq!(mod_name, &format!("{modifier}+{}", crate::keycode::gui_label(false)));
+            assert_eq!(
+                mod_name,
+                &format!("{modifier}+{}", crate::keycode::gui_label(false))
+            );
         }
     }
 

--- a/src/keycode_picker_tabs.rs
+++ b/src/keycode_picker_tabs.rs
@@ -374,17 +374,72 @@ impl KeycodePicker {
         );
         ui.add_space(4.0);
         let mt: Vec<(String, u16, Option<u16>, String)> = vec![
-            (picker_mod_tap_label(0x2100), 0x2100, Some(0x3100), "Ctrl".into()),
-            (picker_mod_tap_label(0x2200), 0x2200, Some(0x3200), "Shift".into()),
-            (picker_mod_tap_label(0x2400), 0x2400, Some(0x3400), "Alt".into()),
-            (picker_mod_tap_label(0x2800), 0x2800, Some(0x3800), lgui.to_string()),
-            (picker_mod_tap_label(0x2300), 0x2300, None, "Ctrl+Shift".into()),
-            (picker_mod_tap_label(0x2500), 0x2500, None, "Ctrl+Alt".into()),
-            (picker_mod_tap_label(0x2900), 0x2900, None, format!("Ctrl+{lgui}")),
-            (picker_mod_tap_label(0x2600), 0x2600, None, "Shift+Alt (LSA)".into()),
-            (picker_mod_tap_label(0x2700), 0x2700, None, "Meh (Ctrl+Shift+Alt)".into()),
-            (picker_mod_tap_label(0x2A00), 0x2A00, None, format!("Shift+{lgui}")),
-            (picker_mod_tap_label(0x2F00), 0x2F00, None, format!("Hyper (Ctrl+Shift+Alt+{})", gui_mod_name())),
+            (
+                picker_mod_tap_label(0x2100),
+                0x2100,
+                Some(0x3100),
+                "Ctrl".into(),
+            ),
+            (
+                picker_mod_tap_label(0x2200),
+                0x2200,
+                Some(0x3200),
+                "Shift".into(),
+            ),
+            (
+                picker_mod_tap_label(0x2400),
+                0x2400,
+                Some(0x3400),
+                "Alt".into(),
+            ),
+            (
+                picker_mod_tap_label(0x2800),
+                0x2800,
+                Some(0x3800),
+                lgui.to_string(),
+            ),
+            (
+                picker_mod_tap_label(0x2300),
+                0x2300,
+                None,
+                "Ctrl+Shift".into(),
+            ),
+            (
+                picker_mod_tap_label(0x2500),
+                0x2500,
+                None,
+                "Ctrl+Alt".into(),
+            ),
+            (
+                picker_mod_tap_label(0x2900),
+                0x2900,
+                None,
+                format!("Ctrl+{lgui}"),
+            ),
+            (
+                picker_mod_tap_label(0x2600),
+                0x2600,
+                None,
+                "Shift+Alt (LSA)".into(),
+            ),
+            (
+                picker_mod_tap_label(0x2700),
+                0x2700,
+                None,
+                "Meh (Ctrl+Shift+Alt)".into(),
+            ),
+            (
+                picker_mod_tap_label(0x2A00),
+                0x2A00,
+                None,
+                format!("Shift+{lgui}"),
+            ),
+            (
+                picker_mod_tap_label(0x2F00),
+                0x2F00,
+                None,
+                format!("Hyper (Ctrl+Shift+Alt+{})", gui_mod_name()),
+            ),
         ];
         ui.horizontal_wrapped(|ui| {
             for (label, left_value, right_value, mod_name) in &mt {

--- a/src/keycode_picker_tabs.rs
+++ b/src/keycode_picker_tabs.rs
@@ -8,6 +8,85 @@ struct OneShotModifierChoice {
     mod_name: String,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+struct ModTapChoice {
+    label: String,
+    left_value: u16,
+    right_value: Option<u16>,
+    mod_name: String,
+}
+
+fn mod_tap_choices(lgui: &str) -> Vec<ModTapChoice> {
+    vec![
+        ModTapChoice {
+            label: picker_mod_tap_label(0x2100),
+            left_value: 0x2100,
+            right_value: Some(0x3100),
+            mod_name: "Ctrl".into(),
+        },
+        ModTapChoice {
+            label: picker_mod_tap_label(0x2200),
+            left_value: 0x2200,
+            right_value: Some(0x3200),
+            mod_name: "Shift".into(),
+        },
+        ModTapChoice {
+            label: picker_mod_tap_label(0x2400),
+            left_value: 0x2400,
+            right_value: Some(0x3400),
+            mod_name: "Alt".into(),
+        },
+        ModTapChoice {
+            label: picker_mod_tap_label(0x2800),
+            left_value: 0x2800,
+            right_value: Some(0x3800),
+            mod_name: lgui.to_string(),
+        },
+        ModTapChoice {
+            label: picker_mod_tap_label(0x2300),
+            left_value: 0x2300,
+            right_value: None,
+            mod_name: "Ctrl+Shift".into(),
+        },
+        ModTapChoice {
+            label: picker_mod_tap_label(0x2500),
+            left_value: 0x2500,
+            right_value: None,
+            mod_name: "Ctrl+Alt".into(),
+        },
+        ModTapChoice {
+            label: picker_mod_tap_label(0x2900),
+            left_value: 0x2900,
+            right_value: None,
+            mod_name: format!("Ctrl+{lgui}"),
+        },
+        ModTapChoice {
+            label: picker_mod_tap_label(0x2600),
+            left_value: 0x2600,
+            right_value: None,
+            mod_name: "Shift+Alt (LSA)".into(),
+        },
+        ModTapChoice {
+            label: picker_mod_tap_label(0x2700),
+            left_value: 0x2700,
+            right_value: None,
+            mod_name: "Meh (Ctrl+Shift+Alt)".into(),
+        },
+        ModTapChoice {
+            label: picker_mod_tap_label(0x2A00),
+            left_value: 0x2A00,
+            right_value: None,
+            mod_name: format!("Shift+{lgui}"),
+        },
+        ModTapChoice {
+            label: picker_mod_tap_label(0x2F00),
+            left_value: 0x2F00,
+            right_value: None,
+            mod_name: format!("Hyper (Ctrl+Shift+Alt+{})", gui_mod_name()),
+        },
+    ]
+}
+
 fn one_shot_modifier_choices(gui_label: &str, gui_mod_name: &str) -> Vec<OneShotModifierChoice> {
     vec![
         OneShotModifierChoice {
@@ -373,95 +452,28 @@ impl KeycodePicker {
                 .color(Color32::from_gray(150)),
         );
         ui.add_space(4.0);
-        let mt: Vec<(String, u16, Option<u16>, String)> = vec![
-            (
-                picker_mod_tap_label(0x2100),
-                0x2100,
-                Some(0x3100),
-                "Ctrl".into(),
-            ),
-            (
-                picker_mod_tap_label(0x2200),
-                0x2200,
-                Some(0x3200),
-                "Shift".into(),
-            ),
-            (
-                picker_mod_tap_label(0x2400),
-                0x2400,
-                Some(0x3400),
-                "Alt".into(),
-            ),
-            (
-                picker_mod_tap_label(0x2800),
-                0x2800,
-                Some(0x3800),
-                lgui.to_string(),
-            ),
-            (
-                picker_mod_tap_label(0x2300),
-                0x2300,
-                None,
-                "Ctrl+Shift".into(),
-            ),
-            (
-                picker_mod_tap_label(0x2500),
-                0x2500,
-                None,
-                "Ctrl+Alt".into(),
-            ),
-            (
-                picker_mod_tap_label(0x2900),
-                0x2900,
-                None,
-                format!("Ctrl+{lgui}"),
-            ),
-            (
-                picker_mod_tap_label(0x2600),
-                0x2600,
-                None,
-                "Shift+Alt (LSA)".into(),
-            ),
-            (
-                picker_mod_tap_label(0x2A00),
-                0x2A00,
-                None,
-                format!("Shift+{lgui}"),
-            ),
-            (
-                picker_mod_tap_label(0x2700),
-                0x2700,
-                None,
-                "Meh (Ctrl+Shift+Alt)".into(),
-            ),
-            (
-                picker_mod_tap_label(0x2F00),
-                0x2F00,
-                None,
-                format!("Hyper (Ctrl+Shift+Alt+{})", gui_mod_name()),
-            ),
-        ];
+        let mt = mod_tap_choices(lgui);
         ui.horizontal_wrapped(|ui| {
-            for (label, left_value, right_value, mod_name) in &mt {
+            for choice in &mt {
                 let resp = ui
                     .add_sized(Self::picker_key_size(ui.ctx()), egui::Button::new(""))
                     .on_hover_cursor(egui::CursorIcon::PointingHand);
-                Self::paint_compact_picker_label(ui, &resp, label);
+                Self::paint_compact_picker_label(ui, &resp, &choice.label);
                 if resp.clicked_by(egui::PointerButton::Primary) {
-                    self.vial_quantum_pending_mt = Some(*left_value);
+                    self.vial_quantum_pending_mt = Some(choice.left_value);
                 }
-                if let Some(right_value) = right_value {
+                if let Some(right_value) = choice.right_value {
                     if resp.clicked_by(egui::PointerButton::Secondary) {
-                        self.vial_quantum_pending_mt = Some(*right_value);
+                        self.vial_quantum_pending_mt = Some(right_value);
                     }
                     resp.on_hover_text(crate::i18n::tr_text(
                         self.language,
-                        &mod_tap_tooltip(mod_name, true),
+                        &mod_tap_tooltip(&choice.mod_name, true),
                     ));
                 } else {
                     resp.on_hover_text(crate::i18n::tr_text(
                         self.language,
-                        &mod_tap_tooltip(mod_name, false),
+                        &mod_tap_tooltip(&choice.mod_name, false),
                     ));
                 }
             }
@@ -522,10 +534,21 @@ mod tests {
 
     #[test]
     fn mod_tap_choices_include_gui_chords() {
-        for (base, modifier) in [(0x2900, "Ctrl"), (0x2A00, "Shift")] {
+        let choices = mod_tap_choices(crate::keycode::gui_label(false));
+        for (value, modifier) in [(0x2900, "Ctrl"), (0x2A00, "Shift")] {
+            let choice = choices
+                .iter()
+                .find(|choice| choice.left_value == value)
+                .expect("GUI Mod-Tap chord should be exposed in the picker");
+
+            assert_eq!(choice.right_value, None);
             assert_eq!(
-                picker_mod_tap_label(base),
+                choice.label,
                 format!("Hold {modifier}+{}/key", crate::keycode::gui_sym())
+            );
+            assert_eq!(
+                choice.mod_name,
+                format!("{modifier}+{}", crate::keycode::gui_label(false))
             );
         }
     }

--- a/src/keycode_picker_tabs.rs
+++ b/src/keycode_picker_tabs.rs
@@ -8,6 +8,22 @@ struct OneShotModifierChoice {
     mod_name: String,
 }
 
+fn mod_tap_choices(lgui: &str) -> Vec<(String, u16, Option<u16>, String)> {
+    vec![
+        (picker_mod_tap_label(0x2100), 0x2100, Some(0x3100), "Ctrl".into()),
+        (picker_mod_tap_label(0x2200), 0x2200, Some(0x3200), "Shift".into()),
+        (picker_mod_tap_label(0x2400), 0x2400, Some(0x3400), "Alt".into()),
+        (picker_mod_tap_label(0x2800), 0x2800, Some(0x3800), lgui.to_string()),
+        (picker_mod_tap_label(0x2300), 0x2300, None, "Ctrl+Shift".into()),
+        (picker_mod_tap_label(0x2500), 0x2500, None, "Ctrl+Alt".into()),
+        (picker_mod_tap_label(0x2900), 0x2900, None, format!("Ctrl+{lgui}")),
+        (picker_mod_tap_label(0x2600), 0x2600, None, "Shift+Alt (LSA)".into()),
+        (picker_mod_tap_label(0x2700), 0x2700, None, "Meh (Ctrl+Shift+Alt)".into()),
+        (picker_mod_tap_label(0x2A00), 0x2A00, None, format!("Shift+{lgui}")),
+        (picker_mod_tap_label(0x2F00), 0x2F00, None, format!("Hyper (Ctrl+Shift+Alt+{})", gui_mod_name())),
+    ]
+}
+
 fn one_shot_modifier_choices(gui_label: &str, gui_mod_name: &str) -> Vec<OneShotModifierChoice> {
     vec![
         OneShotModifierChoice {
@@ -373,74 +389,7 @@ impl KeycodePicker {
                 .color(Color32::from_gray(150)),
         );
         ui.add_space(4.0);
-        let mt: Vec<(String, u16, Option<u16>, String)> = vec![
-            (
-                picker_mod_tap_label(0x2100),
-                0x2100,
-                Some(0x3100),
-                "Ctrl".into(),
-            ),
-            (
-                picker_mod_tap_label(0x2200),
-                0x2200,
-                Some(0x3200),
-                "Shift".into(),
-            ),
-            (
-                picker_mod_tap_label(0x2400),
-                0x2400,
-                Some(0x3400),
-                "Alt".into(),
-            ),
-            (
-                picker_mod_tap_label(0x2800),
-                0x2800,
-                Some(0x3800),
-                lgui.to_string(),
-            ),
-            (
-                picker_mod_tap_label(0x2300),
-                0x2300,
-                None,
-                "Ctrl+Shift".into(),
-            ),
-            (
-                picker_mod_tap_label(0x2500),
-                0x2500,
-                None,
-                "Ctrl+Alt".into(),
-            ),
-            (
-                picker_mod_tap_label(0x2900),
-                0x2900,
-                None,
-                format!("Ctrl+{lgui}"),
-            ),
-            (
-                picker_mod_tap_label(0x2600),
-                0x2600,
-                None,
-                "Shift+Alt (LSA)".into(),
-            ),
-            (
-                picker_mod_tap_label(0x2700),
-                0x2700,
-                None,
-                "Meh (Ctrl+Shift+Alt)".into(),
-            ),
-            (
-                picker_mod_tap_label(0x2A00),
-                0x2A00,
-                None,
-                format!("Shift+{lgui}"),
-            ),
-            (
-                picker_mod_tap_label(0x2F00),
-                0x2F00,
-                None,
-                format!("Hyper (Ctrl+Shift+Alt+{})", gui_mod_name()),
-            ),
-        ];
+        let mt = mod_tap_choices(lgui);
         ui.horizontal_wrapped(|ui| {
             for (label, left_value, right_value, mod_name) in &mt {
                 let resp = ui
@@ -522,11 +471,19 @@ mod tests {
 
     #[test]
     fn mod_tap_choices_include_gui_chords() {
-        for (base, modifier) in [(0x2900, "Ctrl"), (0x2A00, "Shift")] {
+        let choices = mod_tap_choices(crate::keycode::gui_label(false));
+        for (value, modifier) in [(0x2900, "Ctrl"), (0x2A00, "Shift")] {
+            let (label, _, right_value, mod_name) = choices
+                .iter()
+                .find(|(_, left_value, _, _)| *left_value == value)
+                .expect("GUI Mod-Tap chord should be exposed in the picker");
+
+            assert_eq!(*right_value, None);
             assert_eq!(
-                picker_mod_tap_label(base),
-                format!("Hold {modifier}+{}/key", crate::keycode::gui_sym())
+                label,
+                &format!("Hold {modifier}+{}/key", crate::keycode::gui_sym())
             );
+            assert_eq!(mod_name, &format!("{modifier}+{}", crate::keycode::gui_label(false)));
         }
     }
 

--- a/src/keycode_picker_tabs.rs
+++ b/src/keycode_picker_tabs.rs
@@ -8,85 +8,6 @@ struct OneShotModifierChoice {
     mod_name: String,
 }
 
-#[derive(Clone, Debug, PartialEq)]
-struct ModTapChoice {
-    label: String,
-    left_value: u16,
-    right_value: Option<u16>,
-    mod_name: String,
-}
-
-fn mod_tap_choices(lgui: &str) -> Vec<ModTapChoice> {
-    vec![
-        ModTapChoice {
-            label: picker_mod_tap_label(0x2100),
-            left_value: 0x2100,
-            right_value: Some(0x3100),
-            mod_name: "Ctrl".into(),
-        },
-        ModTapChoice {
-            label: picker_mod_tap_label(0x2200),
-            left_value: 0x2200,
-            right_value: Some(0x3200),
-            mod_name: "Shift".into(),
-        },
-        ModTapChoice {
-            label: picker_mod_tap_label(0x2400),
-            left_value: 0x2400,
-            right_value: Some(0x3400),
-            mod_name: "Alt".into(),
-        },
-        ModTapChoice {
-            label: picker_mod_tap_label(0x2800),
-            left_value: 0x2800,
-            right_value: Some(0x3800),
-            mod_name: lgui.to_string(),
-        },
-        ModTapChoice {
-            label: picker_mod_tap_label(0x2300),
-            left_value: 0x2300,
-            right_value: None,
-            mod_name: "Ctrl+Shift".into(),
-        },
-        ModTapChoice {
-            label: picker_mod_tap_label(0x2500),
-            left_value: 0x2500,
-            right_value: None,
-            mod_name: "Ctrl+Alt".into(),
-        },
-        ModTapChoice {
-            label: picker_mod_tap_label(0x2900),
-            left_value: 0x2900,
-            right_value: None,
-            mod_name: format!("Ctrl+{lgui}"),
-        },
-        ModTapChoice {
-            label: picker_mod_tap_label(0x2600),
-            left_value: 0x2600,
-            right_value: None,
-            mod_name: "Shift+Alt (LSA)".into(),
-        },
-        ModTapChoice {
-            label: picker_mod_tap_label(0x2700),
-            left_value: 0x2700,
-            right_value: None,
-            mod_name: "Meh (Ctrl+Shift+Alt)".into(),
-        },
-        ModTapChoice {
-            label: picker_mod_tap_label(0x2A00),
-            left_value: 0x2A00,
-            right_value: None,
-            mod_name: format!("Shift+{lgui}"),
-        },
-        ModTapChoice {
-            label: picker_mod_tap_label(0x2F00),
-            left_value: 0x2F00,
-            right_value: None,
-            mod_name: format!("Hyper (Ctrl+Shift+Alt+{})", gui_mod_name()),
-        },
-    ]
-}
-
 fn one_shot_modifier_choices(gui_label: &str, gui_mod_name: &str) -> Vec<OneShotModifierChoice> {
     vec![
         OneShotModifierChoice {
@@ -452,28 +373,40 @@ impl KeycodePicker {
                 .color(Color32::from_gray(150)),
         );
         ui.add_space(4.0);
-        let mt = mod_tap_choices(lgui);
+        let mt: Vec<(String, u16, Option<u16>, String)> = vec![
+            (picker_mod_tap_label(0x2100), 0x2100, Some(0x3100), "Ctrl".into()),
+            (picker_mod_tap_label(0x2200), 0x2200, Some(0x3200), "Shift".into()),
+            (picker_mod_tap_label(0x2400), 0x2400, Some(0x3400), "Alt".into()),
+            (picker_mod_tap_label(0x2800), 0x2800, Some(0x3800), lgui.to_string()),
+            (picker_mod_tap_label(0x2300), 0x2300, None, "Ctrl+Shift".into()),
+            (picker_mod_tap_label(0x2500), 0x2500, None, "Ctrl+Alt".into()),
+            (picker_mod_tap_label(0x2900), 0x2900, None, format!("Ctrl+{lgui}")),
+            (picker_mod_tap_label(0x2600), 0x2600, None, "Shift+Alt (LSA)".into()),
+            (picker_mod_tap_label(0x2700), 0x2700, None, "Meh (Ctrl+Shift+Alt)".into()),
+            (picker_mod_tap_label(0x2A00), 0x2A00, None, format!("Shift+{lgui}")),
+            (picker_mod_tap_label(0x2F00), 0x2F00, None, format!("Hyper (Ctrl+Shift+Alt+{})", gui_mod_name())),
+        ];
         ui.horizontal_wrapped(|ui| {
-            for choice in &mt {
+            for (label, left_value, right_value, mod_name) in &mt {
                 let resp = ui
                     .add_sized(Self::picker_key_size(ui.ctx()), egui::Button::new(""))
                     .on_hover_cursor(egui::CursorIcon::PointingHand);
-                Self::paint_compact_picker_label(ui, &resp, &choice.label);
+                Self::paint_compact_picker_label(ui, &resp, label);
                 if resp.clicked_by(egui::PointerButton::Primary) {
-                    self.vial_quantum_pending_mt = Some(choice.left_value);
+                    self.vial_quantum_pending_mt = Some(*left_value);
                 }
-                if let Some(right_value) = choice.right_value {
+                if let Some(right_value) = right_value {
                     if resp.clicked_by(egui::PointerButton::Secondary) {
-                        self.vial_quantum_pending_mt = Some(right_value);
+                        self.vial_quantum_pending_mt = Some(*right_value);
                     }
                     resp.on_hover_text(crate::i18n::tr_text(
                         self.language,
-                        &mod_tap_tooltip(&choice.mod_name, true),
+                        &mod_tap_tooltip(mod_name, true),
                     ));
                 } else {
                     resp.on_hover_text(crate::i18n::tr_text(
                         self.language,
-                        &mod_tap_tooltip(&choice.mod_name, false),
+                        &mod_tap_tooltip(mod_name, false),
                     ));
                 }
             }
@@ -534,21 +467,10 @@ mod tests {
 
     #[test]
     fn mod_tap_choices_include_gui_chords() {
-        let choices = mod_tap_choices(crate::keycode::gui_label(false));
-        for (value, modifier) in [(0x2900, "Ctrl"), (0x2A00, "Shift")] {
-            let choice = choices
-                .iter()
-                .find(|choice| choice.left_value == value)
-                .expect("GUI Mod-Tap chord should be exposed in the picker");
-
-            assert_eq!(choice.right_value, None);
+        for (base, modifier) in [(0x2900, "Ctrl"), (0x2A00, "Shift")] {
             assert_eq!(
-                choice.label,
+                picker_mod_tap_label(base),
                 format!("Hold {modifier}+{}/key", crate::keycode::gui_sym())
-            );
-            assert_eq!(
-                choice.mod_name,
-                format!("{modifier}+{}", crate::keycode::gui_label(false))
             );
         }
     }

--- a/src/ui/key_assignment.rs
+++ b/src/ui/key_assignment.rs
@@ -1,5 +1,17 @@
 use super::*;
 
+fn vial_retarget_pending_base(kc: u16) -> Option<(u16, bool)> {
+    if vial_layer_target(kc).is_some() {
+        None
+    } else if (0x2000..0x4000).contains(&kc) {
+        Some((kc & 0xFF00, true))
+    } else if (0x0100..0x2000).contains(&kc) && (kc & 0xFF) != 0 {
+        Some((kc & 0xFF00, false))
+    } else {
+        None
+    }
+}
+
 impl EntropyApp {
     pub(super) fn apply_picker_results(&mut self, ctx: &egui::Context) {
         #[cfg(not(target_arch = "wasm32"))]
@@ -314,19 +326,9 @@ impl EntropyApp {
             self.secondary_click_handled = true;
             return;
         }
-        let is_layer_key = vial_layer_target(kc).is_some();
-        let pending_base: Option<u16> = if is_layer_key {
-            None
-        } else if (0x2000..0x4000).contains(&kc)
-            || ((0x0100..0x2000).contains(&kc) && (kc & 0xFF) != 0)
-        {
-            Some(kc & 0xFF00)
-        } else {
-            None
-        };
-        if let Some(base) = pending_base {
+        if let Some((base, is_mt)) = vial_retarget_pending_base(kc) {
             self.open_picker_for_target(key_target, encoder_target);
-            if kc >= 0x2000 {
+            if is_mt {
                 self.keycode_picker.vial_quantum_pending_mt = Some(base);
                 self.keycode_picker.vial_quantum_pending_mod = None;
             } else {

--- a/src/ui/key_assignment.rs
+++ b/src/ui/key_assignment.rs
@@ -760,6 +760,27 @@ mod tests {
     }
 
     #[test]
+    fn right_click_reopens_gui_chord_mod_tap_tap_key_picker() {
+        let ctx = egui::Context::default();
+        let creation_context = eframe::CreationContext::_new_kittest(ctx.clone());
+
+        for (keycode, base) in [(0x2904, 0x2900), (0x2A04, 0x2A00)] {
+            let mut app = EntropyApp::new(&creation_context);
+            app.handle_secondary_target(
+                &ctx,
+                false,
+                crate::keyboard::KeyBinding::Vial(keycode),
+                Some(0),
+                None,
+            );
+
+            assert!(app.secondary_click_handled);
+            assert!(app.keycode_picker.open);
+            assert_eq!(app.keycode_picker.vial_quantum_pending_mt, Some(base));
+        }
+    }
+
+    #[test]
     fn universal_symbol_can_be_assigned_to_combo_output() {
         let ctx = egui::Context::default();
         let creation_context = eframe::CreationContext::_new_kittest(ctx.clone());

--- a/src/ui/key_assignment.rs
+++ b/src/ui/key_assignment.rs
@@ -1,17 +1,5 @@
 use super::*;
 
-fn vial_retarget_pending_base(kc: u16) -> Option<(u16, bool)> {
-    if vial_layer_target(kc).is_some() {
-        None
-    } else if (0x2000..0x4000).contains(&kc) {
-        Some((kc & 0xFF00, true))
-    } else if (0x0100..0x2000).contains(&kc) && (kc & 0xFF) != 0 {
-        Some((kc & 0xFF00, false))
-    } else {
-        None
-    }
-}
-
 impl EntropyApp {
     pub(super) fn apply_picker_results(&mut self, ctx: &egui::Context) {
         #[cfg(not(target_arch = "wasm32"))]
@@ -326,9 +314,19 @@ impl EntropyApp {
             self.secondary_click_handled = true;
             return;
         }
-        if let Some((base, is_mt)) = vial_retarget_pending_base(kc) {
+        let is_layer_key = vial_layer_target(kc).is_some();
+        let pending_base: Option<u16> = if is_layer_key {
+            None
+        } else if (0x2000..0x4000).contains(&kc)
+            || ((0x0100..0x2000).contains(&kc) && (kc & 0xFF) != 0)
+        {
+            Some(kc & 0xFF00)
+        } else {
+            None
+        };
+        if let Some(base) = pending_base {
             self.open_picker_for_target(key_target, encoder_target);
-            if is_mt {
+            if kc >= 0x2000 {
                 self.keycode_picker.vial_quantum_pending_mt = Some(base);
                 self.keycode_picker.vial_quantum_pending_mod = None;
             } else {

--- a/src/ui/layout_hints.rs
+++ b/src/ui/layout_hints.rs
@@ -36,6 +36,11 @@ impl LayoutBottomHintKind {
                 can_retarget_key,
                 is_mod_tap,
             } => match (can_swap_side, can_retarget_key, is_mod_tap) {
+                (false, true, true) => &[
+                    "key_hints.change_key",
+                    "key_hints.change_mod_tap_key",
+                    "key_hints.clear_key",
+                ],
                 (false, _, _) => &[
                     "key_hints.change_key",
                     "key_hints.change_modifier_key",
@@ -386,7 +391,7 @@ impl EntropyApp {
 
 #[cfg(test)]
 mod tests {
-    use super::LayoutBottomHintKind;
+    use super::{LayoutBottomHintKind, toggle_handed_modifier};
 
     const CLEAR_KEY: &str = "key_hints.clear_key";
 
@@ -434,6 +439,28 @@ mod tests {
                 CLEAR_KEY,
             ]
         );
+    }
+
+    #[test]
+    fn gui_chord_mod_tap_without_side_swap_uses_tap_key_hint() {
+        for keycode in [0x2904, 0x2A04] {
+            let is_mod_tap = (0x2000..0x4000).contains(&keycode);
+            let kind = LayoutBottomHintKind::Modifier {
+                can_swap_side: toggle_handed_modifier(keycode).is_some(),
+                can_retarget_key: is_mod_tap,
+                is_mod_tap,
+            };
+
+            assert_eq!(
+                kind.keys(false),
+                &[
+                    "key_hints.change_key",
+                    "key_hints.change_mod_tap_key",
+                    CLEAR_KEY,
+                ],
+                "wrong hints for {keycode:#06X}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add Ctrl+GUI and Shift+GUI Mod-Tap choices
- preserve existing tap-hold behavior for the new modifier chords

## Testing
- cargo test mod_tap_choices_include_gui_chords