### PR TITLE
fix(matrix-tester): decode switch matrix rows MSB byte first for all firmware

### DIFF
--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -185,7 +185,6 @@ impl EntropyApp {
             key_override_pick_target: None,
             matrix_tester_pressed: Vec::new(),
             matrix_tester_ever_pressed: Vec::new(),
-            matrix_tester_rmk_byte_order: false,
             sticky_layout_prev_pressed: Vec::new(),
             sticky_layout_pressed_key_layers: Vec::new(),
             sticky_layout_toggled_layers: Vec::new(),

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -4687,7 +4687,6 @@ pub struct EntropyApp {
     pub(crate) key_override_pick_target: Option<KeyOverridePickField>,
     pub(crate) matrix_tester_pressed: Vec<bool>,
     pub(crate) matrix_tester_ever_pressed: Vec<bool>,
-    pub(crate) matrix_tester_rmk_byte_order: bool,
     pub(crate) sticky_layout_prev_pressed: Vec<bool>,
     pub(crate) sticky_layout_pressed_key_layers: Vec<Option<usize>>,
     pub(crate) sticky_layout_toggled_layers: Vec<bool>,

--- a/src/hid_parse.rs
+++ b/src/hid_parse.rs
@@ -100,24 +100,22 @@ pub(crate) fn parse_tap_dance_response(resp: &[u8]) -> Result<(u16, u16, u16, u1
     ))
 }
 
