### PR TITLE
Корректно проверять и отображать таймаут Layer LED

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -2080,6 +2080,7 @@ pub(crate) struct LayerLedNumericSetting {
     pub(crate) width: u8,
     pub(crate) value: u16,
     pub(crate) max: u16,
+    pub(crate) variants: Vec<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/hid.rs
+++ b/src/hid.rs
@@ -212,6 +212,7 @@ pub(crate) enum TestHidFault {
     Disconnect,
     Timeout,
     WorkerPanic,
+    IgnoreQmkSettingSet,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -828,6 +829,14 @@ impl HidDevice {
                         TestHidFault::Disconnect => bail!("HID device disconnected"),
                         TestHidFault::Timeout => bail!("HID timeout — device did not respond"),
                         TestHidFault::WorkerPanic => panic!("test HID worker stopped"),
+                        TestHidFault::IgnoreQmkSettingSet => {
+                            if request[0] != CMD_VIA_VIAL_PREFIX
+                                || request[1] != CMD_VIAL_QMK_SETTINGS_SET
+                            {
+                                bail!("test fault expected a QMK Settings SET request");
+                            }
+                            return Ok([0; MSG_LEN]);
+                        }
                     }
                 }
 

--- a/src/ui/device_settings_helpers.rs
+++ b/src/ui/device_settings_helpers.rs
@@ -1065,15 +1065,41 @@ impl EntropyApp {
     }
 
     fn layer_led_field_max(field: &serde_json::Value, width: u8) -> u16 {
-        field
+        if let Some(max) = field
             .get("max")
             .and_then(|value| value.as_u64())
-            .unwrap_or(if width > 1 {
-                u16::MAX as u64
-            } else {
-                u8::MAX as u64
-            })
-            .min(u16::MAX as u64) as u16
+            .map(|max| max.min(u16::MAX as u64) as u16)
+        {
+            return max;
+        }
+        if field.get("type").and_then(|value| value.as_str()) == Some("select") {
+            if let Some(max) = field
+                .get("variants")
+                .and_then(|value| value.as_array())
+                .map(|variants| variants.len().saturating_sub(1))
+                .and_then(|max| u16::try_from(max).ok())
+            {
+                return max;
+            }
+        }
+        if width > 1 {
+            u16::MAX
+        } else {
+            u8::MAX as u16
+        }
+    }
+
+    fn layer_led_field_variants(field: &serde_json::Value) -> Vec<String> {
+        field
+            .get("variants")
+            .and_then(|value| value.as_array())
+            .into_iter()
+            .flatten()
+            .filter_map(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned)
+            .collect()
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -1082,6 +1108,7 @@ impl EntropyApp {
         qsid: u16,
         width: u8,
         max: u16,
+        variants: Vec<String>,
         label: &str,
     ) -> LayerLedNumericSetting {
         let value = if width > 1 {
@@ -1100,6 +1127,7 @@ impl EntropyApp {
             width,
             value,
             max,
+            variants,
         }
     }
 
@@ -1195,6 +1223,7 @@ impl EntropyApp {
                         qsid,
                         width,
                         max.min(255),
+                        Vec::new(),
                         "layer_led brightness",
                     ));
                 } else if lower_title.contains("led timeout") {
@@ -1219,6 +1248,7 @@ impl EntropyApp {
                         qsid,
                         width,
                         max,
+                        Self::layer_led_field_variants(field),
                         "layer_led timeout",
                     ));
                 } else if lower_title.contains("bt profile") && lower_title.contains("color") {
@@ -1327,6 +1357,7 @@ impl EntropyApp {
                     316,
                     2,
                     255,
+                    Vec::new(),
                     "layer_led brightness",
                 ));
             }
@@ -1336,6 +1367,7 @@ impl EntropyApp {
                     317,
                     1,
                     255,
+                    Vec::new(),
                     "layer_led timeout",
                 ));
             }
@@ -2006,6 +2038,22 @@ mod tests {
         );
 
         assert_eq!(groups, vec![(0, vec![300]), (1, vec![301])]);
+    }
+
+    #[test]
+    fn layer_led_select_max_comes_from_variants() {
+        let field = serde_json::json!({
+            "type": "select",
+            "title": "LED timeout",
+            "qsid": 317,
+            "variants": ["Never", "1 min", "2 min", "5 min", "10 min", "15 min", "30 min", "60 min"]
+        });
+
+        assert_eq!(EntropyApp::layer_led_field_max(&field, 1), 7);
+        assert_eq!(
+            EntropyApp::layer_led_field_variants(&field),
+            vec!["Never", "1 min", "2 min", "5 min", "10 min", "15 min", "30 min", "60 min"]
+        );
     }
 
     #[test]

