### PR TITLE
refactor: group modern text field parameters

### DIFF
--- a/src/keycode_picker_macro.rs
+++ b/src/keycode_picker_macro.rs
@@ -306,13 +306,15 @@ impl KeycodePicker {
             if let Some(name) = self.macro_names.get_mut(n) {
                 let resp = crate::ui_style::modern_text_field_sized(
                     ui,
-                    ui.make_persistent_id(("macro_name", grid_id, n)),
-                    name,
-                    124.0 * scale,
-                    32.0 * scale,
-                    crate::i18n::tr_catalog(language, "macro_editor.macro_name"),
-                    MACRO_NAME_CHAR_LIMIT,
-                    egui::Align::Center,
+                    crate::ui_style::ModernTextField::new(
+                        ui.make_persistent_id(("macro_name", grid_id, n)),
+                        name,
+                        124.0 * scale,
+                        32.0 * scale,
+                        crate::i18n::tr_catalog(language, "macro_editor.macro_name"),
+                        MACRO_NAME_CHAR_LIMIT,
+                        egui::Align::Center,
+                    ),
                 );
                 if resp.changed() {
                     limit_chars(name, MACRO_NAME_CHAR_LIMIT);
@@ -324,13 +326,15 @@ impl KeycodePicker {
                 let description_w = ui.available_width().max(180.0 * scale).min(360.0 * scale);
                 let resp = crate::ui_style::modern_text_field_sized(
                     ui,
-                    ui.make_persistent_id(("macro_description", grid_id, n)),
-                    description,
-                    description_w,
-                    32.0 * scale,
-                    crate::i18n::tr_catalog(language, "macro_editor.macro_description"),
-                    MACRO_DESCRIPTION_CHAR_LIMIT,
-                    egui::Align::Min,
+                    crate::ui_style::ModernTextField::new(
+                        ui.make_persistent_id(("macro_description", grid_id, n)),
+                        description,
+                        description_w,
+                        32.0 * scale,
+                        crate::i18n::tr_catalog(language, "macro_editor.macro_description"),
+                        MACRO_DESCRIPTION_CHAR_LIMIT,
+                        egui::Align::Min,
+                    ),
                 )
                 .on_hover_text(crate::i18n::tr_catalog(
                     language,
@@ -434,16 +438,18 @@ impl KeycodePicker {
                             let text_w = (avail_w - 220.0 * scale).max(150.0 * scale);
                             if crate::ui_style::modern_text_field_sized(
                                 ui,
-                                ui.make_persistent_id(("macro_text_action", grid_id, n, i)),
-                                text,
-                                text_w,
-                                32.0 * scale,
-                                crate::i18n::tr_catalog(
-                                    self.language,
-                                    "macro_editor.type_text_here",
+                                crate::ui_style::ModernTextField::new(
+                                    ui.make_persistent_id(("macro_text_action", grid_id, n, i)),
+                                    text,
+                                    text_w,
+                                    32.0 * scale,
+                                    crate::i18n::tr_catalog(
+                                        self.language,
+                                        "macro_editor.type_text_here",
+                                    ),
+                                    256,
+                                    egui::Align::Min,
                                 ),
-                                256,
-                                egui::Align::Min,
                             )
                             .on_hover_text(crate::i18n::tr_catalog(
                                 self.language,
@@ -527,13 +533,15 @@ impl KeycodePicker {
                             let mut ms_str = ms.to_string();
                             if crate::ui_style::modern_text_field_sized(
                                 ui,
-                                ui.make_persistent_id(("macro_delay", grid_id, n, i)),
-                                &mut ms_str,
-                                80.0 * scale,
-                                32.0 * scale,
-                                "",
-                                5,
-                                egui::Align::Center,
+                                crate::ui_style::ModernTextField::new(
+                                    ui.make_persistent_id(("macro_delay", grid_id, n, i)),
+                                    &mut ms_str,
+                                    80.0 * scale,
+                                    32.0 * scale,
+                                    "",
+                                    5,
+                                    egui::Align::Center,
+                                ),
                             )
                             .on_hover_text(crate::i18n::tr_catalog(
                                 self.language,

--- a/src/keycode_picker_tap_dance.rs
+++ b/src/keycode_picker_tap_dance.rs
@@ -87,13 +87,15 @@ impl KeycodePicker {
         let mut edited_name = prev_name.clone();
         let resp = crate::ui_style::modern_text_field_sized(
             ui,
-            ui.make_persistent_id(("tap_dance_name", n)),
-            &mut edited_name,
-            124.0 * scale,
-            32.0 * scale,
-            crate::i18n::tr_catalog(self.language, "tap_dance_editor.td_name"),
-            7,
-            egui::Align::Center,
+            crate::ui_style::ModernTextField::new(
+                ui.make_persistent_id(("tap_dance_name", n)),
+                &mut edited_name,
+                124.0 * scale,
+                32.0 * scale,
+                crate::i18n::tr_catalog(self.language, "tap_dance_editor.td_name"),
+                7,
+                egui::Align::Center,
+            ),
         );
         if resp.changed() {
             let trimmed: String = edited_name.chars().take(7).collect();
@@ -189,13 +191,15 @@ impl KeycodePicker {
                     let mut term_str = prev_term.to_string();
                     if crate::ui_style::modern_text_field_sized(
                         ui,
-                        ui.make_persistent_id(("tap_dance_term", n)),
-                        &mut term_str,
-                        76.0 * scale,
-                        32.0 * scale,
-                        "",
-                        5,
-                        egui::Align::Center,
+                        crate::ui_style::ModernTextField::new(
+                            ui.make_persistent_id(("tap_dance_term", n)),
+                            &mut term_str,
+                            76.0 * scale,
+                            32.0 * scale,
+                            "",
+                            5,
+                            egui::Align::Center,
+                        ),
                     )
                     .on_hover_text(crate::i18n::tr_catalog(
                         self.language,

--- a/src/ui/alt_repeat_settings.rs
+++ b/src/ui/alt_repeat_settings.rs
@@ -380,16 +380,18 @@ impl EntropyApp {
                                         if let Some(name) = self.alt_repeat_names.get_mut(idx) {
                                             let resp = crate::ui_style::modern_text_field_sized(
                                                 ui,
-                                                egui::Id::new(("alt_repeat_name", idx)),
-                                                name,
-                                                control_width,
-                                                metrics.settings_control_height(),
-                                                crate::i18n::tr_catalog(
-                                                    self.app_settings.language,
-                                                    "alt_repeat_editor.name",
+                                                crate::ui_style::ModernTextField::new(
+                                                    egui::Id::new(("alt_repeat_name", idx)),
+                                                    name,
+                                                    control_width,
+                                                    metrics.settings_control_height(),
+                                                    crate::i18n::tr_catalog(
+                                                        self.app_settings.language,
+                                                        "alt_repeat_editor.name",
+                                                    ),
+                                                    12,
+                                                    egui::Align::Center,
                                                 ),
-                                                12,
-                                                egui::Align::Center,
                                             );
                                             name_changed = resp.changed();
                                             resp.clone().on_hover_text(crate::i18n::tr_catalog(

--- a/src/ui/auto_shift_settings.rs
+++ b/src/ui/auto_shift_settings.rs
@@ -251,12 +251,15 @@ impl EntropyApp {
                     let edit_id = egui::Id::new("auto_shift_timeout");
                     let resp = crate::ui_style::modern_text_field_interactive(
                         ui,
-                        edit_id,
-                        &mut self.auto_shift_timeout_text,
-                        field_width,
-                        "",
-                        5,
-                        egui::Align::RIGHT,
+                        crate::ui_style::ModernTextField::new(
+                            edit_id,
+                            &mut self.auto_shift_timeout_text,
+                            field_width,
+                            32.0,
+                            "",
+                            5,
+                            egui::Align::RIGHT,
+                        ),
                         enabled,
                     );
                     let resp = settings_field_unit_tooltip(

--- a/src/ui/combo_settings.rs
+++ b/src/ui/combo_settings.rs
@@ -281,16 +281,18 @@ impl EntropyApp {
                         if let Some(name) = self.combo_names.get_mut(combo_idx) {
                             let resp = crate::ui_style::modern_text_field_sized(
                                 ui,
-                                egui::Id::new(("combo_name", combo_idx)),
-                                name,
-                                control_width,
-                                control_height,
-                                crate::i18n::tr_catalog(
-                                    self.app_settings.language,
-                                    "alt_repeat_editor.name",
+                                crate::ui_style::ModernTextField::new(
+                                    egui::Id::new(("combo_name", combo_idx)),
+                                    name,
+                                    control_width,
+                                    control_height,
+                                    crate::i18n::tr_catalog(
+                                        self.app_settings.language,
+                                        "alt_repeat_editor.name",
+                                    ),
+                                    12,
+                                    egui::Align::Center,
                                 ),
-                                12,
-                                egui::Align::Center,
                             );
                             combo_name_changed = resp.changed();
                             resp.clone().on_hover_text(crate::i18n::tr_catalog(
@@ -594,13 +596,15 @@ impl EntropyApp {
                                     }
                                     let resp = crate::ui_style::modern_text_field_sized(
                                         ui,
-                                        edit_id,
-                                        &mut combo_term_text,
-                                        70.0 * scale,
-                                        control_height,
-                                        "",
-                                        4,
-                                        egui::Align::RIGHT,
+                                        crate::ui_style::ModernTextField::new(
+                                            edit_id,
+                                            &mut combo_term_text,
+                                            70.0 * scale,
+                                            control_height,
+                                            "",
+                                            4,
+                                            egui::Align::RIGHT,
+                                        ),
                                     );
                                     let resp = settings_field_unit_tooltip(
                                         resp,

--- a/src/ui/key_override_settings.rs
+++ b/src/ui/key_override_settings.rs
@@ -593,13 +593,15 @@ impl EntropyApp {
                                                     if let Some(name) = self.key_override_names.get_mut(idx) {
                                                         let resp = crate::ui_style::modern_text_field_sized(
                                                             ui,
-                                                            egui::Id::new(("key_override_name", idx)),
-                                                            name,
-                                                            control_width,
-                                                            32.0 * scale,
-                                                            crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.name"),
-                                                            12,
-                                                            egui::Align::Center,
+                                                            crate::ui_style::ModernTextField::new(
+                                                                egui::Id::new(("key_override_name", idx)),
+                                                                name,
+                                                                control_width,
+                                                                32.0 * scale,
+                                                                crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.name"),
+                                                                12,
+                                                                egui::Align::Center,
+                                                            ),
                                                         );
                                                         name_changed = resp.changed();
                                                         resp.clone().on_hover_text(crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.stored_locally_in_entropy"));

--- a/src/ui/module_settings.rs
+++ b/src/ui/module_settings.rs
@@ -309,13 +309,15 @@ impl EntropyApp {
                         }
                         let resp = crate::ui_style::modern_text_field_sized(
                             ui,
-                            edit_id,
-                            &mut text,
-                            field_width,
-                            metrics.settings_control_height(),
-                            "",
-                            5,
-                            egui::Align::Center,
+                            crate::ui_style::ModernTextField::new(
+                                edit_id,
+                                &mut text,
+                                field_width,
+                                metrics.settings_control_height(),
+                                "",
+                                5,
+                                egui::Align::Center,
+                            ),
                         );
                         let commit = resp.lost_focus()
                             || (resp.has_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)));

--- a/src/ui/mouse_keys_settings.rs
+++ b/src/ui/mouse_keys_settings.rs
@@ -205,13 +205,15 @@ impl EntropyApp {
 
                     let resp = crate::ui_style::modern_text_field_sized(
                         ui,
-                        edit_id,
-                        &mut text,
-                        field_width,
-                        control_height,
-                        "",
-                        5,
-                        egui::Align::RIGHT,
+                        crate::ui_style::ModernTextField::new(
+                            edit_id,
+                            &mut text,
+                            field_width,
+                            control_height,
+                            "",
+                            5,
+                            egui::Align::RIGHT,
+                        ),
                     );
                     let resp = settings_field_unit_tooltip(resp, lang, suppress_tooltips, unit);
 

--- a/src/ui/tap_hold_settings.rs
+++ b/src/ui/tap_hold_settings.rs
@@ -531,13 +531,15 @@ impl EntropyApp {
                         }
                         let resp = crate::ui_style::modern_text_field_sized(
                             ui,
-                            edit_id,
-                            &mut text,
-                            field_width,
-                            control_height,
-                            "",
-                            5,
-                            egui::Align::RIGHT,
+                            crate::ui_style::ModernTextField::new(
+                                edit_id,
+                                &mut text,
+                                field_width,
+                                control_height,
+                                "",
+                                5,
+                                egui::Align::RIGHT,
+                            ),
                         );
                         let resp = match (kind, qsid) {
                             (SettingsRowKind::TapHold, 7 | 25 | 18 | 19 | 27)

--- a/src/ui/text_expander_editor.rs
+++ b/src/ui/text_expander_editor.rs
@@ -1049,13 +1049,15 @@ impl EntropyApp {
                         trigger_resp = Some(
                             crate::ui_style::modern_text_field_sized(
                                 ui,
-                                ui.make_persistent_id(("text_expander_trigger", idx)),
-                                &mut rule.trigger,
-                                trigger_width,
-                                field_height,
-                                crate::i18n::tr_catalog(lang, "text_expander.trigger_hint"),
-                                32,
-                                egui::Align::Center,
+                                crate::ui_style::ModernTextField::new(
+                                    ui.make_persistent_id(("text_expander_trigger", idx)),
+                                    &mut rule.trigger,
+                                    trigger_width,
+                                    field_height,
+                                    crate::i18n::tr_catalog(lang, "text_expander.trigger_hint"),
+                                    32,
+                                    egui::Align::Center,
+                                ),
                             )
                             .on_hover_text(crate::i18n::tr_catalog(
                                 lang,
@@ -1077,13 +1079,15 @@ impl EntropyApp {
                         replacement_resp = Some(
                             crate::ui_style::modern_text_field_sized(
                                 ui,
-                                ui.make_persistent_id(("text_expander_replacement", idx)),
-                                &mut rule.replacement,
-                                replacement_width,
-                                field_height,
-                                crate::i18n::tr_catalog(lang, "text_expander.replacement_hint"),
-                                480,
-                                egui::Align::Min,
+                                crate::ui_style::ModernTextField::new(
+                                    ui.make_persistent_id(("text_expander_replacement", idx)),
+                                    &mut rule.replacement,
+                                    replacement_width,
+                                    field_height,
+                                    crate::i18n::tr_catalog(lang, "text_expander.replacement_hint"),
+                                    480,
+                                    egui::Align::Min,
+                                ),
                             )
                             .on_hover_text(crate::i18n::tr_catalog(
                                 lang,

--- a/src/ui/touchpad_settings.rs
+++ b/src/ui/touchpad_settings.rs
@@ -218,13 +218,15 @@ impl EntropyApp {
                                 }
                                 let resp = crate::ui_style::modern_text_field_sized(
                                     ui,
-                                    edit_id,
-                                    &mut text,
-                                    field_width,
-                                    metrics.settings_control_height(),
-                                    "",
-                                    5,
-                                    egui::Align::Center,
+                                    crate::ui_style::ModernTextField::new(
+                                        edit_id,
+                                        &mut text,
+                                        field_width,
+                                        metrics.settings_control_height(),
+                                        "",
+                                        5,
+                                        egui::Align::Center,
+                                    ),
                                 );
                                 let commit = resp.lost_focus()
                                     || (resp.has_focus()

--- a/src/ui_style.rs
+++ b/src/ui_style.rs
@@ -450,67 +450,65 @@ pub fn modern_button_with_font(
     resp
 }
 
-pub fn modern_text_field_sized(
-    ui: &mut Ui,
+pub(crate) struct ModernTextField<'a> {
     id: egui::Id,
-    text: &mut String,
+    text: &'a mut String,
     width: f32,
     height: f32,
-    hint: &str,
+    hint: &'a str,
     char_limit: usize,
     horizontal_align: egui::Align,
-) -> egui::Response {
-    let font_size = 12.5 * (height / 32.0).clamp(1.0, 1.3);
-    modern_text_field_impl(
-        ui,
-        id,
-        text,
-        width,
-        height,
-        font_size,
-        hint,
-        char_limit,
-        horizontal_align,
-        true,
-    )
 }
 
-pub fn modern_text_field_interactive(
+impl<'a> ModernTextField<'a> {
+    pub(crate) fn new(
+        id: egui::Id,
+        text: &'a mut String,
+        width: f32,
+        height: f32,
+        hint: &'a str,
+        char_limit: usize,
+        horizontal_align: egui::Align,
+    ) -> Self {
+        Self {
+            id,
+            text,
+            width,
+            height,
+            hint,
+            char_limit,
+            horizontal_align,
+        }
+    }
+}
+
+pub(crate) fn modern_text_field_sized(ui: &mut Ui, field: ModernTextField<'_>) -> egui::Response {
+    modern_text_field_impl(ui, field, true)
+}
+
+pub(crate) fn modern_text_field_interactive(
     ui: &mut Ui,
-    id: egui::Id,
-    text: &mut String,
-    width: f32,
-    hint: &str,
-    char_limit: usize,
-    horizontal_align: egui::Align,
+    field: ModernTextField<'_>,
     interactive: bool,
 ) -> egui::Response {
-    modern_text_field_impl(
-        ui,
-        id,
-        text,
-        width,
-        32.0,
-        12.5,
-        hint,
-        char_limit,
-        horizontal_align,
-        interactive,
-    )
+    modern_text_field_impl(ui, field, interactive)
 }
 
 fn modern_text_field_impl(
     ui: &mut Ui,
-    id: egui::Id,
-    text: &mut String,
-    width: f32,
-    height: f32,
-    font_size: f32,
-    hint: &str,
-    char_limit: usize,
-    horizontal_align: egui::Align,
+    field: ModernTextField<'_>,
     interactive: bool,
 ) -> egui::Response {
+    let ModernTextField {
+        id,
+        text,
+        width,
+        height,
+        hint,
+        char_limit,
+        horizontal_align,
+    } = field;
+    let font_size = 12.5 * (height / 32.0).clamp(1.0, 1.3);
     let dark = ui.visuals().dark_mode;
     let field_size = Vec2::new(width, height);
     let (field_rect, _) = ui.allocate_exact_size(field_size, Sense::hover());


### PR DESCRIPTION
### Problem

Modern text-field helpers accepted long positional argument lists for identity, text, geometry, hints, limits, and alignment. That obscured their shared configuration and produced three `clippy::too_many_arguments` diagnostics.

### Fix

- Introduce `ModernTextField` as the typed parameter object for all text-field rendering inputs.
- Migrate 17 callers without changing field dimensions, limits, alignment, or interactivity.

### Verification

- `cargo clippy --locked --all-targets` completes successfully; diagnostics decrease from 69 to 66 and no text-field argument-count warnings remain.
- `cargo test --locked -- --test-threads=1` passed (456 tests).
- Scoped `rustfmt --check` and `git diff --check` passed.