### PR TITLE
refactor: group settings list row layout

### DIFF
--- a/src/ui/about_device.rs
+++ b/src/ui/about_device.rs
@@ -536,12 +536,14 @@ fn draw_about_rows(
         for row in &rows[list.first_visible_row..list.last_visible_row] {
             crate::ui_style::settings_list_row_with_tooltip(
                 ui,
-                list.row_content_width,
-                list.row_height,
+                crate::ui_style::SettingsListRowLayout::new(
+                    list.row_content_width,
+                    list.row_height,
+                    control_width,
+                ),
                 row.label,
                 true,
                 tooltip_enabled.then_some(row.tooltip),
-                control_width,
                 |ui| {
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         let mut text = RichText::new(row.value.as_str())

--- a/src/ui/alt_repeat_settings.rs
+++ b/src/ui/alt_repeat_settings.rs
@@ -221,8 +221,11 @@ impl EntropyApp {
                             0 => {
                                 crate::ui_style::settings_list_row_with_tooltip(
                                     ui,
-                                    row_content_width,
-                                    row_height,
+                                    crate::ui_style::SettingsListRowLayout::new(
+                                        row_content_width,
+                                        row_height,
+                                        control_width,
+                                    ),
                                     crate::i18n::tr_catalog(
                                         self.app_settings.language,
                                         "alt_repeat_editor.entry",
@@ -232,7 +235,6 @@ impl EntropyApp {
                                         self.app_settings.language,
                                         "alt_repeat_editor.select_alt_repeat_slot",
                                     )),
-                                    control_width,
                                     |ui| {
                                         let dropdown_id =
                                             ui.make_persistent_id("alt_repeat_entry_dropdown");
@@ -364,8 +366,11 @@ impl EntropyApp {
                                 let mut name_changed = false;
                                 crate::ui_style::settings_list_row_with_tooltip(
                                     ui,
-                                    row_content_width,
-                                    row_height,
+                                    crate::ui_style::SettingsListRowLayout::new(
+                                        row_content_width,
+                                        row_height,
+                                        control_width,
+                                    ),
                                     crate::i18n::tr_catalog(
                                         self.app_settings.language,
                                         "alt_repeat_editor.name",
@@ -375,7 +380,6 @@ impl EntropyApp {
                                         self.app_settings.language,
                                         "alt_repeat_editor.local_name_for_this_slot",
                                     )),
-                                    control_width,
                                     |ui| {
                                         if let Some(name) = self.alt_repeat_names.get_mut(idx) {
                                             let resp = crate::ui_style::modern_text_field_sized(
@@ -410,15 +414,17 @@ impl EntropyApp {
                             2 => {
                                 crate::ui_style::settings_list_row_with_tooltip(
                                     ui,
-                                    row_content_width,
-                                    row_height,
+                                    crate::ui_style::SettingsListRowLayout::new(
+                                        row_content_width,
+                                        row_height,
+                                        control_width,
+                                    ),
                                     crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.last_key"),
                                     true,
                                     Some(crate::i18n::tr_catalog(
                                         self.app_settings.language,
                                         "alt_repeat_editor.key_that_triggers_alternate_repeat_behavior",
                                     )),
-                                    control_width,
                                     |ui| {
                                         let resp = crate::ui_style::modern_button_with_font(
                                             ui,
@@ -442,15 +448,17 @@ impl EntropyApp {
                             3 => {
                                 crate::ui_style::settings_list_row_with_tooltip(
                                     ui,
-                                    row_content_width,
-                                    row_height,
+                                    crate::ui_style::SettingsListRowLayout::new(
+                                        row_content_width,
+                                        row_height,
+                                        control_width,
+                                    ),
                                     crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.alt_key"),
                                     true,
                                     Some(crate::i18n::tr_catalog(
                                         self.app_settings.language,
                                         "alt_repeat_editor.key_repeated_when_alternate_repeat_activates",
                                     )),
-                                    control_width,
                                     |ui| {
                                         let resp = crate::ui_style::modern_button_with_font(
                                             ui,
@@ -513,8 +521,11 @@ impl EntropyApp {
                                 };
                                 crate::ui_style::settings_list_row_with_tooltip(
                                     ui,
-                                    row_content_width,
-                                    row_height,
+                                    crate::ui_style::SettingsListRowLayout::new(
+                                        row_content_width,
+                                        row_height,
+                                        mod_control_width,
+                                    ),
                                     row_label.as_str(),
                                     true,
                                     Some(match row_idx {
@@ -535,7 +546,6 @@ impl EntropyApp {
                                             "alt_repeat_editor.allowed_os_modifiers",
                                         ),
                                     }),
-                                    mod_control_width,
                                     |ui| {
                                         ui.with_layout(
                                             egui::Layout::right_to_left(egui::Align::Center),
@@ -613,8 +623,11 @@ impl EntropyApp {
                             8 => {
                                 crate::ui_style::settings_list_row_with_tooltip(
                                     ui,
-                                    row_content_width,
-                                    row_height,
+                                    crate::ui_style::SettingsListRowLayout::new(
+                                        row_content_width,
+                                        row_height,
+                                        metrics.value(46.0),
+                                    ),
                                     crate::i18n::tr_catalog(
                                         self.app_settings.language,
                                         "alt_repeat_editor.default_alt_key",
@@ -624,7 +637,6 @@ impl EntropyApp {
                                         self.app_settings.language,
                                         "alt_repeat_editor.use_this_alt_key_by_default",
                                     )),
-                                    metrics.value(46.0),
                                     |ui| {
                                         crate::ui_style::settings_switch_sized(
                                             ui,
@@ -637,8 +649,11 @@ impl EntropyApp {
                             9 => {
                                 crate::ui_style::settings_list_row_with_tooltip(
                                     ui,
-                                    row_content_width,
-                                    row_height,
+                                    crate::ui_style::SettingsListRowLayout::new(
+                                        row_content_width,
+                                        row_height,
+                                        metrics.value(46.0),
+                                    ),
                                     crate::i18n::tr_catalog(
                                         self.app_settings.language,
                                         "alt_repeat_editor.bidirectional",
@@ -648,7 +663,6 @@ impl EntropyApp {
                                         self.app_settings.language,
                                         "alt_repeat_editor.allow_both_keys_to_alternate_each_other",
                                     )),
-                                    metrics.value(46.0),
                                     |ui| {
                                         crate::ui_style::settings_switch_sized(
                                             ui,
@@ -661,12 +675,14 @@ impl EntropyApp {
                             10 => {
                                 crate::ui_style::settings_list_row_with_tooltip(
                                     ui,
-                                    row_content_width,
-                                    row_height,
+                                    crate::ui_style::SettingsListRowLayout::new(
+                                        row_content_width,
+                                        row_height,
+                                        metrics.value(46.0),
+                                    ),
                                     crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.ignore_handedness"),
                                     true,
                                     Some(crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.treat_left_and_right_modifiers_as_equivalent")),
-                                    metrics.value(46.0),
                                     |ui| {
                                         crate::ui_style::settings_switch_sized(
                                             ui,

--- a/src/ui/app_settings.rs
+++ b/src/ui/app_settings.rs
@@ -129,12 +129,14 @@ impl EntropyApp {
                     let mut selected_language = self.app_settings.language;
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
-                        content_width,
-                        row_height,
+                        crate::ui_style::SettingsListRowLayout::new(
+                            content_width,
+                            row_height,
+                            metrics.settings_control_width(),
+                        ),
                         crate::i18n::tr(lang, TrKey::LanguageLabel),
                         true,
                         tooltip(crate::i18n::tr(lang, TrKey::LanguageTooltip)),
-                        metrics.settings_control_width(),
                         |ui| {
                             let dropdown_id = ui.make_persistent_id("app_language_dropdown");
                             let dropdown_resp = crate::ui_style::modern_dropdown_button_sized(
@@ -208,12 +210,14 @@ impl EntropyApp {
                     let mut selected_key_legend_layout = self.app_settings.key_legend_layout;
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
-                        content_width,
-                        row_height,
+                        crate::ui_style::SettingsListRowLayout::new(
+                            content_width,
+                            row_height,
+                            metrics.settings_control_width(),
+                        ),
                         crate::i18n::tr_catalog(lang, "ui.key_legends_label"),
                         true,
                         tooltip(crate::i18n::tr_catalog(lang, "ui.key_legends_tooltip")),
-                        metrics.settings_control_width(),
                         |ui| {
                             let dropdown_id = ui.make_persistent_id("app_key_legends_dropdown");
                             let dropdown_resp = crate::ui_style::modern_dropdown_button_sized(
@@ -309,12 +313,14 @@ impl EntropyApp {
                     );
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
-                        content_width,
-                        row_height,
+                        crate::ui_style::SettingsListRowLayout::new(
+                            content_width,
+                            row_height,
+                            switch_width,
+                        ),
                         close_behavior_label,
                         true,
                         tooltip(close_behavior_tooltip),
-                        switch_width,
                         |ui| {
                             let _ = crate::ui_style::settings_switch_sized_stable(
                                 ui,
@@ -344,12 +350,14 @@ impl EntropyApp {
                     let mut launch_at_startup = self.app_settings.launch_at_startup;
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
-                        content_width,
-                        row_height,
+                        crate::ui_style::SettingsListRowLayout::new(
+                            content_width,
+                            row_height,
+                            switch_width,
+                        ),
                         crate::i18n::tr(lang, TrKey::LaunchAtStartupLabel),
                         true,
                         tooltip(crate::i18n::tr(lang, TrKey::LaunchAtStartupTooltip)),
-                        switch_width,
                         |ui| {
                             let _ = crate::ui_style::settings_switch_sized_stable(
                                 ui,
@@ -372,12 +380,14 @@ impl EntropyApp {
                     let mut show_shifted_symbols = self.app_settings.show_shifted_number_symbols;
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
-                        content_width,
-                        row_height,
+                        crate::ui_style::SettingsListRowLayout::new(
+                            content_width,
+                            row_height,
+                            switch_width,
+                        ),
                         crate::i18n::tr(lang, TrKey::ShiftedNumberSymbolsLabel),
                         true,
                         tooltip(crate::i18n::tr(lang, TrKey::ShiftedNumberSymbolsTooltip)),
-                        switch_width,
                         |ui| {
                             let _ = crate::ui_style::settings_switch_sized_stable(
                                 ui,
@@ -396,12 +406,14 @@ impl EntropyApp {
                     let mut layer_hover_preview = self.app_settings.layer_hover_preview;
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
-                        content_width,
-                        row_height,
+                        crate::ui_style::SettingsListRowLayout::new(
+                            content_width,
+                            row_height,
+                            switch_width,
+                        ),
                         crate::i18n::tr(lang, TrKey::LayerHoverPreviewLabel),
                         true,
                         tooltip(crate::i18n::tr(lang, TrKey::LayerHoverPreviewTooltip)),
-                        switch_width,
                         |ui| {
                             let _ = crate::ui_style::settings_switch_sized_stable(
                                 ui,
@@ -423,12 +435,14 @@ impl EntropyApp {
                     let mut encoder_hover_enlarge = self.app_settings.encoder_hover_enlarge;
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
-                        content_width,
-                        row_height,
+                        crate::ui_style::SettingsListRowLayout::new(
+                            content_width,
+                            row_height,
+                            switch_width,
+                        ),
                         crate::i18n::tr(lang, TrKey::EncoderHoverZoomLabel),
                         true,
                         tooltip(crate::i18n::tr(lang, TrKey::EncoderHoverZoomTooltip)),
-                        switch_width,
                         |ui| {
                             let _ = crate::ui_style::settings_switch_sized_stable(
                                 ui,
@@ -447,12 +461,14 @@ impl EntropyApp {
                     let mut selected_accent = self.app_settings.accent_color;
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
-                        content_width,
-                        row_height,
+                        crate::ui_style::SettingsListRowLayout::new(
+                            content_width,
+                            row_height,
+                            metrics.value(218.0),
+                        ),
                         crate::i18n::tr(lang, TrKey::AccentColorLabel),
                         true,
                         tooltip(crate::i18n::tr(lang, TrKey::AccentColorTooltip)),
-                        metrics.value(218.0),
                         |ui| {
                             ui.horizontal(|ui| {
                                 ui.spacing_mut().item_spacing.x = 7.0;
@@ -499,15 +515,17 @@ impl EntropyApp {
                 8 => {
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
-                        content_width,
-                        row_height,
+                        crate::ui_style::SettingsListRowLayout::new(
+                            content_width,
+                            row_height,
+                            metrics.settings_control_width(),
+                        ),
                         crate::i18n::tr_catalog(lang, "onboarding_tour.settings_row_label"),
                         true,
                         tooltip(crate::i18n::tr_catalog(
                             lang,
                             "onboarding_tour.settings_row_tooltip",
                         )),
-                        metrics.settings_control_width(),
                         |ui| {
                             if crate::ui_style::modern_button(
                                 ui,
@@ -532,12 +550,14 @@ impl EntropyApp {
                     );
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
-                        content_width,
-                        row_height,
+                        crate::ui_style::SettingsListRowLayout::new(
+                            content_width,
+                            row_height,
+                            switch_width,
+                        ),
                         crate::i18n::tr_catalog(lang, "ui.diagnostics_mode_label"),
                         true,
                         (!suppress_tooltips).then_some(diagnostics_tooltip.as_str()),
-                        switch_width,
                         |ui| {
                             let _ = crate::ui_style::settings_switch_sized_stable(
                                 ui,
@@ -562,15 +582,17 @@ impl EntropyApp {
                     let mut show_signature = self.app_settings.show_made_by_signature;
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
-                        content_width,
-                        row_height,
+                        crate::ui_style::SettingsListRowLayout::new(
+                            content_width,
+                            row_height,
+                            switch_width,
+                        ),
                         crate::i18n::tr_catalog(lang, "ui.show_made_by_signature_label"),
                         true,
                         tooltip(crate::i18n::tr_catalog(
                             lang,
                             "ui.show_made_by_signature_tooltip",
                         )),
-                        switch_width,
                         |ui| {
                             let _ = crate::ui_style::settings_switch_sized_stable(
                                 ui,
@@ -606,12 +628,14 @@ impl EntropyApp {
 
         crate::ui_style::settings_list_row_with_tooltip(
             ui,
-            content_width,
-            row_height,
+            crate::ui_style::SettingsListRowLayout::new(
+                content_width,
+                row_height,
+                metrics.settings_control_width(),
+            ),
             crate::i18n::tr_catalog(lang, "ui.vial_udev_rules_label"),
             true,
             tooltip,
-            metrics.settings_control_width(),
             |ui| {
                 if linux_vial_udev_rules_installed() {
                     draw_app_settings_value(

--- a/src/ui/auto_shift_settings.rs
+++ b/src/ui/auto_shift_settings.rs
@@ -205,12 +205,10 @@ impl EntropyApp {
             };
             crate::ui_style::settings_list_row_with_tooltip(
                 ui,
-                content_width,
-                row_height,
+                crate::ui_style::SettingsListRowLayout::new(content_width, row_height, 46.0),
                 row.0,
                 enabled,
                 tooltip,
-                46.0,
                 |ui| {
                     let resp = crate::ui_style::settings_switch_sized_stable_interactive(
                         ui,
@@ -241,12 +239,10 @@ impl EntropyApp {
             }
             crate::ui_style::settings_list_row_with_tooltip(
                 ui,
-                content_width,
-                row_height,
+                crate::ui_style::SettingsListRowLayout::new(content_width, row_height, field_width),
                 row.0,
                 enabled,
                 tooltip,
-                field_width,
                 |ui| {
                     let edit_id = egui::Id::new("auto_shift_timeout");
                     let resp = crate::ui_style::modern_text_field_interactive(

--- a/src/ui/bluetooth_settings.rs
+++ b/src/ui/bluetooth_settings.rs
@@ -234,8 +234,11 @@ impl EntropyApp {
                     let mut enabled = setting.value;
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
-                        content_width,
-                        row_height,
+                        crate::ui_style::SettingsListRowLayout::new(
+                            content_width,
+                            row_height,
+                            switch_width,
+                        ),
                         crate::i18n::tr_catalog(
                             self.app_settings.language,
                             "bluetooth_settings.charge_indicator",
@@ -249,7 +252,6 @@ impl EntropyApp {
                                 "bluetooth_settings.charge_indicator_tooltip",
                             ))
                         },
-                        switch_width,
                         |ui| {
                             let response = crate::ui_style::settings_switch_sized_stable(
                                 ui,
@@ -320,12 +322,10 @@ impl EntropyApp {
         let selected_idx = (setting.value as usize).min(variants.len().saturating_sub(1));
         crate::ui_style::settings_list_row_with_tooltip(
             ui,
-            content_width,
-            row_height,
+            crate::ui_style::SettingsListRowLayout::new(content_width, row_height, dropdown_width),
             label.as_str(),
             true,
             tooltip.as_deref(),
-            dropdown_width,
             |ui| {
                 let dropdown_id =
                     ui.make_persistent_id(("bluetooth_setting_dropdown", setting.qsid));

--- a/src/ui/combo_settings.rs
+++ b/src/ui/combo_settings.rs
@@ -158,15 +158,17 @@ impl EntropyApp {
                 ui.spacing_mut().item_spacing.y = 0.0;
                 crate::ui_style::settings_list_row_with_tooltip(
                     ui,
-                    row_content_width,
-                    row_height,
+                    crate::ui_style::SettingsListRowLayout::new(
+                        row_content_width,
+                        row_height,
+                        control_width,
+                    ),
                     crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.entry"),
                     true,
                     Some(crate::i18n::tr_catalog(
                         self.app_settings.language,
                         "combo_editor.select_combo_slot",
                     )),
-                    control_width,
                     |ui| {
                         let dropdown_id = ui.make_persistent_id("combo_entry_dropdown");
                         let dropdown_resp = crate::ui_style::modern_dropdown_button_sized(
@@ -268,15 +270,17 @@ impl EntropyApp {
                 let mut combo_name_changed = false;
                 crate::ui_style::settings_list_row_with_tooltip(
                     ui,
-                    row_content_width,
-                    row_height,
+                    crate::ui_style::SettingsListRowLayout::new(
+                        row_content_width,
+                        row_height,
+                        control_width,
+                    ),
                     crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.name"),
                     true,
                     Some(crate::i18n::tr_catalog(
                         self.app_settings.language,
                         "combo_editor.local_name_for_this_combo_slot",
                     )),
-                    control_width,
                     |ui| {
                         if let Some(name) = self.combo_names.get_mut(combo_idx) {
                             let resp = crate::ui_style::modern_text_field_sized(
@@ -315,15 +319,17 @@ impl EntropyApp {
                 let color_swatch_size = metrics.size(64.0, 34.0);
                 crate::ui_style::settings_list_row_with_tooltip(
                     ui,
-                    row_content_width,
-                    row_height,
+                    crate::ui_style::SettingsListRowLayout::new(
+                        row_content_width,
+                        row_height,
+                        color_swatch_width,
+                    ),
                     crate::i18n::tr_catalog(self.app_settings.language, "common.color"),
                     true,
                     Some(crate::i18n::tr_catalog(
                         self.app_settings.language,
                         "combo_editor.local_color_for_combo_slot",
                     )),
-                    color_swatch_width,
                     |ui| {
                         let popup_id = ui.make_persistent_id(("combo_color_picker", combo_idx));
                         let popup_open = egui::Popup::is_id_open(ui.ctx(), popup_id);
@@ -461,15 +467,17 @@ impl EntropyApp {
 
                 crate::ui_style::settings_list_row_with_tooltip(
                     ui,
-                    row_content_width,
-                    input_keys_row_height,
+                    crate::ui_style::SettingsListRowLayout::new(
+                        row_content_width,
+                        input_keys_row_height,
+                        input_keys_control_width,
+                    ),
                     crate::i18n::tr_catalog(self.app_settings.language, "combo_editor.input_keys"),
                     true,
                     Some(crate::i18n::tr_catalog(
                         self.app_settings.language,
                         "combo_editor.keys_that_must_be_pressed_together",
                     )),
-                    input_keys_control_width,
                     |ui| {
                         ui.spacing_mut().item_spacing.x = 4.0 * scale;
                         for key_idx in 0..4 {
@@ -517,15 +525,17 @@ impl EntropyApp {
 
                 crate::ui_style::settings_list_row_with_tooltip(
                     ui,
-                    row_content_width,
-                    input_keys_row_height,
+                    crate::ui_style::SettingsListRowLayout::new(
+                        row_content_width,
+                        input_keys_row_height,
+                        input_key_size.x,
+                    ),
                     crate::i18n::tr_catalog(self.app_settings.language, "combo_editor.output_key"),
                     true,
                     Some(crate::i18n::tr_catalog(
                         self.app_settings.language,
                         "combo_editor.keycode_sent_when_the_combo_activates",
                     )),
-                    input_key_size.x,
                     |ui| {
                         let value = self.combo_entries[combo_idx].output;
                         let button_label = if value == 0 {
@@ -568,15 +578,17 @@ impl EntropyApp {
                 if let Some(current_combo_term) = self.combo_term {
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
-                        row_content_width,
-                        row_height,
+                        crate::ui_style::SettingsListRowLayout::new(
+                            row_content_width,
+                            row_height,
+                            timeout_control_width,
+                        ),
                         crate::i18n::tr_catalog(self.app_settings.language, "common.timeout"),
                         true,
                         Some(crate::i18n::tr_catalog(
                             self.app_settings.language,
                             "combo_editor.maximum_time_between_combo_key_presses",
                         )),
-                        timeout_control_width,
                         |ui| {
                             ui.with_layout(
                                 egui::Layout::right_to_left(egui::Align::Center),

--- a/src/ui/encoder_visibility_settings.rs
+++ b/src/ui/encoder_visibility_settings.rs
@@ -220,12 +220,14 @@ impl EntropyApp {
         };
         crate::ui_style::settings_list_row_with_tooltip(
             ui,
-            row.content_width,
-            row.height,
+            crate::ui_style::SettingsListRowLayout::new(
+                row.content_width,
+                row.height,
+                metrics.value(46.0),
+            ),
             &label,
             true,
             (!row.suppress_tooltips).then_some(tooltip.as_str()),
-            metrics.value(46.0),
             |ui| {
                 let resp = crate::ui_style::settings_switch_sized_stable(
                     ui,

--- a/src/ui/grave_escape_settings.rs
+++ b/src/ui/grave_escape_settings.rs
@@ -119,12 +119,14 @@ impl EntropyApp {
                             let mut value = self.grave_escape_settings.bit(bit);
                             crate::ui_style::settings_list_row_with_tooltip(
                                 ui,
-                                row_content_width,
-                                row_height,
+                                crate::ui_style::SettingsListRowLayout::new(
+                                    row_content_width,
+                                    row_height,
+                                    switch_width,
+                                ),
                                 &label,
                                 true,
                                 Some(&tooltip),
-                                switch_width,
                                 |ui| {
                                     let resp = crate::ui_style::settings_switch_sized(
                                         ui,

--- a/src/ui/key_override_settings.rs
+++ b/src/ui/key_override_settings.rs
@@ -333,12 +333,10 @@ impl EntropyApp {
             let mut checked = (*mask & bit) != 0;
             crate::ui_style::settings_list_row_with_tooltip(
                 ui,
-                popup_width,
-                row_height,
+                crate::ui_style::SettingsListRowLayout::new(popup_width, row_height, switch_width),
                 label.as_str(),
                 true,
                 None,
-                switch_width,
                 |ui| {
                     let resp =
                         crate::ui_style::settings_switch_sized(ui, &mut checked, switch_size);
@@ -495,12 +493,14 @@ impl EntropyApp {
                                         0 => {
                                             crate::ui_style::settings_list_row_with_tooltip(
                                                 ui,
-                                                row_content_width,
-                                                row_height,
+                                                crate::ui_style::SettingsListRowLayout::new(
+                                                    row_content_width,
+                                                    row_height,
+                                                    control_width,
+                                                ),
                                                 crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.entry"),
                                                 true,
                                                 Some(crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.select_key_override_slot")),
-                                                control_width,
                                                 |ui| {
                                                     let dropdown_id = ui.make_persistent_id("key_override_entry_dropdown");
                                                     let dropdown_resp = crate::ui_style::modern_dropdown_button_sized(
@@ -583,12 +583,14 @@ impl EntropyApp {
                                             let mut name_changed = false;
                                             crate::ui_style::settings_list_row_with_tooltip(
                                                 ui,
-                                                row_content_width,
-                                                row_height,
+                                                crate::ui_style::SettingsListRowLayout::new(
+                                                    row_content_width,
+                                                    row_height,
+                                                    control_width,
+                                                ),
                                                 crate::i18n::tr_catalog(self.app_settings.language, "alt_repeat_editor.name"),
                                                 true,
                                                 Some(crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.local_name_for_this_key_override_slot")),
-                                                control_width,
                                                 |ui| {
                                                     if let Some(name) = self.key_override_names.get_mut(idx) {
                                                         let resp = crate::ui_style::modern_text_field_sized(
@@ -613,12 +615,14 @@ impl EntropyApp {
                                         2 => {
                                             crate::ui_style::settings_list_row_with_tooltip(
                                                 ui,
-                                                row_content_width,
-                                                row_height,
+                                                crate::ui_style::SettingsListRowLayout::new(
+                                                    row_content_width,
+                                                    row_height,
+                                                    control_width,
+                                                ),
                                                 crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.trigger"),
                                                 true,
                                                 Some(crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.original_key_that_can_be_overridden")),
-                                                control_width,
                                                 |ui| {
                                                     let resp = crate::ui_style::modern_button_with_font(ui, trigger_label.as_str(), Vec2::new(control_width, control_height), control_font_size, true);
                                                     if resp.clicked() {
@@ -631,12 +635,14 @@ impl EntropyApp {
                                         3 => {
                                             crate::ui_style::settings_list_row_with_tooltip(
                                                 ui,
-                                                row_content_width,
-                                                row_height,
+                                                crate::ui_style::SettingsListRowLayout::new(
+                                                    row_content_width,
+                                                    row_height,
+                                                    control_width,
+                                                ),
                                                 crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.replacement"),
                                                 true,
                                                 Some(crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.keycode_sent_while_override_conditions_match")),
-                                                control_width,
                                                 |ui| {
                                                     let resp = crate::ui_style::modern_button_with_font(ui, replacement_label.as_str(), Vec2::new(control_width, control_height), control_font_size, true);
                                                     if resp.clicked() {
@@ -649,12 +655,14 @@ impl EntropyApp {
                                         4 => {
                                             crate::ui_style::settings_list_row_with_tooltip(
                                                 ui,
-                                                row_content_width,
-                                                row_height,
+                                                crate::ui_style::SettingsListRowLayout::new(
+                                                    row_content_width,
+                                                    row_height,
+                                                    control_width,
+                                                ),
                                                 crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.suppressed_mods"),
                                                 true,
                                                 Some(crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.modifiers_hidden_while_the_replacement_is_active")),
-                                                control_width,
                                                 |ui| {
                                                     let popup_id = ui.make_persistent_id(("ko_suppressed_mods_popup", idx));
                                                     let summary = Self::key_override_mod_mask_summary(self.app_settings.language, edited.suppressed_mods);
@@ -671,12 +679,14 @@ impl EntropyApp {
                                         5 => {
                                             crate::ui_style::settings_list_row_with_tooltip(
                                                 ui,
-                                                row_content_width,
-                                                row_height,
+                                                crate::ui_style::SettingsListRowLayout::new(
+                                                    row_content_width,
+                                                    row_height,
+                                                    control_width,
+                                                ),
                                                 crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.trigger_mods"),
                                                 true,
                                                 Some(crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.modifiers_required_for_this_override")),
-                                                control_width,
                                                 |ui| {
                                                     let popup_id = ui.make_persistent_id(("ko_trigger_mods_popup", idx));
                                                     let summary = Self::key_override_mod_mask_summary(self.app_settings.language, edited.trigger_mods);
@@ -693,12 +703,14 @@ impl EntropyApp {
                                         6 => {
                                             crate::ui_style::settings_list_row_with_tooltip(
                                                 ui,
-                                                row_content_width,
-                                                row_height,
+                                                crate::ui_style::SettingsListRowLayout::new(
+                                                    row_content_width,
+                                                    row_height,
+                                                    control_width,
+                                                ),
                                                 crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.negative_mods"),
                                                 true,
                                                 Some(crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.modifiers_that_block_this_override")),
-                                                control_width,
                                                 |ui| {
                                                     let popup_id = ui.make_persistent_id(("ko_negative_mods_popup", idx));
                                                     let summary = Self::key_override_mod_mask_summary(self.app_settings.language, edited.negative_mod_mask);
@@ -715,12 +727,14 @@ impl EntropyApp {
                                         7 => {
                                             crate::ui_style::settings_list_row_with_tooltip(
                                                 ui,
-                                                row_content_width,
-                                                row_height,
+                                                crate::ui_style::SettingsListRowLayout::new(
+                                                    row_content_width,
+                                                    row_height,
+                                                    control_width,
+                                                ),
                                                 crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.enable_on_layers"),
                                                 true,
                                                 Some(crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.layers_where_this_override_can_activate")),
-                                                control_width,
                                                 |ui| {
                                                     let popup_id = ui.make_persistent_id(("ko_layers_popup", idx));
                                                     let summary = Self::key_override_layers_summary(self.app_settings.language, edited.layers);
@@ -734,12 +748,78 @@ impl EntropyApp {
                                                 },
                                             );
                                         }
-                                        8 => crate::ui_style::settings_list_row_with_tooltip(ui, row_content_width, row_height, crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.trigger_press"), true, Some(crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.activate_when_the_trigger_key_is_pressed")), switch_width, |ui| { crate::ui_style::settings_switch_sized_stable(ui, ("key_override_settings", "trigger_press"), &mut edited.options.activation_trigger_down, switch_size); }),
-                                        9 => crate::ui_style::settings_list_row_with_tooltip(ui, row_content_width, row_height, crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.required_mod_press"), true, Some(crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.activate_when_a_required_modifier_is_pressed")), switch_width, |ui| { crate::ui_style::settings_switch_sized_stable(ui, ("key_override_settings", "required_mod_press"), &mut edited.options.activation_required_mod_down, switch_size); }),
-                                        10 => crate::ui_style::settings_list_row_with_tooltip(ui, row_content_width, row_height, crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.blocked_mod_release"), true, Some(crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.activate_when_a_blocking_modifier_is_released")), switch_width, |ui| { crate::ui_style::settings_switch_sized_stable(ui, ("key_override_settings", "blocked_mod_release"), &mut edited.options.activation_negative_mod_up, switch_size); }),
-                                        11 => crate::ui_style::settings_list_row_with_tooltip(ui, row_content_width, row_height, crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.any_one_mod"), true, Some(crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.any_one_trigger_modifier_is_enough")), switch_width, |ui| { crate::ui_style::settings_switch_sized_stable(ui, ("key_override_settings", "any_one_mod"), &mut edited.options.one_mod, switch_size); }),
-                                        12 => crate::ui_style::settings_list_row_with_tooltip(ui, row_content_width, row_height, crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.no_re_send"), true, Some(crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.do_not_resend_the_trigger_after_override_ends")), switch_width, |ui| { crate::ui_style::settings_switch_sized_stable(ui, ("key_override_settings", "no_re_send"), &mut edited.options.no_reregister_trigger, switch_size); }),
-                                        13 => crate::ui_style::settings_list_row_with_tooltip(ui, row_content_width, row_height, crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.stay_active"), true, Some(crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.stay_active_when_another_key_is_pressed")), switch_width, |ui| { crate::ui_style::settings_switch_sized_stable(ui, ("key_override_settings", "stay_active"), &mut edited.options.no_unregister_on_other_key_down, switch_size); }),
+                                        8 => crate::ui_style::settings_list_row_with_tooltip(
+                                            ui,
+                                            crate::ui_style::SettingsListRowLayout::new(
+                                                row_content_width,
+                                                row_height,
+                                                switch_width,
+                                            ),
+                                            crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.trigger_press"),
+                                            true,
+                                            Some(crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.activate_when_the_trigger_key_is_pressed")),
+                                            |ui| { crate::ui_style::settings_switch_sized_stable(ui, ("key_override_settings", "trigger_press"), &mut edited.options.activation_trigger_down, switch_size); },
+                                        ),
+                                        9 => crate::ui_style::settings_list_row_with_tooltip(
+                                            ui,
+                                            crate::ui_style::SettingsListRowLayout::new(
+                                                row_content_width,
+                                                row_height,
+                                                switch_width,
+                                            ),
+                                            crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.required_mod_press"),
+                                            true,
+                                            Some(crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.activate_when_a_required_modifier_is_pressed")),
+                                            |ui| { crate::ui_style::settings_switch_sized_stable(ui, ("key_override_settings", "required_mod_press"), &mut edited.options.activation_required_mod_down, switch_size); },
+                                        ),
+                                        10 => crate::ui_style::settings_list_row_with_tooltip(
+                                            ui,
+                                            crate::ui_style::SettingsListRowLayout::new(
+                                                row_content_width,
+                                                row_height,
+                                                switch_width,
+                                            ),
+                                            crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.blocked_mod_release"),
+                                            true,
+                                            Some(crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.activate_when_a_blocking_modifier_is_released")),
+                                            |ui| { crate::ui_style::settings_switch_sized_stable(ui, ("key_override_settings", "blocked_mod_release"), &mut edited.options.activation_negative_mod_up, switch_size); },
+                                        ),
+                                        11 => crate::ui_style::settings_list_row_with_tooltip(
+                                            ui,
+                                            crate::ui_style::SettingsListRowLayout::new(
+                                                row_content_width,
+                                                row_height,
+                                                switch_width,
+                                            ),
+                                            crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.any_one_mod"),
+                                            true,
+                                            Some(crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.any_one_trigger_modifier_is_enough")),
+                                            |ui| { crate::ui_style::settings_switch_sized_stable(ui, ("key_override_settings", "any_one_mod"), &mut edited.options.one_mod, switch_size); },
+                                        ),
+                                        12 => crate::ui_style::settings_list_row_with_tooltip(
+                                            ui,
+                                            crate::ui_style::SettingsListRowLayout::new(
+                                                row_content_width,
+                                                row_height,
+                                                switch_width,
+                                            ),
+                                            crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.no_re_send"),
+                                            true,
+                                            Some(crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.do_not_resend_the_trigger_after_override_ends")),
+                                            |ui| { crate::ui_style::settings_switch_sized_stable(ui, ("key_override_settings", "no_re_send"), &mut edited.options.no_reregister_trigger, switch_size); },
+                                        ),
+                                        13 => crate::ui_style::settings_list_row_with_tooltip(
+                                            ui,
+                                            crate::ui_style::SettingsListRowLayout::new(
+                                                row_content_width,
+                                                row_height,
+                                                switch_width,
+                                            ),
+                                            crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.stay_active"),
+                                            true,
+                                            Some(crate::i18n::tr_catalog(self.app_settings.language, "key_override_editor.stay_active_when_another_key_is_pressed")),
+                                            |ui| { crate::ui_style::settings_switch_sized_stable(ui, ("key_override_settings", "stay_active"), &mut edited.options.no_unregister_on_other_key_down, switch_size); },
+                                        ),
                                         _ => {}
                                     }
                     }

--- a/src/ui/layer_led_settings.rs
+++ b/src/ui/layer_led_settings.rs
@@ -147,8 +147,11 @@ impl EntropyApp {
                         .clamp(0.0, 100.0);
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
-                        content_width,
-                        row_height,
+                        crate::ui_style::SettingsListRowLayout::new(
+                            content_width,
+                            row_height,
+                            slider_control_width,
+                        ),
                         crate::i18n::tr_catalog(
                             self.app_settings.language,
                             "advanced_settings.led_brightness",
@@ -162,7 +165,6 @@ impl EntropyApp {
                                 "advanced_settings.global_led_brightness_for_layer_color_lighting",
                             ))
                         },
-                        slider_control_width,
                         |ui| {
                             let value_text = format!("{}%", value.round() as u8);
                             if self.draw_layer_led_slider_control(
@@ -219,8 +221,11 @@ impl EntropyApp {
                     };
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
-                        content_width,
-                        row_height,
+                        crate::ui_style::SettingsListRowLayout::new(
+                            content_width,
+                            row_height,
+                            slider_control_width,
+                        ),
                         crate::i18n::tr_catalog(
                             self.app_settings.language,
                             "advanced_settings.led_timeout",
@@ -234,7 +239,6 @@ impl EntropyApp {
                                 tooltip_key,
                             ))
                         },
-                        slider_control_width,
                         |ui| {
                             let value_text = if value.round() as u16 == 0 {
                                 crate::i18n::tr_catalog(
@@ -439,8 +443,7 @@ impl EntropyApp {
             .min((LAYER_LED_PALETTE.len() - 1) as u16) as u8;
         crate::ui_style::settings_list_row_with_tooltip(
             ui,
-            content_width,
-            row_height,
+            crate::ui_style::SettingsListRowLayout::new(content_width, row_height, swatch_width),
             label,
             true,
             if suppress_tooltips {
@@ -448,7 +451,6 @@ impl EntropyApp {
             } else {
                 Some(tooltip)
             },
-            swatch_width,
             |ui| {
                 let dark = ui.visuals().dark_mode;
                 let popup_id = match target {

--- a/src/ui/layout_image_export.rs
+++ b/src/ui/layout_image_export.rs
@@ -580,12 +580,14 @@ impl EntropyApp {
                     let mut format = before;
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
-                        content_width,
-                        row_height,
+                        crate::ui_style::SettingsListRowLayout::new(
+                            content_width,
+                            row_height,
+                            metrics.settings_control_width(),
+                        ),
                         export_text(lang, "format"),
                         true,
                         tooltip(export_text(lang, "format_tooltip")),
-                        metrics.settings_control_width(),
                         |ui| draw_format_dropdown(ui, metrics, dark, lang, &mut format),
                     );
                     if format != before {
@@ -598,12 +600,14 @@ impl EntropyApp {
                     let mut theme = before;
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
-                        content_width,
-                        row_height,
+                        crate::ui_style::SettingsListRowLayout::new(
+                            content_width,
+                            row_height,
+                            metrics.settings_control_width(),
+                        ),
                         export_text(lang, "theme"),
                         true,
                         tooltip(export_text(lang, "theme_tooltip")),
-                        metrics.settings_control_width(),
                         |ui| draw_theme_dropdown(ui, metrics, dark, lang, &mut theme),
                     );
                     if theme != before {
@@ -616,12 +620,14 @@ impl EntropyApp {
                     let mut key_legend_layout = before;
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
-                        content_width,
-                        row_height,
+                        crate::ui_style::SettingsListRowLayout::new(
+                            content_width,
+                            row_height,
+                            metrics.settings_control_width(),
+                        ),
                         export_text(lang, "legends"),
                         true,
                         tooltip(export_text(lang, "legends_tooltip")),
-                        metrics.settings_control_width(),
                         |ui| {
                             draw_key_legend_dropdown(
                                 ui,
@@ -642,12 +648,14 @@ impl EntropyApp {
                     let mut show_layer_names = before;
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
-                        content_width,
-                        row_height,
+                        crate::ui_style::SettingsListRowLayout::new(
+                            content_width,
+                            row_height,
+                            switch_width,
+                        ),
                         export_text(lang, "layer_names"),
                         true,
                         tooltip(export_text(lang, "layer_names_tooltip")),
-                        switch_width,
                         |ui| {
                             let _ = crate::ui_style::settings_switch_sized_stable(
                                 ui,
@@ -677,12 +685,14 @@ impl EntropyApp {
                     let label = layer_export_label(lang, &self.layer_names, layer_idx);
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
-                        content_width,
-                        row_height,
+                        crate::ui_style::SettingsListRowLayout::new(
+                            content_width,
+                            row_height,
+                            switch_width,
+                        ),
                         label.as_str(),
                         true,
                         tooltip(export_text(lang, "layer_tooltip")),
-                        switch_width,
                         |ui| {
                             let _ = crate::ui_style::settings_switch_sized_stable(
                                 ui,

--- a/src/ui/layout_options_settings.rs
+++ b/src/ui/layout_options_settings.rs
@@ -100,15 +100,17 @@ impl EntropyApp {
                             let mut enabled = values.get(row_idx).copied().unwrap_or(0) != 0;
                             crate::ui_style::settings_list_row_with_tooltip(
                                 ui,
-                                row_content_width,
-                                row_height,
+                                crate::ui_style::SettingsListRowLayout::new(
+                                    row_content_width,
+                                    row_height,
+                                    switch_width,
+                                ),
                                 translated_option_label.as_str(),
                                 true,
                                 Some(crate::i18n::tr_catalog(
                                     self.app_settings.language,
                                     "auto_shift_settings.toggle_firmware_layout_display_option",
                                 )),
-                                switch_width,
                                 |ui| {
                                     let resp = crate::ui_style::settings_switch_sized_stable(
                                         ui,
@@ -148,12 +150,14 @@ impl EntropyApp {
                             };
                             crate::ui_style::settings_list_row_with_tooltip(
                                 ui,
-                                row_content_width,
-                                row_height,
+                                crate::ui_style::SettingsListRowLayout::new(
+                                    row_content_width,
+                                    row_height,
+                                    dropdown_width,
+                                ),
                                 translated_label,
                                 true,
                                 Some(&tooltip),
-                                dropdown_width,
                                 |ui| {
                                     let dropdown_id =
                                         ui.make_persistent_id(("layout_option_dropdown", row_idx));

--- a/src/ui/live_features_settings.rs
+++ b/src/ui/live_features_settings.rs
@@ -59,12 +59,14 @@ impl EntropyApp {
         };
         crate::ui_style::settings_list_row_with_tooltip(
             ui,
-            metrics.settings_row_content_width(),
-            metrics.settings_row_height(),
+            crate::ui_style::SettingsListRowLayout::new(
+                metrics.settings_row_content_width(),
+                metrics.settings_row_height(),
+                metrics.settings_control_width(),
+            ),
             label,
             true,
             hint,
-            metrics.settings_control_width(),
             |ui| {
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     ui.label(
@@ -100,15 +102,17 @@ impl EntropyApp {
         let switch_size = metrics.size(46.0, 24.0);
         crate::ui_style::settings_list_row_with_tooltip(
             ui,
-            metrics.settings_row_content_width(),
-            metrics.settings_row_height(),
+            crate::ui_style::SettingsListRowLayout::new(
+                metrics.settings_row_content_width(),
+                metrics.settings_row_height(),
+                metrics.settings_control_width(),
+            ),
             crate::i18n::tr_catalog(lang, "live_features.layout_sync"),
             true,
             Some(crate::i18n::tr_catalog(
                 lang,
                 "live_features.layout_sync_tooltip",
             )),
-            metrics.settings_control_width(),
             |ui| {
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     let _ = crate::ui_style::settings_switch_sized_stable(

--- a/src/ui/magic_settings.rs
+++ b/src/ui/magic_settings.rs
@@ -214,8 +214,11 @@ impl EntropyApp {
             let mut value = self.magic_settings.bit(bit);
             crate::ui_style::settings_list_row_with_tooltip(
                 ui,
-                content_width,
-                row_height,
+                crate::ui_style::SettingsListRowLayout::new(
+                    content_width,
+                    row_height,
+                    switch_width,
+                ),
                 label.as_str(),
                 true,
                 if suppress_tooltips {
@@ -223,7 +226,6 @@ impl EntropyApp {
                 } else {
                     Some(tooltip.as_str())
                 },
-                switch_width,
                 |ui| {
                     let resp = crate::ui_style::settings_switch_sized_stable(
                         ui,

--- a/src/ui/module_settings.rs
+++ b/src/ui/module_settings.rs
@@ -261,12 +261,14 @@ impl EntropyApp {
                 let mut checked = raw_value & mask != 0;
                 crate::ui_style::settings_list_row_with_tooltip(
                     ui,
-                    content_width,
-                    row_height,
+                    crate::ui_style::SettingsListRowLayout::new(
+                        content_width,
+                        row_height,
+                        switch_width,
+                    ),
                     label.as_str(),
                     true,
                     tooltip.as_deref(),
-                    switch_width,
                     |ui| {
                         let resp = crate::ui_style::settings_switch_sized_stable(
                             ui,
@@ -289,12 +291,14 @@ impl EntropyApp {
                 let field_width = metrics.value(86.0);
                 crate::ui_style::settings_list_row_with_tooltip(
                     ui,
-                    content_width,
-                    row_height,
+                    crate::ui_style::SettingsListRowLayout::new(
+                        content_width,
+                        row_height,
+                        field_width,
+                    ),
                     label.as_str(),
                     true,
                     tooltip.as_deref(),
-                    field_width,
                     |ui| {
                         let edit_id = egui::Id::new(("module_setting_edit", group_idx, field.qsid));
                         let current = raw_value.clamp(field.min, field.max);
@@ -351,12 +355,14 @@ impl EntropyApp {
                     .collect::<Vec<_>>();
                 crate::ui_style::settings_list_row_with_tooltip(
                     ui,
-                    content_width,
-                    row_height,
+                    crate::ui_style::SettingsListRowLayout::new(
+                        content_width,
+                        row_height,
+                        dropdown_width,
+                    ),
                     label.as_str(),
                     true,
                     tooltip.as_deref(),
-                    dropdown_width,
                     |ui| {
                         let dropdown_id = ui.make_persistent_id((
                             "module_setting_dropdown",
@@ -605,12 +611,10 @@ impl EntropyApp {
         });
         crate::ui_style::settings_list_row_with_tooltip(
             ui,
-            content_width,
-            row_height,
+            crate::ui_style::SettingsListRowLayout::new(content_width, row_height, dropdown_width),
             crate::i18n::tr_catalog(lang, "modules_settings.module_side"),
             true,
             tooltip.as_deref(),
-            dropdown_width,
             |ui| {
                 let dropdown_id = ui.make_persistent_id("module_settings_side_dropdown");
                 let (_, picked) = Self::draw_touchpad_select_control(

--- a/src/ui/mouse_keys_settings.rs
+++ b/src/ui/mouse_keys_settings.rs
@@ -181,8 +181,7 @@ impl EntropyApp {
 
             crate::ui_style::settings_list_row_with_tooltip(
                 ui,
-                content_width,
-                row_height,
+                crate::ui_style::SettingsListRowLayout::new(content_width, row_height, field_width),
                 crate::i18n::tr_catalog(lang, label),
                 true,
                 if suppress_tooltips {
@@ -190,7 +189,6 @@ impl EntropyApp {
                 } else {
                     Some(crate::i18n::tr_catalog(lang, tooltip))
                 },
-                field_width,
                 |ui| {
                     let edit_id = egui::Id::new(("mouse_keys_edit", qsid));
                     let mut text = ui.ctx().data_mut(|d| {

--- a/src/ui/tap_hold_settings.rs
+++ b/src/ui/tap_hold_settings.rs
@@ -468,8 +468,11 @@ impl EntropyApp {
                     .unwrap_or_else(|| self.tap_hold_bool_value(qsid));
                 crate::ui_style::settings_list_row_with_tooltip(
                     ui,
-                    content_width,
-                    row_height,
+                    crate::ui_style::SettingsListRowLayout::new(
+                        content_width,
+                        row_height,
+                        switch_width,
+                    ),
                     label,
                     true,
                     if suppress_tooltips {
@@ -477,7 +480,6 @@ impl EntropyApp {
                     } else {
                         Some(tooltip)
                     },
-                    switch_width,
                     |ui| {
                         let resp = crate::ui_style::settings_switch_sized_stable(
                             ui,
@@ -498,8 +500,11 @@ impl EntropyApp {
                 let current = self.pending_settings_write_value(qsid).unwrap_or(current);
                 crate::ui_style::settings_list_row_with_tooltip(
                     ui,
-                    content_width,
-                    row_height,
+                    crate::ui_style::SettingsListRowLayout::new(
+                        content_width,
+                        row_height,
+                        field_width,
+                    ),
                     label,
                     true,
                     if suppress_tooltips {
@@ -507,7 +512,6 @@ impl EntropyApp {
                     } else {
                         Some(tooltip)
                     },
-                    field_width,
                     |ui| {
                         let edit_id = egui::Id::new((
                             match kind {

--- a/src/ui/text_expander_editor.rs
+++ b/src/ui/text_expander_editor.rs
@@ -57,15 +57,17 @@ impl EntropyApp {
                 let mut enabled = self.app_settings.text_expander_enabled;
                 crate::ui_style::settings_list_row_with_tooltip(
                     ui,
-                    content_width,
-                    row_height,
+                    crate::ui_style::SettingsListRowLayout::new(
+                        content_width,
+                        row_height,
+                        switch_width,
+                    ),
                     crate::i18n::tr_catalog(lang, "text_expander.enabled_label"),
                     true,
                     tooltip(crate::i18n::tr_catalog(
                         lang,
                         "text_expander.enabled_tooltip",
                     )),
-                    switch_width,
                     |ui| {
                         crate::ui_style::settings_switch_sized_stable(
                             ui,
@@ -91,15 +93,17 @@ impl EntropyApp {
                 let mut remove_app: Option<String> = None;
                 crate::ui_style::settings_list_row_with_tooltip(
                     ui,
-                    content_width,
-                    row_height,
+                    crate::ui_style::SettingsListRowLayout::new(
+                        content_width,
+                        row_height,
+                        control_width,
+                    ),
                     crate::i18n::tr_catalog(lang, "text_expander.blacklist_label"),
                     true,
                     tooltip(crate::i18n::tr_catalog(
                         lang,
                         "text_expander.blacklist_tooltip",
                     )),
-                    control_width,
                     |ui| {
                         let control_rect = ui.max_rect();
                         let dark = ui.visuals().dark_mode;
@@ -491,15 +495,17 @@ impl EntropyApp {
                 let button_width = metrics.value(118.0);
                 crate::ui_style::settings_list_row_with_tooltip(
                     ui,
-                    content_width,
-                    row_height,
+                    crate::ui_style::SettingsListRowLayout::new(
+                        content_width,
+                        row_height,
+                        button_width,
+                    ),
                     crate::i18n::tr_catalog(lang, "text_expander.rules_file_label"),
                     true,
                     tooltip(crate::i18n::tr_catalog(
                         lang,
                         "text_expander.rules_file_tooltip",
                     )),
-                    button_width,
                     |ui| {
                         if crate::ui_style::modern_button(
                             ui,
@@ -522,15 +528,17 @@ impl EntropyApp {
                 let mut remove_file: Option<usize> = None;
                 crate::ui_style::settings_list_row_with_tooltip(
                     ui,
-                    content_width,
-                    row_height,
+                    crate::ui_style::SettingsListRowLayout::new(
+                        content_width,
+                        row_height,
+                        control_width,
+                    ),
                     crate::i18n::tr_catalog(lang, "text_expander.extra_rules_file_label"),
                     true,
                     tooltip(crate::i18n::tr_catalog(
                         lang,
                         "text_expander.extra_rules_file_select_tooltip",
                     )),
-                    control_width,
                     |ui| {
                         let control_rect = ui.max_rect();
                         let dark = ui.visuals().dark_mode;
@@ -943,15 +951,17 @@ impl EntropyApp {
                 let control_width = metrics.value(250.0);
                 crate::ui_style::settings_list_row_with_tooltip(
                     ui,
-                    content_width,
-                    row_height,
+                    crate::ui_style::SettingsListRowLayout::new(
+                        content_width,
+                        row_height,
+                        control_width,
+                    ),
                     crate::i18n::tr_catalog(lang, "text_expander.empty_rules_label"),
                     true,
                     tooltip(crate::i18n::tr_catalog(
                         lang,
                         "text_expander.empty_rules_tooltip",
                     )),
-                    control_width,
                     |ui| {
                         let rect = ui.max_rect();
                         ui.painter().text(
@@ -986,12 +996,14 @@ impl EntropyApp {
                 .unwrap_or_else(|| crate::i18n::tr_catalog(lang, "text_expander.rule_tooltip"));
             crate::ui_style::settings_list_row_with_tooltip(
                 ui,
-                content_width,
-                row_height,
+                crate::ui_style::SettingsListRowLayout::new(
+                    content_width,
+                    row_height,
+                    control_width,
+                ),
                 label.as_str(),
                 true,
                 tooltip(rule_tooltip),
-                control_width,
                 |ui| {
                     let control_rect = ui.max_rect();
                     let field_height = metrics.settings_control_height();

--- a/src/ui/touchpad_settings.rs
+++ b/src/ui/touchpad_settings.rs
@@ -189,8 +189,11 @@ impl EntropyApp {
                         (self.touchpad_settings.dpi as usize).min(variants.len().saturating_sub(1));
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
-                        content_width,
-                        row_height,
+                        crate::ui_style::SettingsListRowLayout::new(
+                            content_width,
+                            row_height,
+                            dropdown_width + status_width,
+                        ),
                         label,
                         true,
                         if suppress_tooltips {
@@ -201,7 +204,6 @@ impl EntropyApp {
                                 "touchpad_settings.touchpad_pointer_resolution_in_dots_per_inch",
                             ))
                         },
-                        dropdown_width + status_width,
                         |ui| {
                             self.draw_settings_write_status(ui, 120, metrics, suppress_tooltips);
                             if variants.is_empty() {
@@ -320,8 +322,11 @@ impl EntropyApp {
                     let mut value = current as f32;
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
-                        content_width,
-                        row_height,
+                        crate::ui_style::SettingsListRowLayout::new(
+                            content_width,
+                            row_height,
+                            slider_control_width + status_width,
+                        ),
                         label,
                         true,
                         if suppress_tooltips {
@@ -329,7 +334,6 @@ impl EntropyApp {
                         } else {
                             Some(tooltip)
                         },
-                        slider_control_width + status_width,
                         |ui| {
                             self.draw_settings_write_status(ui, qsid, metrics, suppress_tooltips);
                             ui.spacing_mut().item_spacing.x = 0.0;
@@ -405,8 +409,11 @@ impl EntropyApp {
                     };
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
-                        content_width,
-                        row_height,
+                        crate::ui_style::SettingsListRowLayout::new(
+                            content_width,
+                            row_height,
+                            switch_width + status_width,
+                        ),
                         label,
                         true,
                         if suppress_tooltips {
@@ -414,7 +421,6 @@ impl EntropyApp {
                         } else {
                             Some(tooltip)
                         },
-                        switch_width + status_width,
                         |ui| {
                             self.draw_settings_write_status(ui, 124, metrics, suppress_tooltips);
                             let old_bits = self.touchpad_settings.bits;
@@ -439,8 +445,11 @@ impl EntropyApp {
                     );
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
-                        content_width,
-                        row_height,
+                        crate::ui_style::SettingsListRowLayout::new(
+                            content_width,
+                            row_height,
+                            switch_width + status_width,
+                        ),
                         label,
                         true,
                         if suppress_tooltips {
@@ -448,7 +457,6 @@ impl EntropyApp {
                         } else {
                             Some(crate::i18n::tr_catalog(self.app_settings.language, "touchpad_settings.automatically_switch_to_the_selected_layer_while_the_touchpad_is_activ"))
                         },
-                        switch_width + status_width,
                         |ui| {
                             self.draw_settings_write_status(ui, 142, metrics, suppress_tooltips);
                             let mut value = self.touchpad_settings.auto_layer_enable;
@@ -476,8 +484,11 @@ impl EntropyApp {
                         .min(variants.len().saturating_sub(1));
                     crate::ui_style::settings_list_row_with_tooltip(
                         ui,
-                        content_width,
-                        row_height,
+                        crate::ui_style::SettingsListRowLayout::new(
+                            content_width,
+                            row_height,
+                            dropdown_width + status_width,
+                        ),
                         label,
                         true,
                         if suppress_tooltips {
@@ -488,7 +499,6 @@ impl EntropyApp {
                                 "touchpad_settings.layer_selected_automatically_while_the_touchpad_is_active",
                             ))
                         },
-                        dropdown_width + status_width,
                         |ui| {
                             self.draw_settings_write_status(ui, 143, metrics, suppress_tooltips);
                             let dropdown_id = ui.make_persistent_id("touchpad_auto_layer_dropdown");

--- a/src/ui/universal_symbols_setup.rs
+++ b/src/ui/universal_symbols_setup.rs
@@ -301,12 +301,14 @@ impl EntropyApp {
         match row_idx {
             0 => crate::ui_style::settings_list_row_with_tooltip(
                 ui,
-                row.content_width,
-                row.height,
+                crate::ui_style::SettingsListRowLayout::new(
+                    row.content_width,
+                    row.height,
+                    row.metrics.settings_control_width(),
+                ),
                 crate::i18n::tr_catalog(row.lang, "universal_symbols_setup.current_backend"),
                 true,
                 tooltip("universal_symbols_setup.current_backend_tooltip"),
-                row.metrics.settings_control_width(),
                 |ui| {
                     draw_universal_symbols_value(
                         ui,
@@ -322,24 +324,28 @@ impl EntropyApp {
             3 => self.draw_macos_event_capture_status_row(ui, row),
             4 => crate::ui_style::settings_list_row_with_tooltip(
                 ui,
-                row.content_width,
-                row.height,
+                crate::ui_style::SettingsListRowLayout::new(
+                    row.content_width,
+                    row.height,
+                    row.metrics.settings_control_width(),
+                ),
                 crate::i18n::tr_catalog(row.lang, "universal_symbols_setup.recommended_setup"),
                 true,
                 tooltip("universal_symbols_setup.recommended_setup_tooltip"),
-                row.metrics.settings_control_width(),
                 |ui| self.draw_universal_symbols_recommended_control(ui, row.metrics, row.lang),
             ),
             5 => draw_universal_symbols_finish_step_row(ui, row, universal_symbols_finish_step_2()),
             6 => draw_universal_symbols_finish_step_row(ui, row, universal_symbols_finish_step_3()),
             7 => crate::ui_style::settings_list_row_with_tooltip(
                 ui,
-                row.content_width,
-                row.height,
+                crate::ui_style::SettingsListRowLayout::new(
+                    row.content_width,
+                    row.height,
+                    row.metrics.value(220.0),
+                ),
                 crate::i18n::tr_catalog(row.lang, "universal_symbols_setup.text_expander"),
                 true,
                 tooltip("universal_symbols_setup.text_expander_tooltip"),
-                row.metrics.value(220.0),
                 |ui| {
                     draw_universal_symbols_value(
                         ui,
@@ -401,12 +407,14 @@ impl EntropyApp {
 
         crate::ui_style::settings_list_row_with_tooltip(
             ui,
-            row_content_width,
-            row_height,
+            crate::ui_style::SettingsListRowLayout::new(
+                row_content_width,
+                row_height,
+                metrics.settings_control_width(),
+            ),
             crate::i18n::tr_catalog(lang, "universal_symbols_setup.current_backend"),
             true,
             tooltip("universal_symbols_setup.current_backend_tooltip"),
-            metrics.settings_control_width(),
             |ui| {
                 draw_universal_symbols_value(
                     ui,
@@ -420,12 +428,14 @@ impl EntropyApp {
 
         crate::ui_style::settings_list_row_with_tooltip(
             ui,
-            row_content_width,
-            row_height,
+            crate::ui_style::SettingsListRowLayout::new(
+                row_content_width,
+                row_height,
+                metrics.settings_control_width(),
+            ),
             crate::i18n::tr_catalog(lang, "universal_symbols_setup.recommended_setup"),
             true,
             tooltip("universal_symbols_setup.recommended_setup_tooltip"),
-            metrics.settings_control_width(),
             |ui| self.draw_universal_symbols_recommended_control(ui, metrics, lang),
         );
 
@@ -441,12 +451,14 @@ impl EntropyApp {
 
         crate::ui_style::settings_list_row_with_tooltip(
             ui,
-            row_content_width,
-            row_height,
+            crate::ui_style::SettingsListRowLayout::new(
+                row_content_width,
+                row_height,
+                metrics.value(220.0),
+            ),
             crate::i18n::tr_catalog(lang, "universal_symbols_setup.text_expander"),
             true,
             tooltip("universal_symbols_setup.text_expander_tooltip"),
-            metrics.value(220.0),
             |ui| {
                 draw_universal_symbols_value(
                     ui,
@@ -667,13 +679,15 @@ impl EntropyApp {
 
         crate::ui_style::settings_list_row_with_tooltip(
             ui,
-            row.content_width,
-            row.height,
+            crate::ui_style::SettingsListRowLayout::new(
+                row.content_width,
+                row.height,
+                row.metrics.value(250.0),
+            ),
             crate::i18n::tr_catalog(row.lang, permission.label_key),
             true,
             (!row.suppress_tooltips)
                 .then_some(crate::i18n::tr_catalog(row.lang, permission.tooltip_key)),
-            row.metrics.value(250.0),
             |ui| {
                 draw_universal_symbols_value(
                     ui,
@@ -700,15 +714,17 @@ impl EntropyApp {
 
         crate::ui_style::settings_list_row_with_tooltip(
             ui,
-            row.content_width,
-            row.height,
+            crate::ui_style::SettingsListRowLayout::new(
+                row.content_width,
+                row.height,
+                row.metrics.value(250.0),
+            ),
             crate::i18n::tr_catalog(row.lang, "universal_symbols_setup.event_capture_status"),
             true,
             (!row.suppress_tooltips).then_some(crate::i18n::tr_catalog(
                 row.lang,
                 "universal_symbols_setup.event_capture_status_tooltip",
             )),
-            row.metrics.value(250.0),
             |ui| {
                 let status_label = if status.event_tap_active {
                     active
@@ -894,12 +910,14 @@ fn draw_universal_symbols_finish_step_row(
 ) {
     crate::ui_style::settings_list_row_with_tooltip(
         ui,
-        row.content_width,
-        row.height,
+        crate::ui_style::SettingsListRowLayout::new(
+            row.content_width,
+            row.height,
+            row.metrics.value(250.0),
+        ),
         crate::i18n::tr_catalog(row.lang, step.label_key),
         true,
         Some(crate::i18n::tr_catalog(row.lang, step.tooltip_key)),
-        row.metrics.value(250.0),
         |ui| {
             if let Some(detail_key) = step.detail_key {
                 draw_universal_symbols_two_line_value(
@@ -941,12 +959,14 @@ fn draw_universal_symbols_action_row_with_tooltip_state(
     let mut clicked = false;
     crate::ui_style::settings_list_row_with_tooltip(
         ui,
-        row.content_width,
-        row.height,
+        crate::ui_style::SettingsListRowLayout::new(
+            row.content_width,
+            row.height,
+            row.metrics.settings_control_width(),
+        ),
         crate::i18n::tr_catalog(row.lang, action.label_key),
         true,
         (!row.suppress_tooltips).then_some(crate::i18n::tr_catalog(row.lang, action.tooltip_key)),
-        row.metrics.settings_control_width(),
         |ui| {
             clicked = crate::ui_style::modern_button(
                 ui,

--- a/src/ui_style.rs
+++ b/src/ui_style.rs
@@ -962,6 +962,23 @@ pub fn modal_centered_text_block(ui: &mut Ui, width: f32, add_contents: impl FnO
     });
 }
 
+#[derive(Clone, Copy)]
+pub struct SettingsListRowLayout {
+    content_width: f32,
+    row_height: f32,
+    control_width: f32,
+}
+
+impl SettingsListRowLayout {
+    pub const fn new(content_width: f32, row_height: f32, control_width: f32) -> Self {
+        Self {
+            content_width,
+            row_height,
+            control_width,
+        }
+    }
+}
+
 pub fn settings_list_row(
     ui: &mut Ui,
     content_width: f32,
@@ -973,36 +990,34 @@ pub fn settings_list_row(
 ) {
     settings_list_row_with_tooltip(
         ui,
-        content_width,
-        row_height,
+        SettingsListRowLayout::new(content_width, row_height, control_width),
         label,
         label_enabled,
         None,
-        control_width,
         add_control,
     );
 }
 
 pub fn settings_list_row_with_tooltip(
     ui: &mut Ui,
-    content_width: f32,
-    row_height: f32,
+    layout: SettingsListRowLayout,
     label: &str,
     label_enabled: bool,
     tooltip: Option<&str>,
-    control_width: f32,
     add_control: impl FnOnce(&mut Ui),
 ) {
     let dark = ui.visuals().dark_mode;
-    let (row_rect, _) =
-        ui.allocate_exact_size(egui::vec2(content_width, row_height), egui::Sense::hover());
+    let (row_rect, _) = ui.allocate_exact_size(
+        egui::vec2(layout.content_width, layout.row_height),
+        egui::Sense::hover(),
+    );
     let separator = border_color(dark).gamma_multiply(if dark { 0.72 } else { 0.9 });
     ui.painter().line_segment(
         [row_rect.left_bottom(), row_rect.right_bottom()],
         Stroke::new(1.0_f32, separator),
     );
 
-    let label_scale = (content_width / 452.0).clamp(1.0, 1.12);
+    let label_scale = (layout.content_width / 452.0).clamp(1.0, 1.12);
     let label_color = if label_enabled {
         ui.visuals().text_color()
     } else {
@@ -1018,7 +1033,7 @@ pub fn settings_list_row_with_tooltip(
 
     if let Some(tooltip) = tooltip {
         let text_width = (label.chars().count() as f32 * 7.4 * label_scale + 8.0)
-            .min((content_width - control_width - 20.0).max(0.0));
+            .min((layout.content_width - layout.control_width - 20.0).max(0.0));
         let label_rect = egui::Rect::from_center_size(
             egui::pos2(
                 row_rect.left() + 2.0 + text_width / 2.0,
@@ -1039,11 +1054,11 @@ pub fn settings_list_row_with_tooltip(
     }
 
     let control_rect = egui::Rect::from_min_size(
-        egui::pos2(row_rect.right() - control_width, row_rect.top()),
-        egui::vec2(control_width, row_height),
+        egui::pos2(row_rect.right() - layout.control_width, row_rect.top()),
+        egui::vec2(layout.control_width, layout.row_height),
     );
     crate::ui_style::allocate_ui_at_rect(ui, control_rect, |ui| {
-        ui.set_min_size(egui::vec2(control_width, row_height));
+        ui.set_min_size(egui::vec2(layout.control_width, layout.row_height));
         ui.with_layout(
             egui::Layout::left_to_right(egui::Align::Center),
             add_control,


### PR DESCRIPTION
### Problem

`settings_list_row_with_tooltip` accepted eight positional inputs, including three coupled layout dimensions, at 89 UI call sites. That obscured the row geometry and emitted a `clippy::too_many_arguments` diagnostic.

### Fix

- Add `SettingsListRowLayout` to model a row's content width, height, and control width as one typed value.
- Migrate all 89 callers without changing their label, tooltip, control, or geometry values.

### Verification

- `cargo clippy --locked --all-targets` passes; the current workspace reports 68 non-blocking warnings and none for `settings_list_row_with_tooltip`.
- `cargo test --locked -- --test-threads=1` passed (456 tests).
- Argument equivalence against `origin/main` passed for all 89 callers; scoped `rustfmt --check` and `git diff --check` also passed.