### PR TITLE
fix(matrix-tester): keep the board below the header and honour layout options

### DIFF
--- a/src/ui/layout_shared.rs
+++ b/src/ui/layout_shared.rs
@@ -20,30 +20,6 @@ pub(crate) fn responsive_layout_max_scale(ctx: &egui::Context, viewport: egui::R
     1.0 + 0.35 * t
 }
 
-pub(crate) fn layout_geometry_with_reserved(
-    ctx: &egui::Context,
-    layout: &KeyboardLayout,
-    viewport: egui::Rect,
-    ui_scale: f32,
-    top_reserved: f32,
-    bottom_reserved: f32,
-    fit_margin: f32,
-    max_scale_override: Option<f32>,
-) -> LayoutGeometry {
-    layout_geometry_with_reserved_and_filter(
-        ctx,
-        layout,
-        viewport,
-        ui_scale,
-        top_reserved,
-        bottom_reserved,
-        fit_margin,
-        max_scale_override,
-        |_| true,
-        |_| true,
-    )
-}
-
 pub(crate) fn layout_geometry_with_reserved_and_filter(
     ctx: &egui::Context,
     layout: &KeyboardLayout,

--- a/src/ui/layout_shared.rs
+++ b/src/ui/layout_shared.rs
@@ -20,24 +20,6 @@ pub(crate) fn responsive_layout_max_scale(ctx: &egui::Context, viewport: egui::R
     1.0 + 0.35 * t
 }
 
-pub(crate) fn layout_geometry(
-    ctx: &egui::Context,
-    layout: &KeyboardLayout,
-    viewport: egui::Rect,
-    ui_scale: f32,
-) -> LayoutGeometry {
-    layout_geometry_with_reserved(
-        ctx,
-        layout,
-        viewport,
-        ui_scale,
-        LAYOUT_TOP_RESERVED_H,
-        LAYOUT_BOTTOM_RESERVED_H,
-        LAYOUT_FIT_MARGIN,
-        None,
-    )
-}
-
 pub(crate) fn layout_geometry_with_reserved(
     ctx: &egui::Context,
     layout: &KeyboardLayout,

--- a/src/ui/matrix_tester.rs
+++ b/src/ui/matrix_tester.rs
@@ -162,18 +162,33 @@ impl EntropyApp {
             self.prompt_if_vial_locked_for_matrix_poll();
         }
 
-        let total_keys = layout.keys.len();
-        let tested_count = layout
-            .keys
-            .iter()
-            .filter(|key| {
-                let idx = key.row as usize * layout.cols + key.col as usize;
-                self.matrix_tester_ever_pressed
-                    .get(idx)
-                    .copied()
-                    .unwrap_or(false)
-            })
-            .count();
+        // Only the caps of the currently selected physical configuration exist
+        // on the board: alternative layout-option variants share matrix
+        // positions and must not be drawn or counted on top of each other, and
+        // layout_key_visible() also hides a module-owned encoder press key when
+        // its module is set to something other than an encoder.
+        let mut total_keys = 0;
+        let mut tested_count = 0;
+        for key in &layout.keys {
+            if !Self::layout_key_visible(
+                &self.module_settings,
+                layout,
+                key,
+                self.layout_options_value,
+            ) {
+                continue;
+            }
+            total_keys += 1;
+            let idx = key.row as usize * layout.cols + key.col as usize;
+            if self
+                .matrix_tester_ever_pressed
+                .get(idx)
+                .copied()
+                .unwrap_or(false)
+            {
+                tested_count += 1;
+            }
+        }
 
         crate::ui_style::allocate_ui_at_rect(
             ui,
@@ -301,7 +316,15 @@ impl EntropyApp {
         // `content_rect`, which already sits below the top chrome. Fit the board
         // into the rectangle left between them instead of the whole panel, so the
         // caps never cover the header or the "Tested" button.
-        let geometry = layout_geometry_with_reserved(
+        let key_visible = |key: &crate::keyboard::PhysicalKey| {
+            Self::layout_key_visible(
+                &self.module_settings,
+                layout,
+                key,
+                self.layout_options_value,
+            )
+        };
+        let geometry = layout_geometry_with_reserved_and_filter(
             ui.ctx(),
             layout,
             board_rect,
@@ -310,6 +333,8 @@ impl EntropyApp {
             0.0,
             LAYOUT_FIT_MARGIN,
             None,
+            key_visible,
+            |_| false,
         );
 
         let hint_color = if dark {
@@ -329,6 +354,9 @@ impl EntropyApp {
         );
 
         for key in &layout.keys {
+            if !key_visible(key) {
+                continue;
+            }
             let matrix_idx = key.row as usize * layout.cols + key.col as usize;
             let is_pressed = self
                 .matrix_tester_pressed

--- a/src/ui/matrix_tester.rs
+++ b/src/ui/matrix_tester.rs
@@ -297,18 +297,19 @@ impl EntropyApp {
             return;
         }
 
-        let viewport = egui::Rect::from_min_max(
-            ui.min_rect().min,
-            egui::pos2(
-                ui.min_rect().left() + ui.available_size().x,
-                ui.max_rect().bottom(),
-            ),
-        );
-        let geometry = layout_geometry(
+        // The header, the status button and the bottom hint are laid out from
+        // `content_rect`, which already sits below the top chrome. Fit the board
+        // into the rectangle left between them instead of the whole panel, so the
+        // caps never cover the header or the "Tested" button.
+        let geometry = layout_geometry_with_reserved(
             ui.ctx(),
             layout,
-            viewport,
+            board_rect,
             clamp_ui_scale(self.app_settings.ui_scale),
+            0.0,
+            0.0,
+            LAYOUT_FIT_MARGIN,
+            None,
         );
 
         let hint_color = if dark {


### PR DESCRIPTION
Fixes #159. Two independent rendering defects in the Matrix Tester, kept as two
commits as requested.

## 1. The board covered the header

`fix(matrix-tester): keep the board inside its own area below the header`

The tester draws its title, description and `Tested` button inside
`content_rect`, but it built the key geometry from the whole panel viewport.
`layout_geometry()` reserved `LAYOUT_TOP_RESERVED_H` from the panel top, which
lands exactly on `content_rect.top()` — nothing accounted for the tester's own
header and status block below that. The board therefore started a full header
height too high, and at the default window size its caps covered the
description line and the `Tested` button, leaving the text unreadable and the
button unclickable.

`board_rect` was already computed for the area between that header and the
bottom hint, but it was only used to centre the placeholder messages. The fix
passes that already-trimmed rectangle to the existing
`layout_geometry_with_reserved_and_filter()` with no additional top or bottom
reserve, so the caps stay between the header and the hint.

The tester was the only caller of `layout_geometry()`, so this commit removes
that wrapper; `layout_geometry_with_reserved()` stays until the second commit
routes the tester through the filtering variant and leaves it unused. The other
on-screen views already call `layout_geometry_with_reserved_and_filter()`
directly.

## 2. Layout-option variants drew on top of each other

`fix(matrix-tester): draw and count only keys of the selected layout options`

The tester drew every key in the layout definition, including the variants of
each layout option. Variants share matrix positions, so they were painted on
top of each other and the last one defined won. On a board with a split/unsplit
spacebar row this meant caps that exist on the physical keyboard were hidden,
pressing one switch lit a cap spanning several keys, and the `Tested`
denominator counted each variant separately so the counter could never reach
100%.

The fix applies `layout_key_visible()` to the counter, the geometry and the
drawing loop. That is the same filter the Layout page, the layout indicator
preview and the image export already apply; the Matrix Tester was the only
view drawing every variant.

Note that `layout_key_visible()` covers more than `layout_options_value`: for a
module-owned encoder press key it defers to the existing module-settings rule
(`module_settings_encoder_visible`), so setting a module to None, Trackball or
Touchpad now hides that module's press key here and drops it from the `Tested`
denominator, exactly as it already does in the other views. Tell me if you would
rather the tester ignore that rule and probe every matrix position regardless of
the module configuration — that would be a one-line change to
`layout_condition_visible()`, but it would make the tester the only view with
its own visibility rule.

Encoders are excluded from the geometry because the tester does not draw
them. Routing the tester through
`layout_geometry_with_reserved_and_filter()` leaves
`layout_geometry_with_reserved()` unused, so this commit removes it.

## Verification

- `cargo test --all-targets`: 693 passed locally on this branch.
- Each commit builds on its own: `cargo check --all-targets` passes at both
  the first and the second commit, so the branch stays bisectable.
- `cargo build --release`: succeeds.
- CI: the repository's Build workflow passes on all four targets on my fork,
  including the Linux `cargo test --all-targets` job -
  https://github.com/techmech-keeb/entropy/actions/runs/33945567691
- Hardware: OLSK60 v2 (6x13). The description and the `Tested` button are
  readable and clickable at the default window size, every physical cap is
  drawn exactly once, and `Tested: n/N` reaches 100%.
- Not verified on hardware: the module-owned encoder press-key path described
  above. The OLSK60 v2 has no interchangeable Encoder / Trackball / Touchpad
  module, so that branch of `layout_key_visible()` is covered only by the
  existing unit test `module_settings_own_the_conditional_encoder_press_key`.