### PR TITLE
chore: reduce app and settings Clippy warnings

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -3101,7 +3101,11 @@ fn typing_trainer_number_token(seed: usize, idx: usize) -> String {
 }
 
 fn typing_trainer_should_append_punctuation(seed: usize, idx: usize, word_count: usize) -> bool {
-    idx + 1 < word_count && seed.wrapping_add(idx * 17).wrapping_add(idx / 4) % 5 == 0
+    idx + 1 < word_count
+        && seed
+            .wrapping_add(idx * 17)
+            .wrapping_add(idx / 4)
+            .is_multiple_of(5)
 }
 
 fn typing_trainer_punctuation_mark(seed: usize, idx: usize) -> char {
@@ -4102,8 +4106,10 @@ mod layout_image_export_persist_tests {
 
     #[test]
     fn pdf_persists_backward_compatibly() {
-        let mut state = LayoutImageExportState::default();
-        state.format = LayoutImageExportFormat::Pdf;
+        let state = LayoutImageExportState {
+            format: LayoutImageExportFormat::Pdf,
+            ..Default::default()
+        };
         let json = serde_json::to_value(&state).unwrap();
         // A pre-PDF build only understands png/svg for `format`; PDF is stored
         // in the ignored `export_pdf` sidecar so it can't break their parsing.
@@ -4117,8 +4123,10 @@ mod layout_image_export_persist_tests {
             (LayoutImageExportFormat::Png, "png"),
             (LayoutImageExportFormat::Svg, "svg"),
         ] {
-            let mut state = LayoutImageExportState::default();
-            state.format = fmt;
+            let state = LayoutImageExportState {
+                format: fmt,
+                ..Default::default()
+            };
             let json = serde_json::to_value(&state).unwrap();
             assert_eq!(json["format"], expected);
             assert_eq!(json["export_pdf"], false);
@@ -4132,8 +4140,10 @@ mod layout_image_export_persist_tests {
             LayoutImageExportFormat::Svg,
             LayoutImageExportFormat::Pdf,
         ] {
-            let mut state = LayoutImageExportState::default();
-            state.format = fmt;
+            let state = LayoutImageExportState {
+                format: fmt,
+                ..Default::default()
+            };
             let json = serde_json::to_string(&state).unwrap();
             let back: LayoutImageExportState = serde_json::from_str(&json).unwrap();
             assert_eq!(back.format, fmt);

--- a/src/app_update.rs
+++ b/src/app_update.rs
@@ -29,8 +29,9 @@ pub(crate) enum UpdateCheckOutcome {
     Failed(String),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub(crate) enum UpdateCheckState {
+    #[default]
     Idle,
     Checking {
         #[cfg(not(target_arch = "wasm32"))]
@@ -38,12 +39,6 @@ pub(crate) enum UpdateCheckState {
     },
     Ready(UpdateCheckResult),
     Failed(String),
-}
-
-impl Default for UpdateCheckState {
-    fn default() -> Self {
-        Self::Idle
-    }
 }
 
 #[derive(serde::Deserialize)]

--- a/src/smart_input.rs
+++ b/src/smart_input.rs
@@ -219,11 +219,6 @@ pub fn text_expander_runs_outside_entropy_process() -> bool {
     matches!(linux_session_kind(), LinuxSessionKind::Wayland)
 }
 
-#[cfg(not(target_os = "linux"))]
-pub fn text_expander_runs_outside_entropy_process() -> bool {
-    false
-}
-
 #[cfg(target_os = "linux")]
 fn linux_input_method_hint() -> &'static str {
     let combined = linux_input_method_env();

--- a/src/ui/device_deferred_load.rs
+++ b/src/ui/device_deferred_load.rs
@@ -1249,12 +1249,10 @@ impl EntropyApp {
                         let status = self.deferred_device_load.section_status(section);
                         (!status.ready()).then_some(DeferredOverlayTarget::Section(section, status))
                     })
-                    .unwrap_or_else(|| {
-                        DeferredOverlayTarget::Layer(
-                            self.selected_layer,
-                            DeferredLoadStatus::Loaded,
-                        )
-                    })
+                    .unwrap_or(DeferredOverlayTarget::Layer(
+                        self.selected_layer,
+                        DeferredLoadStatus::Loaded,
+                    ))
             } else {
                 DeferredOverlayTarget::Layer(self.selected_layer, DeferredLoadStatus::Loaded)
             }

--- a/src/ui/module_settings.rs
+++ b/src/ui/module_settings.rs
@@ -235,15 +235,15 @@ impl EntropyApp {
         let old_value = self.module_settings.value(field.qsid);
         let requested = Self::module_setting_transport_value(field, value);
 
-        self.queue_module_setting_write(
+        self.queue_module_setting_write(super::settings_write_queue::ModuleSettingWrite {
             group_title,
             field_title,
             display_label,
-            field.qsid,
-            field.width,
+            qsid: field.qsid,
+            width: field.width,
             old_value,
             requested,
-        );
+        });
         self.sync_firmware_managed_layout_options();
     }
 

--- a/src/ui/settings_write_queue.rs
+++ b/src/ui/settings_write_queue.rs
@@ -35,6 +35,22 @@ enum SettingsWriteTarget {
     },
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct SettingsReadback {
+    qsid: u16,
+    value: u16,
+}
+
+pub(super) struct ModuleSettingWrite {
+    pub(super) group_title: String,
+    pub(super) field_title: String,
+    pub(super) display_label: String,
+    pub(super) qsid: u16,
+    pub(super) width: u8,
+    pub(super) old_value: u16,
+    pub(super) requested: u16,
+}
+
 impl SettingsWriteTarget {
     fn display_label(&self) -> &str {
         match self {
@@ -86,41 +102,41 @@ impl SettingsWriteTarget {
         tap_hold_settings: &mut TapHoldSettingsState,
         one_shot_settings: &mut OneShotSettingsState,
         layer_led_settings: &mut LayerLedSettingsState,
-        qsid: u16,
-        readback: u16,
+        readback: SettingsReadback,
     ) {
+        let SettingsReadback { qsid, value } = readback;
         match self {
-            Self::Module { .. } => module_settings.set_value(qsid, readback),
+            Self::Module { .. } => module_settings.set_value(qsid, value),
             Self::Touchpad { .. } => match qsid {
-                120 => touchpad_settings.dpi = readback,
-                121 => touchpad_settings.sniper_sens = readback.min(u8::MAX as u16) as u8,
-                122 => touchpad_settings.scroll_sens = readback.min(u8::MAX as u16) as u8,
-                123 => touchpad_settings.text_sens = readback.min(u8::MAX as u16) as u8,
-                124 => touchpad_settings.bits = readback.min(u8::MAX as u16) as u8,
-                142 => touchpad_settings.auto_layer_enable = readback != 0,
-                143 => touchpad_settings.auto_layer = readback.min(u8::MAX as u16) as u8,
+                120 => touchpad_settings.dpi = value,
+                121 => touchpad_settings.sniper_sens = value.min(u8::MAX as u16) as u8,
+                122 => touchpad_settings.scroll_sens = value.min(u8::MAX as u16) as u8,
+                123 => touchpad_settings.text_sens = value.min(u8::MAX as u16) as u8,
+                124 => touchpad_settings.bits = value.min(u8::MAX as u16) as u8,
+                142 => touchpad_settings.auto_layer_enable = value != 0,
+                143 => touchpad_settings.auto_layer = value.min(u8::MAX as u16) as u8,
                 _ => {}
             },
             Self::TapHold { .. } => match qsid {
-                7 => tap_hold_settings.tapping_term = readback,
-                18 => tap_hold_settings.tap_code_delay = readback,
-                19 => tap_hold_settings.tap_hold_caps_delay = readback,
-                20 => tap_hold_settings.tapping_toggle = readback,
-                22 => tap_hold_settings.permissive_hold = readback != 0,
-                23 => tap_hold_settings.hold_on_other_key_press = readback != 0,
-                24 => tap_hold_settings.retro_tapping = readback != 0,
-                25 => tap_hold_settings.quick_tap_term = readback,
-                26 => tap_hold_settings.chordal_hold = readback != 0,
-                27 => tap_hold_settings.flow_tap = readback,
+                7 => tap_hold_settings.tapping_term = value,
+                18 => tap_hold_settings.tap_code_delay = value,
+                19 => tap_hold_settings.tap_hold_caps_delay = value,
+                20 => tap_hold_settings.tapping_toggle = value,
+                22 => tap_hold_settings.permissive_hold = value != 0,
+                23 => tap_hold_settings.hold_on_other_key_press = value != 0,
+                24 => tap_hold_settings.retro_tapping = value != 0,
+                25 => tap_hold_settings.quick_tap_term = value,
+                26 => tap_hold_settings.chordal_hold = value != 0,
+                27 => tap_hold_settings.flow_tap = value,
                 _ => {}
             },
             Self::OneShot { .. } => match qsid {
-                5 => one_shot_settings.tap_toggle = readback.min(u8::MAX as u16) as u8,
-                6 => one_shot_settings.timeout = readback,
+                5 => one_shot_settings.tap_toggle = value.min(u8::MAX as u16) as u8,
+                6 => one_shot_settings.timeout = value,
                 _ => {}
             },
             Self::LayerLed { .. } => {
-                layer_led_settings.set_value(qsid, readback);
+                layer_led_settings.set_value(qsid, value);
             }
         }
     }
@@ -372,16 +388,16 @@ impl EntropyApp {
         }
     }
 
-    pub(super) fn queue_module_setting_write(
-        &mut self,
-        group_title: String,
-        field_title: String,
-        display_label: String,
-        qsid: u16,
-        width: u8,
-        old_value: u16,
-        requested: u16,
-    ) {
+    pub(super) fn queue_module_setting_write(&mut self, write: ModuleSettingWrite) {
+        let ModuleSettingWrite {
+            group_title,
+            field_title,
+            display_label,
+            qsid,
+            width,
+            old_value,
+            requested,
+        } = write;
         self.queue_settings_write(SettingsWriteRequest {
             id: 0,
             generation: self.settings_write_generation,
@@ -661,8 +677,10 @@ impl EntropyApp {
                         &mut self.tap_hold_settings,
                         &mut self.one_shot_settings,
                         &mut self.layer_led_settings,
-                        request.qsid,
-                        readback,
+                        SettingsReadback {
+                            qsid: request.qsid,
+                            value: readback,
+                        },
                     );
                     if request.target.is_touchpad() {
                         self.status_msg = crate::i18n::tr_catalog_format(
@@ -701,8 +719,10 @@ impl EntropyApp {
                             &mut self.tap_hold_settings,
                             &mut self.one_shot_settings,
                             &mut self.layer_led_settings,
-                            request.qsid,
-                            *actual,
+                            SettingsReadback {
+                                qsid: request.qsid,
+                                value: *actual,
+                            },
                         );
                     }
                     self.status_msg = crate::i18n::tr_catalog_format(
@@ -853,8 +873,7 @@ mod tests {
             &mut tap_hold_settings,
             &mut one_shot_settings,
             &mut layer_led_settings,
-            7,
-            3,
+            SettingsReadback { qsid: 7, value: 3 },
         );
         SettingsWriteTarget::Touchpad {
             display_label: "Scroll sensitivity".to_owned(),
@@ -865,8 +884,10 @@ mod tests {
             &mut tap_hold_settings,
             &mut one_shot_settings,
             &mut layer_led_settings,
-            122,
-            9,
+            SettingsReadback {
+                qsid: 122,
+                value: 9,
+            },
         );
         SettingsWriteTarget::TapHold {
             display_label: "Tap-hold timeout".to_owned(),
@@ -877,8 +898,10 @@ mod tests {
             &mut tap_hold_settings,
             &mut one_shot_settings,
             &mut layer_led_settings,
-            7,
-            175,
+            SettingsReadback {
+                qsid: 7,
+                value: 175,
+            },
         );
         SettingsWriteTarget::OneShot {
             display_label: "One-shot timeout".to_owned(),
@@ -889,8 +912,10 @@ mod tests {
             &mut tap_hold_settings,
             &mut one_shot_settings,
             &mut layer_led_settings,
-            6,
-            800,
+            SettingsReadback {
+                qsid: 6,
+                value: 800,
+            },
         );
         SettingsWriteTarget::LayerLed {
             display_label: "Layer LED brightness".to_owned(),
@@ -901,8 +926,10 @@ mod tests {
             &mut tap_hold_settings,
             &mut one_shot_settings,
             &mut layer_led_settings,
-            316,
-            128,
+            SettingsReadback {
+                qsid: 316,
+                value: 128,
+            },
         );
 
         assert_eq!(module_settings.value(7), 3);

--- a/src/ui/vial_hid_task.rs
+++ b/src/ui/vial_hid_task.rs
@@ -777,7 +777,7 @@ mod tests {
         assert_eq!(requests.len(), 5);
         assert!(requests
             .iter()
-            .all(|request| &request[..3] == [0x08, 0xE8, 0x01]));
+            .all(|request| request[..3] == [0x08, 0xE8, 0x01]));
     }
 
     #[test]
@@ -1045,15 +1045,15 @@ mod tests {
         assert!(app.hid_device.is_none());
         assert!(app.qmk_setting_transport_available());
 
-        app.queue_module_setting_write(
-            "Left Modules".to_owned(),
-            "Mode".to_owned(),
-            "Mode".to_owned(),
-            134,
-            1,
-            0,
-            3,
-        );
+        app.queue_module_setting_write(super::settings_write_queue::ModuleSettingWrite {
+            group_title: "Left Modules".to_owned(),
+            field_title: "Mode".to_owned(),
+            display_label: "Mode".to_owned(),
+            qsid: 134,
+            width: 1,
+            old_value: 0,
+            requested: 3,
+        });
         app.queue_layer_led_setting_write("Layer LED brightness".to_owned(), 316, 2, 32, 128);
 
         assert!(app.settings_write_task.is_none());


### PR DESCRIPTION
### Problem

Ten remaining Clippy diagnostics were spread across app state, update state, platform-specific smart input, deferred loading, firmware settings writes, and Vial tests. Two settings-write diagnostics came from long positional argument lists, where suppressing the lint would hide the warning without improving the API.

### Fix

- Group module-setting writes and readback identity into typed records, preserving every field mapping while removing both `too_many_arguments` diagnostics.
- Apply the remaining behavior-preserving Clippy rewrites for defaults, state initialization, divisibility, platform-gated dead code, eager fallback construction, and test assertions.
- No new `#[allow(clippy::...)]` attributes were added.

### Verification

- `cargo clippy --locked --all-targets` passes; warnings decreased from 60 to 54 for the binary and from 68 to 58 for the test target. All ten selected diagnostics are gone.
- 17 focused tests covering layout-image persistence, typing-trainer punctuation, settings readback and writes, deferred export targeting, background loading, and Vial battery transport passed.
- Scoped `rustfmt --check` and `git diff --check` pass.