### PR TITLE
chore: reduce default initialization Clippy warnings

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -100,15 +100,11 @@ pub(crate) enum CloseToTrayBehavior {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub(crate) enum StickyLayoutVisibilityMode {
+    #[default]
     LayoutAndPresses,
     PressedOnly,
-}
-
-impl Default for StickyLayoutVisibilityMode {
-    fn default() -> Self {
-        Self::LayoutAndPresses
-    }
 }
 
 pub(crate) fn default_show_shifted_number_symbols() -> bool {
@@ -2534,15 +2530,11 @@ pub(crate) use super::typing_trainer_words::{TypingTrainerLanguage, TYPING_TRAIN
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub(crate) enum TypingTrainerMode {
+    #[default]
     Time,
     Words,
-}
-
-impl Default for TypingTrainerMode {
-    fn default() -> Self {
-        Self::Time
-    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -4102,8 +4094,10 @@ mod layout_image_export_persist_tests {
 
     #[test]
     fn pdf_persists_backward_compatibly() {
-        let mut state = LayoutImageExportState::default();
-        state.format = LayoutImageExportFormat::Pdf;
+        let state = LayoutImageExportState {
+            format: LayoutImageExportFormat::Pdf,
+            ..Default::default()
+        };
         let json = serde_json::to_value(&state).unwrap();
         // A pre-PDF build only understands png/svg for `format`; PDF is stored
         // in the ignored `export_pdf` sidecar so it can't break their parsing.
@@ -4117,8 +4111,10 @@ mod layout_image_export_persist_tests {
             (LayoutImageExportFormat::Png, "png"),
             (LayoutImageExportFormat::Svg, "svg"),
         ] {
-            let mut state = LayoutImageExportState::default();
-            state.format = fmt;
+            let state = LayoutImageExportState {
+                format: fmt,
+                ..Default::default()
+            };
             let json = serde_json::to_value(&state).unwrap();
             assert_eq!(json["format"], expected);
             assert_eq!(json["export_pdf"], false);
@@ -4132,8 +4128,10 @@ mod layout_image_export_persist_tests {
             LayoutImageExportFormat::Svg,
             LayoutImageExportFormat::Pdf,
         ] {
-            let mut state = LayoutImageExportState::default();
-            state.format = fmt;
+            let state = LayoutImageExportState {
+                format: fmt,
+                ..Default::default()
+            };
             let json = serde_json::to_string(&state).unwrap();
             let back: LayoutImageExportState = serde_json::from_str(&json).unwrap();
             assert_eq!(back.format, fmt);

--- a/src/app_update.rs
+++ b/src/app_update.rs
@@ -29,8 +29,9 @@ pub(crate) enum UpdateCheckOutcome {
     Failed(String),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub(crate) enum UpdateCheckState {
+    #[default]
     Idle,
     Checking {
         #[cfg(not(target_arch = "wasm32"))]
@@ -38,12 +39,6 @@ pub(crate) enum UpdateCheckState {
     },
     Ready(UpdateCheckResult),
     Failed(String),
-}
-
-impl Default for UpdateCheckState {
-    fn default() -> Self {
-        Self::Idle
-    }
 }
 
 #[derive(serde::Deserialize)]

--- a/src/keycode_picker.rs
+++ b/src/keycode_picker.rs
@@ -253,16 +253,20 @@ mod tests {
     #[test]
     fn pending_modifier_picker_renders_layout_and_list_tabs() {
         let ctx = egui::Context::default();
-        let mut picker = KeycodePicker::default();
-        picker.open = true;
-        picker.vial_quantum_pending_mod = Some(0x0100);
+        let mut picker = KeycodePicker {
+            open: true,
+            vial_quantum_pending_mod: Some(0x0100),
+            ..Default::default()
+        };
 
         let mut render = || {
-            let mut input = egui::RawInput::default();
-            input.screen_rect = Some(egui::Rect::from_min_size(
-                egui::Pos2::ZERO,
-                egui::vec2(1_100.0, 800.0),
-            ));
+            let input = egui::RawInput {
+                screen_rect: Some(egui::Rect::from_min_size(
+                    egui::Pos2::ZERO,
+                    egui::vec2(1_100.0, 800.0),
+                )),
+                ..Default::default()
+            };
             ctx.run_ui(input, |_ui| {
                 picker.show(
                     &ctx,

--- a/src/keycode_picker_model.rs
+++ b/src/keycode_picker_model.rs
@@ -298,10 +298,7 @@ fn is_symbol(value: u16) -> bool {
 }
 
 fn is_modifier_or_layer_action(value: u16) -> bool {
-    matches!(
-        value,
-        0x0100..=0x3FFF | 0x4000..=0x4FFF | 0x5000..=0x52FF
-    )
+    matches!(value, 0x0100..=0x52FF)
 }
 
 #[cfg(test)]

--- a/src/ui/bluetooth_settings.rs
+++ b/src/ui/bluetooth_settings.rs
@@ -494,11 +494,13 @@ mod tests {
         assert!(app.hid_device.is_none());
         assert!(app.vial_hid_task_active());
 
-        let mut input = egui::RawInput::default();
-        input.screen_rect = Some(egui::Rect::from_min_size(
-            egui::Pos2::ZERO,
-            egui::vec2(900.0, 700.0),
-        ));
+        let input = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::vec2(900.0, 700.0),
+            )),
+            ..Default::default()
+        };
         let output = ctx.run_ui(input, |ui| {
             app.draw_bluetooth_settings_page(ui, ui.max_rect());
         });

--- a/src/ui/device_deferred_load.rs
+++ b/src/ui/device_deferred_load.rs
@@ -1249,12 +1249,10 @@ impl EntropyApp {
                         let status = self.deferred_device_load.section_status(section);
                         (!status.ready()).then_some(DeferredOverlayTarget::Section(section, status))
                     })
-                    .unwrap_or_else(|| {
-                        DeferredOverlayTarget::Layer(
-                            self.selected_layer,
-                            DeferredLoadStatus::Loaded,
-                        )
-                    })
+                    .unwrap_or(DeferredOverlayTarget::Layer(
+                        self.selected_layer,
+                        DeferredLoadStatus::Loaded,
+                    ))
             } else {
                 DeferredOverlayTarget::Layer(self.selected_layer, DeferredLoadStatus::Loaded)
             }


### PR DESCRIPTION
### Problem

Eleven behavior-preserving Clippy diagnostics obscured the remaining warning baseline across state defaults, test fixtures, deferred loading, and keycode classification.

### Fix

- Derive enum defaults and construct targeted test fixtures directly from their default values.
- Simplify the deferred-load fallback and the contiguous keycode-action range.
- Add no `#[allow(clippy::...)]` attributes.

### Verification

- `cargo clippy --locked --all-targets` passes with all 11 selected diagnostics removed.
- Nine focused tests passed for layout export persistence, picker rendering, Bluetooth settings, and keycode classification.
- Scoped `rustfmt --check` and `git diff --check` pass.
- The serial suite has the same three pre-existing failures on this branch and pristine `origin/main`: `automatic_background_queue_loads_every_remaining_layer_in_order`, `module_setting_write_matches_vial_set_without_readback_or_debounce`, and `module_setting_write_waits_for_busy_hid_owner` (462 passed / 3 failed in both).