--- a/src/ui/layer_led_settings.rs
+++ b/src/ui/layer_led_settings.rs
@@ -236,15 +236,22 @@ impl EntropyApp {
                         },
                         slider_control_width,
                         |ui| {
-                            let value_text = if value.round() as u16 == 0 {
-                                crate::i18n::tr_catalog(
-                                    self.app_settings.language,
-                                    "advanced_settings.off",
-                                )
-                                .to_string()
-                            } else {
-                                format!("{}{}", value.round() as u16, suffix)
-                            };
+                            let raw_value = value.round() as u16;
+                            let value_text = setting
+                                .variants
+                                .get(raw_value as usize)
+                                .cloned()
+                                .unwrap_or_else(|| {
+                                    if raw_value == 0 {
+                                        crate::i18n::tr_catalog(
+                                            self.app_settings.language,
+                                            "advanced_settings.off",
+                                        )
+                                        .to_string()
+                                    } else {
+                                        format!("{raw_value}{suffix}")
+                                    }
+                                });
                             if self.draw_layer_led_slider_control(
                                 ui,
                                 scale,

--- a/src/ui/settings_write_queue.rs
+++ b/src/ui/settings_write_queue.rs
@@ -883,6 +883,7 @@ mod tests {
                 width: 2,
                 value: 32,
                 max: 255,
+                variants: Vec::new(),
             }),
             ..LayerLedSettingsState::default()
         };

--- a/src/ui/settings_write_queue.rs
+++ b/src/ui/settings_write_queue.rs
@@ -88,11 +88,12 @@ impl SettingsWriteTarget {
         matches!(self, Self::Touchpad { .. })
     }
 