-fn parse_switch_matrix_payload_inner(
-    data: &[u8],
-    rows: usize,
-    cols: usize,
-    reverse_row_bytes: bool,
-) -> Vec<bool> {
+/// Decode the VIA `id_switch_matrix_state` payload into a row-major pressed map.
+///
+/// Each matrix row is packed into `ceil(cols / 8)` bytes with the most significant
+/// byte first: the first byte of a row carries its highest columns and the last
+/// byte carries columns 0-7. QMK (`quantum/via.c`), Vial GUI and RMK all emit
+/// and expect this wire order, so it does not depend on the firmware family.
+/// Within the chunk `k = col / 8`, bit `n` is column `8 * k + n`; the chunks
+/// themselves are serialised in descending order.
+pub(crate) fn parse_switch_matrix_payload(data: &[u8], rows: usize, cols: usize) -> Vec<bool> {
     let total = rows * cols;
     let bytes_per_row = cols.div_ceil(8);
     let mut pressed = vec![false; total];
 
     for row in 0..rows {
         for col in 0..cols {
-            let col_byte = col / 8;
-            let row_byte = if reverse_row_bytes {
-                bytes_per_row.saturating_sub(1).saturating_sub(col_byte)
-            } else {
-                col_byte
-            };
+            let row_byte = bytes_per_row - 1 - col / 8;
             let byte_idx = row * bytes_per_row + row_byte;
             let bit_idx = col % 8;
             if byte_idx < data.len() {
@@ -127,15 +125,6 @@ fn parse_switch_matrix_payload_inner(
     }
 
     pressed
-}
-
-pub(crate) fn parse_switch_matrix_payload(data: &[u8], rows: usize, cols: usize) -> Vec<bool> {
-    parse_switch_matrix_payload_inner(data, rows, cols, false)
-}
-
-pub(crate) fn parse_rmk_switch_matrix_payload(data: &[u8], rows: usize, cols: usize) -> Vec<bool> {
-    // RMK MatrixState::read_all emits each row's byte chunks in reverse order.
-    parse_switch_matrix_payload_inner(data, rows, cols, true)
 }
 
 pub(crate) fn parse_vialrgb_supported_effects_payload(
@@ -273,8 +262,8 @@ mod tests {
     }
 
     #[test]
-    fn parses_rmk_switch_matrix_reversed_row_bytes() {
-        let pressed = parse_rmk_switch_matrix_payload(
+    fn parses_switch_matrix_with_msb_row_byte_first() {
+        let pressed = parse_switch_matrix_payload(
             &[0b0000_0010, 0b0000_0100, 0b0000_0001, 0b0000_0000],
             2,
             12,
@@ -283,6 +272,30 @@ mod tests {
         assert!(pressed[9]);
         assert!(pressed[20]);
         assert_eq!(pressed.iter().filter(|&&pressed| pressed).count(), 3);
+    }
+
+    #[test]
+    fn parses_thirteen_column_switch_matrix_without_column_shift() {
+        // 13 columns use two bytes per row: [columns 8-12, columns 0-7].
+        // Row 0: column 0 pressed. Row 1: column 8 pressed. Row 2: column 5 pressed.
+        let pressed = parse_switch_matrix_payload(
+            &[
+                0b0000_0000,
+                0b0000_0001,
+                0b0000_0001,
+                0b0000_0000,
+                0b0000_0000,
+                0b0010_0000,
+            ],
+            3,
+            13,
+        );
+        let pressed_cells: Vec<usize> = pressed
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, &is_pressed)| is_pressed.then_some(idx))
+            .collect();
+        assert_eq!(pressed_cells, vec![0, 13 + 8, 26 + 5]);
     }
 
     #[test]

--- a/src/hid_settings.rs
+++ b/src/hid_settings.rs
@@ -1,7 +1,4 @@
-use super::hid_parse::{
-    parse_rmk_switch_matrix_payload, parse_switch_matrix_payload,
-    parse_vialrgb_supported_effects_payload,
-};
+use super::hid_parse::{parse_switch_matrix_payload, parse_vialrgb_supported_effects_payload};
 use super::hid_protocol::*;
 use super::HidDevice;
 
@@ -405,20 +402,11 @@ impl HidDevice {
         Ok(())
     }
 
-    pub fn get_switch_matrix_with_rmk_byte_order(
-        &self,
-        rows: usize,
-        cols: usize,
-        rmk_byte_order: bool,
-    ) -> Result<Vec<bool>> {
+    pub fn get_switch_matrix(&self, rows: usize, cols: usize) -> Result<Vec<bool>> {
         let resp = self.usb_send(&[CMD_VIA_GET_KEYBOARD_VALUE, VIA_SWITCH_MATRIX_STATE])?;
-        // Matrix data is packed row-by-row, with each row padded to whole bytes.
-        // QMK sends row bytes low-to-high; RMK reverses byte order inside each row.
-        Ok(if rmk_byte_order {
-            parse_rmk_switch_matrix_payload(&resp[2..], rows, cols)
-        } else {
-            parse_switch_matrix_payload(&resp[2..], rows, cols)
-        })
+        // Matrix data is packed row-by-row, each row padded to whole bytes with the
+        // most significant byte first (same for QMK and RMK firmware).
+        Ok(parse_switch_matrix_payload(&resp[2..], rows, cols))
     }
 }
 

--- a/src/ui/device_connect_apply.rs
+++ b/src/ui/device_connect_apply.rs
@@ -477,7 +477,6 @@ impl EntropyApp {
                 } else {
                     self.schedule_battery_refresh_for_result(r.about_info.battery_halves);
                 }
-                self.matrix_tester_rmk_byte_order = self.current_device_is_likely_rmk();
                 self.current_encoder_visibility_id =
                     encoder_visibility_id(&r.device_name, r.keyboard_id);
                 if let Some(dev) = self

--- a/src/ui/device_connection.rs
+++ b/src/ui/device_connection.rs
@@ -249,7 +249,6 @@ impl EntropyApp {
         self.layer_led_settings = LayerLedSettingsState::default();
         self.rgb_settings = RgbSettingsState::default();
         self.layout_options_value = None;
-        self.matrix_tester_rmk_byte_order = false;
         self.sticky_layout_prev_pressed.clear();
         self.sticky_layout_pressed_key_layers.clear();
         self.sticky_layout_toggled_layers.clear();

--- a/src/ui/vial_hid_task.rs
+++ b/src/ui/vial_hid_task.rs
@@ -27,7 +27,6 @@ pub(super) enum VialHidOperation {
     Matrix {
         rows: usize,
         cols: usize,
-        rmk_byte_order: bool,
         remember_ever_pressed: bool,
     },
     BatteryRefresh,
@@ -125,13 +124,8 @@ fn run_vial_hid_operation(
             hid.lock()?;
             Ok(VialHidOutcome::Locked)
         }
-        VialHidOperation::Matrix {
-            rows,
-            cols,
-            rmk_byte_order,
-            ..
-        } => hid
-            .get_switch_matrix_with_rmk_byte_order(rows, cols, rmk_byte_order)
+        VialHidOperation::Matrix { rows, cols, .. } => hid
+            .get_switch_matrix(rows, cols)
             .map(VialHidOutcome::Matrix),
         VialHidOperation::BatteryRefresh => hid.get_battery_halves().map(VialHidOutcome::Battery),
         VialHidOperation::KeyWrite {
@@ -333,7 +327,6 @@ impl EntropyApp {
             VialHidOperation::Matrix {
                 rows,
                 cols,
-                rmk_byte_order: self.matrix_tester_rmk_byte_order,
                 remember_ever_pressed,
             },
         )
@@ -840,7 +833,6 @@ mod tests {
             VialHidOperation::Matrix {
                 rows: 2,
                 cols: 3,
-                rmk_byte_order: true,
                 remember_ever_pressed: true,
             },
         )


### PR DESCRIPTION
Fixes #156.

## Summary

`id_switch_matrix_state` was decoded with a byte order chosen from the device
name: `parse_rmk_switch_matrix_payload()` (row bytes reversed) when the device
name or manufacturer contained "rmk", `parse_switch_matrix_payload()` (row bytes
in ascending order) otherwise.

Only the first order is correct. QMK packs each matrix row into
`ceil(cols / 8)` bytes **most significant byte first** — `via.c` writes
`matrix_get_row(row) >> (i * 8)` from the highest chunk down — Vial GUI decodes
`len(row_data) - 1 - floor(col / 8)`, and RMK's VIA response path produces the
same wire order. It is a property of the protocol, not of the firmware family,
so the name check made the default path wrong for every protocol-compliant
board with more than 8 columns that took it.

## Impact

Boards whose matrix fits in 8 columns pack one byte per row, so both paths
agreed and nothing changes for them.

Boards with more than 8 columns had their row chunks read in reverse unless the
device name or manufacturer happened to contain "rmk", so a switch lit the cap
in the mirrored column block, and a column whose mirrored position fell outside
the declared matrix width was not reported at all. On the 13-column build of
the board in #156, columns 0-4 and 8-12 swapped places while columns 5-7
mirrored to the non-existent columns 13-15 and stayed dark.

I cannot tell from this repository which shipped boards are affected. The
dimensions passed to the matrix poll come from the connected device's own Vial
descriptor at connect time (`KeyboardLayout::from_vial_json` reads
`matrix.rows` / `matrix.cols`), and the JSON files under `src/layouts/` are
test fixtures rather than a runtime source — `mod layouts` is `#[cfg(test)]`.
For what it is worth, those fixtures address columns up to 14 for Imperial44
and up to 13 for Omega Point 36, which suggests both have matrices wider than
8 columns, but you are better placed to confirm that against the real
descriptors and USB strings.

The same decode feeds the sticky Layout Indicator window
(`layout_indicator_window.rs` calls `poll_switch_matrix_state`), so its live
key highlighting was affected in the same way and is fixed too.

## Changes

- `parse_switch_matrix_payload()` always reads each row's bytes
  most-significant first. The `reverse_row_bytes` parameter, the
  `parse_rmk_switch_matrix_payload()` wrapper and the
  `get_switch_matrix_with_rmk_byte_order()` entry point are removed.
- The `matrix_tester_rmk_byte_order` flag and the plumbing that carried it
  (`app_state`, `app_init`, `device_connect_apply`, `device_connection`,
  `vial_hid_task`) are removed with it.
- Tests: the existing case is renamed to
  `parses_switch_matrix_with_msb_row_byte_first`, and
  `parses_thirteen_column_switch_matrix_without_column_shift` is added to cover
  a two-byte row where the old default shifted columns.

## Verification

- `cargo test --all-targets`: 694 passed locally on this branch.
- `cargo build --release`: succeeds.
- CI: the repository's Build workflow passes on all four targets on my fork,
  including the Linux `cargo test --all-targets` job —
  https://github.com/techmech-keeb/entropy/actions/runs/33931435969
- Hardware: OLSK60 v2 (6x13) with both Vial-QMK and Vial-RMK, using the Windows
  build from that run. Every switch highlights its own cap (left-most column,
  `K`, `F`/`G`/`H`/`J`), columns 5-7 are detected again, and `Tested: n/N`
  reaches 100%.
- Not verified on hardware: any board other than the OLSK60 v2. The change is
  covered by the added 13-column unit test and by the QMK / Vial GUI wire order
  cited above.