### PR TITLE
chore(ci): move GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
             target: x86_64-apple-darwin
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -93,7 +93,7 @@ jobs:
           cargo test --all-targets app::app_lifecycle::tests::layer_completion_starts_settings_queued_behind_it -- --exact
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.binary }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
             target: x86_64-apple-darwin
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -88,7 +88,7 @@ jobs:
           cp dist/macos/*.dmg "dist/release/$asset"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-assets-${{ matrix.os }}
           path: dist/release/*
@@ -99,10 +99,10 @@ jobs:
     if: ${{ startsWith(github.ref_name, 'v0.') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts/
 


### PR DESCRIPTION
## Summary

- stop relying on GitHub's temporary Node 24 compatibility mode for actions that still target deprecated Node 20
- move checkout and artifact handling to their current official Node 24 major versions
- preserve the existing workflow inputs, artifact names, and archived download behavior

## Verification

- `actionlint -shellcheck=`
- all three workflow files parse successfully as YAML
- `cargo test --locked` — 655 passed
- full `actionlint` reports the same four pre-existing release-notes ShellCheck findings on this branch and pristine `main`
- the official action manifests for checkout v7, upload-artifact v7, and download-artifact v8 declare `node24`

## Post-Deploy Monitoring & Validation

- inspect the Build and Nix PR jobs for successful checkout and artifact upload on every runner
- confirm the logs no longer contain the Node 20 compatibility warning or the related `punycode` deprecation
- validate artifact download during the next Release workflow
- treat checkout, upload, download, or digest-validation failures as rollback triggers; revert this commit if a major-version compatibility issue appears
- validation window: this PR's CI and the next tagged release; owner: PR author and release maintainer