-    fn verifies_readback(&self) -> bool {
-        // RMK persists device settings asynchronously after SET. Match Vial's
-        // single-request path for Module and Layer LED settings so an immediate
-        // GET cannot collide with that flash work over Bluetooth.
-        self.is_touchpad()
+    fn verifies_readback(&self, is_bluetooth_transport: bool) -> bool {
+        // RMK persists device settings asynchronously after SET, so an immediate
+        // GET can collide with that flash work over Bluetooth. USB Layer LED
+        // writes still need readback because some firmware acknowledges SET
+        // without applying the requested value.
+        self.is_touchpad() || (matches!(self, Self::LayerLed { .. }) && !is_bluetooth_transport)
     }
 
     fn reconcile_readback(
@@ -257,7 +258,10 @@ fn run_settings_write(
     hid: &crate::hid::HidDevice,
     request: &SettingsWriteRequest,
 ) -> (Result<u16, ModuleSettingWritebackError>, bool) {
-    let policy = if request.target.verifies_readback() {
+    let policy = if request
+        .target
+        .verifies_readback(hid.is_bluetooth_transport())
+    {
         QmkSettingWritePolicy::VerifiedReadback
     } else {
         QmkSettingWritePolicy::SetOnly
@@ -992,6 +996,47 @@ mod tests {
         let requests = recorder.requests();
         assert_eq!(requests.len(), 2);
         assert!(requests.iter().all(|request| request[1] == 0x0B));
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn usb_layer_led_write_rejects_ignored_set() {
+        let (hid_device, recorder) = crate::hid::HidDevice::test_device_with_fault_after_requests(
+            Some((0, crate::hid::TestHidFault::IgnoreQmkSettingSet)),
+        );
+        let request = SettingsWriteRequest {
+            id: 1,
+            generation: 0,
+            qsid: 317,
+            width: 1,
+            old_value: 4,
+            requested: 5,
+            target: SettingsWriteTarget::LayerLed {
+                display_label: "Layer LED timeout".to_owned(),
+            },
+        };
+
+        assert_eq!(
+            run_settings_write(&hid_device, &request).0,
+            Err(ModuleSettingWritebackError::ReadbackMismatch {
+                expected: 5,
+                actual: 0,
+            })
+        );
+        let requests = recorder.requests();
+        assert_eq!(requests[0][1], 0x0B);
+        assert!(!requests[1..].is_empty());
+        assert!(requests[1..].iter().all(|request| request[1] == 0x0A));
+    }
+
+    #[test]
+    fn layer_led_readback_is_usb_only() {
+        let target = SettingsWriteTarget::LayerLed {
+            display_label: "Layer LED timeout".to_owned(),
+        };
+
+        assert!(target.verifies_readback(false));
+        assert!(!target.verifies_readback(true));
     }
 
     #[test]

--- a/src/ui/vial_hid_task.rs
+++ b/src/ui/vial_hid_task.rs
@@ -1200,6 +1200,7 @@ mod tests {
                 width: 2,
                 value: 32,
                 max: 255,
+                variants: Vec::new(),
             }),
             supported: true,
             ..LayerLedSettingsState::default()

--- a/src/ui/vial_hid_task.rs
+++ b/src/ui/vial_hid_task.rs
@@ -1271,17 +1271,17 @@ mod tests {
         assert_eq!(requests.first().map(|request| request[0]), Some(0x12));
         assert!(module_set.is_some_and(|index| index > 0));
         assert!(layer_led_set.is_some_and(|index| Some(index) > module_set));
-        assert_eq!(
-            requests
-                .iter()
-                .filter(|request| {
-                    request[0] == 0xFE
-                        && matches!(request[1], 0x0A | 0x0B)
-                        && u16::from_le_bytes([request[2], request[3]]) == 316
-                })
-                .count(),
-            1
-        );
+        let layer_led_requests = requests
+            .iter()
+            .filter(|request| {
+                request[0] == 0xFE
+                    && matches!(request[1], 0x0A | 0x0B)
+                    && u16::from_le_bytes([request[2], request[3]]) == 316
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(layer_led_requests.len(), 2);
+        assert_eq!(layer_led_requests[0][1], 0x0B);
+        assert_eq!(layer_led_requests[1][1], 0x0A);
     }
 
     #[test]


### PR DESCRIPTION
## Воспроизведение

Проверено на Ergohaven M4CR0Pad v3 по USB.

На firmware 4.0.5:

1. Открыть настройки Layer LED.
2. Установить таймаут в `0` или другое значение.
3. Entropy показывал успешное сохранение после ответа на `SET`, хотя повторный `GET` возвращал прежнее значение.
4. После перезапуска приложения UI снова показывал старое значение.

После обновления Entropy до 0.3.4 UI мог показывать `128m`: firmware M4CR0Pad v3 не включала описание LED timeout в Vial schema, а legacy fallback отображал QSID `317` как произвольное байтовое значение.

## Первопричина

Проблема состояла из двух частей:

- Entropy использовал для Layer LED режим `SetOnly`, поэтому успешный ответ на команду не подтверждал, что устройство фактически применило значение.
- Entropy не учитывал `variants` поля с `type: select` при вычислении диапазона и отображении значения Layer LED.

Отдельная причина отсутствия сохранения находилась в firmware M4CR0Pad v3: QSID `317` был зарегистрирован, но из-за конфигурации `RGB_MATRIX` использовал weak setter без записи. Исправление firmware: https://github.com/ergohaven/vial-qmk/pull/39

## Что исправляет этот PR

- После записи Layer LED по USB Entropy выполняет отложенный readback через существующий механизм проверки.
- Статус сохранения устанавливается только при совпадении прочитанного и запрошенного значений; при отказе устройства UI возвращается к фактическому значению и показывает ошибку.
- Для Bluetooth сохраняется `SetOnly`, потому что немедленный `GET` может конфликтовать с асинхронным сохранением RMK во flash.
- Для Layer LED `select` диапазон вычисляется по числу `variants`, а UI показывает label выбранного варианта вместо сырого индекса.
- Legacy numeric schema остаётся совместимой с прежним поведением.

С firmware из связанного PR M4CR0Pad v3 предлагает варианты `Never`, `1 min`, `2 min`, `5 min`, `10 min`, `15 min`, `30 min`, `60 min`; `Never` кодируется индексом `0`.

## Автоматическая проверка

- Новый parser test подтверждает диапазон `0..7` и labels select-схемы.
- Fake-HID regression test подтверждает, что USB-запись с успешным `SET`, но несовпадающим `GET`, не получает ложный статус сохранения.
- `cargo +1.92.0 test layer_led` — 5 тестов прошли.
- Изолированные timing-sensitive тесты очередей — 8 тестов прошли.
- Полный последовательный suite: 502/505; три существующих timing-sensitive теста очередей падают только в полном прогоне и проходят изолированно.
- `cargo +1.92.0 clippy --all-targets` — код возврата 0, с существующими предупреждениями репозитория.
- `rustfmt +1.92.0 --check --edition 2021` для пяти изменённых файлов — успешно.
- `cargo +1.92.0 build --release` — успешно.

## Проверка на реальном устройстве

С firmware из https://github.com/ergohaven/vial-qmk/pull/39:

- Entropy вместо `128m` показывает label фактического варианта.
- Установка `Never` обычным drag в UI даёт readback QSID `317=0`; после полного USB-переподключения и нового запуска UI снова показывает `Never`.
- Установка `10 min` даёт readback QSID `317=4`; после полного USB-переподключения Entropy снова показывает `10 min`.
- При установленном `1 min` RGB-подсветка клавиш физически выключается через минуту бездействия и включается после нажатия клавиши.
- После проверки пользовательское значение возвращено в `Never` и подтверждено readback `0`.
- `MacropadDisplay` был приостановлен на время изолированной проверки; актуальный код `codex-macropad` обращается только к Vial RGB effect/speed/hue/saturation/brightness и не использует QSID `317`.

Refs #146
