### PR TITLE
linux_ble: fix panic in report_reference on empty descriptor value

### DIFF
--- a/src/linux_ble.rs
+++ b/src/linux_ble.rs
@@ -390,7 +390,7 @@ fn select_hid_vial_endpoints(
                 })
                 .and_then(|descriptor| {
                     (descriptor.value.len() >= 2)
-                        .then_some((descriptor.value[0], descriptor.value[1]))
+                        .then(|| (descriptor.value[0], descriptor.value[1]))
                 })
         };
 


### PR DESCRIPTION
Fixes #136.

`bool::then_some(t)` evaluates `t` eagerly regardless of the boolean, unlike `then(|| t)`. In `report_reference`, `(descriptor.value.len() >= 2).then_some((descriptor.value[0], descriptor.value[1]))` indexed `descriptor.value[0]`/`[1]` unconditionally, so a GATT report reference descriptor with an empty value panicked on startup during BLE scanning instead of being skipped by the length guard.

Switched to the lazy `then(|| ...)` closure so the tuple is only built once the length check passes.

## Test plan

- `cargo build`
- Ran the app on Linux against a real Vial keyboard exposed over the composite HOGP path added in 50a8995 — no more panic, device connects and layout/keymap/macros load normally.
